### PR TITLE
Remove `Backend#defaultPath`

### DIFF
--- a/core/src/main/scala/quasar/backend.scala
+++ b/core/src/main/scala/quasar/backend.scala
@@ -215,8 +215,6 @@ sealed trait Backend { self =>
   def exists(path: Path): PathTask[Boolean] =
     if (path == Path.Root) true.point[PathTask]
     else ls(path.parent).map(_.map(path.parent ++ _.path) contains path)
-
-  def defaultPath: Path
 }
 
 /** May be mixed in to implement the query methods of Backend using a Planner and Evaluator. */
@@ -458,8 +456,6 @@ final case class NestedBackend(sourceMounts: Map[DirNode, Backend]) extends Back
         })
       }))
       else delegate(dir)(_.ls0(_), ι)
-
-  def defaultPath = Path.Current
 
   private def delegate[E, A](path: Path)(f: (Backend, Path) => ETask[E, A], ef: PathError => E): ETask[E, A] =
     path.asAbsolute.dir.headOption.fold[ETask[E, A]](

--- a/core/src/main/scala/quasar/physical/mongodb/filesystem.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/filesystem.scala
@@ -147,8 +147,6 @@ trait MongoDbFileSystem extends PlannerBackend[Workflow.Crystallized] {
     cols <- server.listCollections
     allPaths = cols.map(_.asPath)
   } yield allPaths.map(_.rebase(dir).toOption.map(p => FilesystemNode(p.head, Plain))).flatten.toSet)
-
-  def defaultPath = server.defaultDB.map(Path(_).asDir).getOrElse(Path.Current)
 }
 
 sealed trait RenameSemantics

