### PR TITLE
Add infrastructure required in order concisely write integration tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -124,4 +124,4 @@ lazy val core = (project in file("core")) settings (oneJarSettings: _*) enablePl
 
 lazy val web = (project in file("web")) dependsOn (core % "test->test;compile->compile") settings (oneJarSettings: _*) enablePlugins(AutomateHeaderPlugin)
 
-lazy val it = (project in file("it")) dependsOn (core % "test->test;compile->compile", web) settings (standardSettings: _*) enablePlugins(AutomateHeaderPlugin)
+lazy val it = (project in file("it")) dependsOn (core % "test->test;compile->compile", web % "test->test;compile->compile") settings (standardSettings: _*) enablePlugins(AutomateHeaderPlugin)

--- a/core/src/main/scala/quasar/backend.scala
+++ b/core/src/main/scala/quasar/backend.scala
@@ -82,26 +82,6 @@ sealed trait Backend { self =>
       })
   }
 
-  /**
-   * Convenience method for executing an SQL query on this backend. This method is usefull for certain tests
-   * and in a scripting context where a robust handling of all error scenarios is not required.
-   * @param query The SQL query to run
-   * @return The result path where the result of this query was stored. The return type is weakly typed, partly for
-   *         convenience, partly because I did not find a Tuple2T and was unwilling to create one. If anything bad
-   *         occurs, the `Task` will fail with an `Exception` containing a message describing the error.
-   */
-  def run(query: String, destinationPath: String): Task[ResultPath] = {
-    val parser = new SQLParser()
-    for {
-      sql <- Task.fromDisjunction(parser.parse(Query(query)).leftMap(parseError => new java.lang.Exception("Parse error" + parseError.message)))
-      query = QueryRequest(sql, Some(Path(destinationPath)), Variables(Map()))
-      resultPath <- run(query).fold(
-        err => Task.fail(new java.lang.Exception(err.message)),
-        a => a.run.flatMap(either => Task.fromDisjunction(either.leftMap(e => new java.lang.Exception("Evaluation error" + e.message))))
-      )._2
-    } yield resultPath
-  }
-
   def run0(req: QueryRequest):
       EitherT[(Vector[PhaseResult], ?),
               CompilationError,
@@ -122,23 +102,6 @@ sealed trait Backend { self =>
           case _                     => results
         }
       })
-  }
-
-  /**
-   * Convenience method for evaluating an SQL query on this backend. This method is useful for certain tests
-   * and in a scripting context where robust handling of all error scenarios is not required.
-   * @param query The SQL query to evaluate
-   * @return A Stream of `Data` representing the result of the query.
-   */
-  def eval(query: String): Process[ProcessingTask, Data] = {
-    val parser = new SQLParser()
-    parser.parse(Query(query)).fold(
-      err => Process.fail(new scala.Exception("Parser Error" + err.message)),
-      sql => eval(QueryRequest(sql, None, Variables(Map()))).run._2.fold(
-        err => Process.fail(new scala.Exception("Compilation Error" + err.message)),
-        process => process
-      )
-    )
   }
 
   /**

--- a/it/src/test/scala/quasar/Interactive.scala
+++ b/it/src/test/scala/quasar/Interactive.scala
@@ -1,0 +1,57 @@
+package quasar
+
+import Predef._
+import Backend.ProcessingTask
+import fs.Path
+import sql.{Query, SQLParser}
+
+import scalaz.Scalaz
+import scalaz.concurrent.Task
+import scalaz.stream.Process
+import Scalaz._
+
+/**
+ * Convenience methods that trade strong type safety for simplicity.
+ * Intended to be used in test code where a failure is unexpected and may be useful in
+ * a scripting or console context for playing around with the Quasar API.
+ */
+package object interactive {
+  /**
+   * Execute an SQL query on the backend and store the result in the provided `destinationPath`
+   * @param backend The Backend on which to run this query.
+   * @param query The SQL query to run
+   * @param destinationPath The path at which to store the result of the query.
+   * @return The result path where the result of this query was stored. For now, this should be equal to the
+   *         `destinationPath` specified as an argument, but that might eventually change. All failures are encoded as
+   *         a `Task` failure for convenience at the expense of safety and strong typing. The failure will be a
+   *         `scala.Exception` that contains a string message describing the nature of the failure.
+   */
+  def run(backend: Backend, query: String, destinationPath: String): Task[ResultPath] = {
+    val parser = new SQLParser()
+    for {
+      sql <- Task.fromDisjunction(parser.parse(Query(query)).leftMap(parseError => new scala.Exception("Parse error" + parseError.message)))
+      query = QueryRequest(sql, Some(Path(destinationPath)), Variables(Map()))
+      resultPath <- backend.run(query).fold(
+        err => Task.fail(new scala.Exception(err.message)),
+        a => a.run.flatMap(either => Task.fromDisjunction(either.leftMap(e => new scala.Exception("Evaluation error" + e.message))))
+      )._2
+    } yield resultPath
+  }
+
+  /**
+   * Execute an SQL query on the backend and return the result as a stream.
+   * @param backend The `Backend` on which to run this query.
+   * @param query The SQL query to evaluate
+   * @return A Stream of `Data` representing the result of the query.
+   */
+  def eval(backend: Backend, query: String): Process[ProcessingTask, Data] = {
+    val parser = new SQLParser()
+    parser.parse(Query(query)).fold(
+      err => Process.fail(new scala.Exception("Parser Error" + err.message)),
+      sql => backend.eval(QueryRequest(sql, None, Variables(Map()))).run._2.fold(
+        err => Process.fail(new scala.Exception("Compilation Error" + err.message)),
+        process => process
+      )
+    )
+  }
+}

--- a/it/src/test/scala/quasar/backendtest.scala
+++ b/it/src/test/scala/quasar/backendtest.scala
@@ -16,7 +16,9 @@ import quasar.fs._
 
 object TestConfig {
 
-  lazy val backendNames: List[String] = List("mongodb_2_6", "mongodb_3_0")
+  val MONGO_2_6 = "mongodb_2_6"
+  val MONGO_3_0 = "mongodb_3_0"
+  lazy val backendNames: List[String] = List(MONGO_2_6, MONGO_3_0)
 
   private def fail[A](msg: String): Task[A] = Task.fail(new RuntimeException(msg))
 


### PR DESCRIPTION
- Add test classes of web project to it (integration) classpath
- Add convenience methods used by tests as conceivably sripts one day
- Create constants for MongoDB names