### PR TITLE
Rename the remaining references to SlamData in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ java -jar [<path to jar>] [-c <config file>]
 
 ### Configure
 
-The various JARs can be configured by using a command-line argument to indicate the location of a JSON configuration file. If no config file is specified, it is assumed to be `slamengine-config.json`, from a standard location in the user's home directory.
+The various JARs can be configured by using a command-line argument to indicate the location of a JSON configuration file. If no config file is specified, it is assumed to be `quasar-config.json`, from a standard location in the user's home directory.
 
 The JSON configuration file must have the following format:
 
@@ -96,7 +96,7 @@ One or more mountings may be included, and each must have a unique path (above, 
 
 The `connectionUri` is a standard [MongoDB connection string](http://docs.mongodb.org/manual/reference/connection-string/). Only the primary host is required to be present, however in most cases a database name should be specified as well. Additional hosts and options may be included as specified in the linked documentation.
 
-For example, say a MongoDB instance is running on the default port on the same machine as SlamData, and contains databases `test` and `students`, the `students` database contains a collection `cs101`, and the configuration looks like this:
+For example, say a MongoDB instance is running on the default port on the same machine as Quasar, and contains databases `test` and `students`, the `students` database contains a collection `cs101`, and the configuration looks like this:
 ```json
   "mountings": {
     "/local": {
@@ -436,7 +436,7 @@ object id | `"abc"`         | `{ "$oid": "abc" }` |
 
 ### CSV
 
-When SlamData produces CSV, all fields and array elements are "flattened" so that each column in the output contains the data for a single location in the source document. For example, the document `{ "foo": { "bar": 1, "baz": 2 } }` becomes
+When Quasar produces CSV, all fields and array elements are "flattened" so that each column in the output contains the data for a single location in the source document. For example, the document `{ "foo": { "bar": 1, "baz": 2 } }` becomes
 
 ```
 foo.bar,foo.baz


### PR DESCRIPTION
A couple references to SlamData slipped through, this renames them to Quasar.