--- a/it/src/test/scala/quasar/backendtest.scala
+++ b/it/src/test/scala/quasar/backendtest.scala
@@ -16,49 +16,78 @@ import quasar.fs._
 
 object TestConfig {
 
+  /**
+   * The path prefix under which test data may be found as well as where tests
+   * can write test data/output.
+   */
+  val DefaultTestPathPrefix = Path("/quasar-test/")
+
+  /**
+   * The environment variable used to externally specify the test path prefix.
+   *
+   * NB: The same path prefix is used for all backends under test.
+   */
+  val TestPathPrefixEnvName = "QUASAR_TEST_PATH_PREFIX"
+
   lazy val backendNames: List[String] = List("mongodb_2_6", "mongodb_3_0")
 
   private def fail[A](msg: String): Task[A] = Task.fail(new RuntimeException(msg))
 
-  def envName(backend: String): String = "SLAMDATA_" + backend.toUpperCase
+  def backendEnvName(backend: String): String = "QUASAR_" + backend.toUpperCase
+
+  /** Read the value of an envrionment variable. */
+  def readEnv(name: String): OptionT[Task, String] =
+    Task.delay(System.getenv).liftM[OptionT]
+      .flatMap(env => OptionT(Task.delay(Option(env.get(name)))))
 
   /**
    * Load backend config from environment variable.
    * Fails if it cannot parse the config
    * Returns None if there is no config.
    */
-  def loadConfig(name: String): Task[Option[BackendConfig]] = {
-    Task.delay(System.getenv()).flatMap { env =>
-      Option(env.get(envName(name))).map { value =>
-        Parse.decodeEither[BackendConfig](value).fold(
-          e => fail("Failed to parse $" + envName(name) + ": " + e),
-          cfg => Task.now(Some(cfg)))
-      }.getOrElse(Task.now(None))
-    }
-  }
+  def loadConfig(name: String): OptionT[Task, BackendConfig] =
+    readEnv(backendEnvName(name)).flatMapF(value =>
+      Parse.decodeEither[BackendConfig](value).fold(
+        e => fail("Failed to parse $" + backendEnvName(name) + ": " + e),
+        _.point[Task]))
+
+  /**
+   * Returns the absolute path within a backend to the directory containing test
+   * data.
+   *
+   * One may specify this externally by setting the [[TestPathPrefixEnvName]].
+   * The returned [[Task]] will fail if an invalid path is provided from the
+   * environment and return the [[DefaultTestPathPrefix]] if nothing is provided.
+   */
+  def testDataPathPrefix: Task[Path] =
+    readEnv(TestPathPrefixEnvName).map(Path(_)).flatMapF { path =>
+      if (path.absolute) Task.now(path)
+      else fail("Test path prefix must be an absolute dir, got: " + path.shows)
+    } getOrElse DefaultTestPathPrefix
+
 }
 
 trait BackendTest extends Specification {
   sequential  // makes it easier to clean up
   args.report(showtimes=true)
 
-  lazy val AllBackends: Task[NonEmptyList[(String, Backend)]] = (TestConfig.backendNames.map { name =>
-    for {
-      config  <-  TestConfig.loadConfig(name)
-      backend <- config.fold[Task[Option[Backend]]](Task.now(None)) { cfg =>
-        BackendDefinitions.All(cfg).fold[Task[Option[Backend]]](Task.fail(new RuntimeException("Invalid config for backend " + name + ": " + cfg))) { tb =>
-          tb.map(Some(_))
-        }
-      }
-    } yield backend.map(name -> _)
-  }).sequenceU.flatMap(_.flatten match {
-    case Nil => Task.fail(new java.lang.Exception(
-      s"No backend to test. Consider setting one of these environment variables ${TestConfig.backendNames.map(TestConfig.envName)}"
-    ))
-    case h::t => Task.now(NonEmptyList.nel(h, t))
-  })
+  lazy val AllBackends: Task[NonEmptyList[(String, Backend)]] = {
+    def backendNamed(name: String): OptionT[Task, Backend] =
+      TestConfig.loadConfig(name).flatMapF(bcfg =>
+        BackendDefinitions.All(bcfg).getOrElse(Task.fail(
+          new RuntimeException("Invalid config for backend " + name + ": " + bcfg))))
 
-  def testRootDir(back: Backend) = back.defaultPath ++ Path("test_tmp/")
+    def noBackendsFound: Throwable = new RuntimeException(
+      "No backend to test. Consider setting one of these environment variables: " +
+      TestConfig.backendNames.map(TestConfig.backendEnvName).mkString(", ")
+    )
+
+    TestConfig.backendNames
+      .traverse(n => backendNamed(n).strengthL(n).run)
+      .flatMap(_.flatten.toNel.cata(Task.now, Task.fail(noBackendsFound)))
+  }
+
+  val testRootDir = Path("test_tmp/")
 
   def genTempFile: Task[Path] = Task.delay {
     Path("gen_" + scala.util.Random.nextInt().toHexString)
@@ -68,19 +97,23 @@ trait BackendTest extends Specification {
 
   /**
    * Run the supplied tests against all backends.
-   * If the fixture fails to load any backends for some reason, will print a message to the developer with the reason
-   * why we were unable to load a backend.
-   * @param runTests A function that accepts a backend (filesystem) as well as a nane associated with the backend.
-   *                 the functions type is Unit, but it should be running tests. I am not sure what specs2 magic is
-   *                 happening for this to  work.
+   *
+   * If the fixture fails to load any backends for some reason, an exception is
+   * thrown stating so.
+   *
+   * @param runTests A function that accepts a path prefix under which both test
+   *                 data may be found and tests may use as a sandbox, a backend
+   *                 (filesystem) and an associated name for purposes of
+   *                 identifying the backend in messages.
    */
-  def backendShould(runTests: (Backend, String) => Unit): Unit = {
-    (AllBackends.flatMap { backends =>
-      (backends.map {
-        case (name, backend) => Task.delay(name should runTests(backend, name))
-      }).sequenceU
-    }).map(_ => ()).run
-  }
+  def backendShould(runTests: (Path, Backend, String) => Unit): Unit =
+    (for {
+      dir   <- TestConfig.testDataPathPrefix
+      bknds <- AllBackends
+      _     <- bknds.traverse_ { case (n, b) =>
+                 Task.delay(n should runTests(dir, b, n)).void
+               }
+    } yield ()).run
 
   def deleteTempFiles(backend: Backend, dir: Path): Task[Unit] =
     backend.ls(dir).run.flatMap(_.fold(

--- a/it/src/test/scala/quasar/backendtest.scala
+++ b/it/src/test/scala/quasar/backendtest.scala
@@ -16,17 +16,15 @@ import quasar.fs._
 
 object TestConfig {
 
-  /**
-   * The path prefix under which test data may be found as well as where tests
-   * can write test data/output.
-   */
+  /** The path prefix under which test data may be found as well as where tests
+    * can write test data/output.
+    */
   val DefaultTestPathPrefix = Path("/quasar-test/")
 
-  /**
-   * The environment variable used to externally specify the test path prefix.
-   *
-   * NB: The same path prefix is used for all backends under test.
-   */
+  /** The environment variable used to externally specify the test path prefix.
+    *
+    * NB: The same path prefix is used for all backends under test.
+    */
   val TestPathPrefixEnvName = "QUASAR_TEST_PATH_PREFIX"
 
   lazy val backendNames: List[String] = List("mongodb_2_6", "mongodb_3_0")
@@ -40,25 +38,23 @@ object TestConfig {
     Task.delay(System.getenv).liftM[OptionT]
       .flatMap(env => OptionT(Task.delay(Option(env.get(name)))))
 
-  /**
-   * Load backend config from environment variable.
-   * Fails if it cannot parse the config
-   * Returns None if there is no config.
-   */
+  /** Load backend config from environment variable.
+    *
+    * Fails if it cannot parse the config and returns None if there is no config.
+    */
   def loadConfig(name: String): OptionT[Task, BackendConfig] =
     readEnv(backendEnvName(name)).flatMapF(value =>
       Parse.decodeEither[BackendConfig](value).fold(
         e => fail("Failed to parse $" + backendEnvName(name) + ": " + e),
         _.point[Task]))
 
-  /**
-   * Returns the absolute path within a backend to the directory containing test
-   * data.
-   *
-   * One may specify this externally by setting the [[TestPathPrefixEnvName]].
-   * The returned [[Task]] will fail if an invalid path is provided from the
-   * environment and return the [[DefaultTestPathPrefix]] if nothing is provided.
-   */
+  /** Returns the absolute path within a backend to the directory containing test
+    * data.
+    *
+    * One may specify this externally by setting the [[TestPathPrefixEnvName]].
+    * The returned [[Task]] will fail if an invalid path is provided from the
+    * environment and return the [[DefaultTestPathPrefix]] if nothing is provided.
+    */
   def testDataPathPrefix: Task[Path] =
     readEnv(TestPathPrefixEnvName).map(Path(_)).flatMapF { path =>
       if (path.absolute) Task.now(path)
@@ -95,25 +91,22 @@ trait BackendTest extends Specification {
 
   def genTempDir: Task[Path] = genTempFile.map(_.asDir)
 
-  /**
-   * Run the supplied tests against all backends.
-   *
-   * If the fixture fails to load any backends for some reason, an exception is
-   * thrown stating so.
-   *
-   * @param runTests A function that accepts a path prefix under which both test
-   *                 data may be found and tests may use as a sandbox, a backend
-   *                 (filesystem) and an associated name for purposes of
-   *                 identifying the backend in messages.
-   */
+  /** Run the supplied tests against all backends.
+    *
+    * If the fixture fails to load any backends for some reason, an exception is
+    * thrown stating so.
+    *
+    * @param runTests A function that accepts a path prefix under which both test
+    *                 data may be found and tests may use as a sandbox, a backend
+    *                 (filesystem) and an associated name for purposes of
+    *                 identifying the backend in messages.
+    */
   def backendShould(runTests: (Path, Backend, String) => Unit): Unit =
-    (for {
-      dir   <- TestConfig.testDataPathPrefix
-      bknds <- AllBackends
-      _     <- bknds.traverse_ { case (n, b) =>
-                 Task.delay(n should runTests(dir, b, n)).void
-               }
-    } yield ()).run
+    (TestConfig.testDataPathPrefix |@| AllBackends)((dir, backends) =>
+      backends.traverse_ { case (n, b) =>
+        Task.delay(n should runTests(dir, b, n)).void
+      }
+    ).join.run
 
   def deleteTempFiles(backend: Backend, dir: Path): Task[Unit] =
     backend.ls(dir).run.flatMap(_.fold(

--- a/it/src/test/scala/quasar/regression.scala
+++ b/it/src/test/scala/quasar/regression.scala
@@ -25,9 +25,9 @@ class RegressionSpec extends BackendTest {
   implicit val codec = DataCodec.Precise
   implicit val ED = EncodeJson[Data](codec.encode(_).fold(err => scala.sys.error(err.message), ι))
 
-  backendShould { (backend, backendName) =>
+  backendShould { (prefix, backend, backendName) =>
 
-    val tmpDir = testRootDir(backend) ++ genTempDir.run
+    val tmpDir = prefix ++ testRootDir ++ genTempDir.run
 
     val TestRoot = new File("it/src/test/resources/tests")
 

--- a/scripts/build
+++ b/scripts/build
@@ -24,6 +24,14 @@ echo "REPL Jar Path: $QUASAR_REPL_JAR_PATH"
 
 QUASAR_TEMP_JAR="$TEMP_DIR/$QUASAR_WEB_JAR"
 
+QUASAR_MONGODB_TESTDB="quasar-test"
+QUASAR_MONGODB_HOST_2_6="localhost:27018"
+QUASAR_MONGODB_HOST_3_0="localhost:27019"
+
+QUASAR_TEST_PATH_PREFIX="/${QUASAR_MONGODB_TESTDB}/"
+QUASAR_MONGODB_2_6="{\"mongodb\": {\"connectionUri\": \"mongodb://${QUASAR_MONGODB_HOST_2_6}\"}}"
+QUASAR_MONGODB_3_0="{\"mongodb\": {\"connectionUri\": \"mongodb://${QUASAR_MONGODB_HOST_3_0}\"}}"
+
 rm -rf "$TEMP_DIR"
 mkdir -p "$TEMP_DIR"
 
@@ -38,25 +46,27 @@ cp "$QUASAR_WEB_JAR_PATH" "$QUASAR_TEMP_JAR"
 if [[ ${LOCAL_MONGODB:-} == "true" ]] ; then
   echo "Using local MongoDB config"
 
-  export SLAMDATA_MONGODB_2_6='{"mongodb": {"connectionUri": "mongodb://localhost:27018/test"}}'
-  export SLAMDATA_MONGODB_3_0='{"mongodb": {"connectionUri": "mongodb://localhost:27019/test"}}'
+  export QUASAR_TEST_PATH_PREFIX
+  export QUASAR_MONGODB_2_6
+  export QUASAR_MONGODB_3_0
 
   # TODO: Move to code
   echo "Importing zips data set for integration tests"
 
-  mongo2.6/bin/mongoimport -h localhost:27018 --db test --collection zips --file "$WS_DIR/it/src/test/resources/tests/zips.data"
-  mongo3.0/bin/mongoimport -h localhost:27019 --db test --collection zips --file "$WS_DIR/it/src/test/resources/tests/zips.data"
+  mongo2.6/bin/mongoimport -h localhost:27018 --db $QUASAR_MONGODB_TESTDB --collection zips --file "$WS_DIR/it/src/test/resources/tests/zips.data"
+  mongo3.0/bin/mongoimport -h localhost:27019 --db $QUASAR_MONGODB_TESTDB --collection zips --file "$WS_DIR/it/src/test/resources/tests/zips.data"
 elif [[ ${AMBIENT_MONGODB:-} == "true" ]] ; then
   echo "Using ambient MongoDB config (2.6:27018, 3.0:27019)"
 
-  export SLAMDATA_MONGODB_2_6='{"mongodb": {"connectionUri": "mongodb://localhost:27018/quasar-test"}}'
-  export SLAMDATA_MONGODB_3_0='{"mongodb": {"connectionUri": "mongodb://localhost:27019/quasar-test"}}'
+  export QUASAR_TEST_PATH_PREFIX
+  export QUASAR_MONGODB_2_6
+  export QUASAR_MONGODB_3_0
 
   # TODO: Move to code
   echo "Importing zips data set for integration tests"
 
-  /usr/bin/env mongoimport -h localhost:27018 --db quasar-test --collection zips --file "$WS_DIR/it/src/test/resources/tests/zips.data"
-  /usr/bin/env mongoimport -h localhost:27019 --db quasar-test --collection zips --file "$WS_DIR/it/src/test/resources/tests/zips.data"
+  /usr/bin/env mongoimport -h localhost:27018 --db $QUASAR_MONGODB_TESTDB --collection zips --file "$WS_DIR/it/src/test/resources/tests/zips.data"
+  /usr/bin/env mongoimport -h localhost:27019 --db $QUASAR_MONGODB_TESTDB --collection zips --file "$WS_DIR/it/src/test/resources/tests/zips.data"
 fi
 
 # Build and run all tests everywhere (including integration)


### PR DESCRIPTION
This removes `Backend#defaultPath` which had dubious semantics and was only used in tests. Test usage was replaced with the ability to explicitly specify the prefix path for test backends via an environment variable, defaulting to `/quasar-test/` when unspecified.