### PR TITLE
[SD-895] Don't require the MongoDB connection string to include an authentication database

### DIFF
--- a/core/src/main/scala/quasar/backend.scala
+++ b/core/src/main/scala/quasar/backend.scala
@@ -349,16 +349,15 @@ object Backend {
       _       <- testWrite(backend)
     } yield ()
 
-  private def testWrite(backend: Backend): ETask[EnvironmentError, Unit] = {
-    val data = Data.Obj(ListMap("a" -> Data.Int(1)))
+  private def testWrite(backend: Backend): ETask[EnvironmentError, Unit] =
     for {
       files <- backend.ls.leftMap(EnvPathError(_))
-      dir = files.map(_.path).find(_.pureDir).getOrElse(Path.Root)
-      tmp = dir ++ Path(".quasar_tmp_connection_test")
-      _ <- backend.save(tmp, Process.emit(data)).leftMap(EnvWriteError(_))
-      _ <- backend.delete(tmp).leftMap(EnvPathError(_))
+      dir   =  files.map(_.path).find(_.pureDir).getOrElse(Path.Root)
+      tmp   =  dir ++ Path(".quasar_tmp_connection_test")
+      data  =  Data.Obj(ListMap("a" -> Data.Int(1)))
+      _     <- backend.save(tmp, Process.emit(data)).leftMap(EnvWriteError(_))
+      _     <- backend.delete(tmp).leftMap(EnvPathError(_))
     } yield ()
-  }
 
   private def wrap(description: String)(e: Throwable): EnvironmentError =
     EnvEvalError(CommandFailed(description + ": " + e.getMessage))

--- a/core/src/main/scala/quasar/backend.scala
+++ b/core/src/main/scala/quasar/backend.scala
@@ -63,8 +63,6 @@ sealed trait Backend { self =>
   import Path._
   import Planner._
 
-  def checkCompatibility: ETask[EnvironmentError, Unit]
-
   /**
    * Executes a query, producing a compilation log and the path where the result
    * can be found.
@@ -226,8 +224,6 @@ trait PlannerBackend[PhysicalPlan] extends Backend {
 
   lazy val queryPlanner = planner.queryPlanner(evaluator.compile(_))
 
-  def checkCompatibility = evaluator.checkCompatibility
-
   def run0(req: QueryRequest) = {
     queryPlanner(req).map(plan => for {
       rez    <- evaluator.execute(plan)
@@ -341,10 +337,7 @@ object Backend {
 
   def test(config: BackendConfig): ETask[EnvironmentError, Unit] =
     for {
-      backend <- BackendDefinitions.All(config).fold[ETask[EnvironmentError, Backend]](
-        EitherT.left(Task.now(MissingBackend("no backend in config: " + config))))(
-        EitherT.right(_))
-      _       <- backend.checkCompatibility
+      backend <- BackendDefinitions.All(config)
       _       <- trap(backend.ls.leftMap(EnvPathError(_)), err => InsufficientPermissions(err.toString))
       _       <- testWrite(backend)
     } yield ()
@@ -380,9 +373,6 @@ final case class NestedBackend(sourceMounts: Map[DirNode, Backend]) extends Back
   private var mounts = sourceMounts
 
   private def nodePath(node: DirNode) = Path(List(DirNode.Current, node), None)
-
-  def checkCompatibility: ETask[EnvironmentError, Unit] =
-    mounts.values.toList.map(_.checkCompatibility).sequenceU.map(κ(()))
 
   def run0(req: QueryRequest) = {
     mounts.map { case (mountDir, backend) =>
@@ -471,15 +461,22 @@ final case class NestedBackend(sourceMounts: Map[DirNode, Backend]) extends Back
         b => Process.eval[ETask[E, ?], Path](EitherT(Task.now(path.rebase(nodePath(node)).leftMap(ef)))).flatMap[ETask[E, ?], A](f(b, _))))
 }
 
-final case class BackendDefinition(create: PartialFunction[BackendConfig, Task[Backend]]) extends (BackendConfig => Option[Task[Backend]]) {
-  def apply(config: BackendConfig): Option[Task[Backend]] = create.lift(config)
+final case class BackendDefinition(run: BackendConfig => EnvTask[Backend]) {
+  def apply(config: BackendConfig): EnvTask[Backend] = run(config)
 }
 
 object BackendDefinition {
+  import EnvironmentError._
+
+  def fromPF(pf: PartialFunction[BackendConfig, EnvTask[Backend]]): BackendDefinition =
+    BackendDefinition(cfg => pf.lift(cfg).getOrElse(mzero[BackendDefinition].run(cfg)))
+
   implicit val BackendDefinitionMonoid = new Monoid[BackendDefinition] {
-    def zero = BackendDefinition(PartialFunction.empty)
+    def zero = BackendDefinition(cfg =>
+      MonadError[ETask, EnvironmentError]
+        .raiseError(MissingBackend("no backend for config: " + cfg)))
 
     def append(v1: BackendDefinition, v2: => BackendDefinition): BackendDefinition =
-      BackendDefinition(v1.create.orElse(v2.create))
+      BackendDefinition(c => v1(c) ||| v2(c))
   }
 }

--- a/core/src/main/scala/quasar/evaluator.scala
+++ b/core/src/main/scala/quasar/evaluator.scala
@@ -104,6 +104,7 @@ object Evaluator {
       def format(message: String, detail: Option[String]) =
         Json(("error" := message) :: detail.toList.map("errorDetail" := _): _*)
 
+      // TODO: These seem to be rather MongoDB-specific
       EncodeJson[EnvironmentError] {
         case MissingDatabase              => format("Authentication database not specified in connection URI.", None)
         case ConnectionFailed(msg)        => format("Invalid server and / or port specified.", Some(msg))

--- a/core/src/main/scala/quasar/evaluator.scala
+++ b/core/src/main/scala/quasar/evaluator.scala
@@ -20,7 +20,6 @@ import quasar.Predef._
 
 import scalaz._
 import scalaz.concurrent._
-import scalaz.syntax.show._
 
 import quasar.fs._; import Path._
 import quasar.Errors._
@@ -59,12 +58,6 @@ trait Evaluator[PhysicalPlan] {
    * that can be run natively on the backend.
    */
   def compile(physical: PhysicalPlan): (String, Cord)
-
-  /**
-   * Fails if the backend implementation is not compatible with the connected
-   * system (typically because it does not have not the correct version number).
-   */
-  def checkCompatibility: ETask[EnvironmentError, Unit]
 }
 object Evaluator {
 
@@ -95,8 +88,8 @@ object Evaluator {
     final case class EnvWriteError(error: Backend.ProcessingError) extends EnvironmentError {
       def message = "write failed: " + error.message
     }
-    final case class UnsupportedVersion(backend: Evaluator[_], version: List[Int]) extends EnvironmentError {
-      def message = s"Unsupported ${backend.shows} version: ${version.mkString(".")}"
+    final case class UnsupportedVersion(backendName: String, version: List[Int]) extends EnvironmentError {
+      def message = s"Unsupported $backendName version: ${version.mkString(".")}"
     }
 
     import argonaut._, Argonaut._
@@ -193,9 +186,11 @@ object Evaluator {
     }
   }
   object UnsupportedVersion {
-    def apply(backend: Evaluator[_], version: List[Int]): EnvironmentError = EnvironmentError.UnsupportedVersion(backend, version)
-    def unapply(obj: EnvironmentError): Option[(Evaluator[_], List[Int])] = obj match {
-      case EnvironmentError.UnsupportedVersion(backend, version) => Some((backend, version))
+    def apply(backendName: String, version: List[Int]): EnvironmentError =
+      EnvironmentError.UnsupportedVersion(backendName, version)
+
+    def unapply(obj: EnvironmentError): Option[(String, List[Int])] = obj match {
+      case EnvironmentError.UnsupportedVersion(name, version) => Some((name, version))
       case _                       => None
     }
   }

--- a/core/src/main/scala/quasar/mounter.scala
+++ b/core/src/main/scala/quasar/mounter.scala
@@ -33,9 +33,10 @@ object Mounter {
       backend match {
         case NestedBackend(base) => path match {
           case Nil =>
-            backendDef(conf).cata(
-              EitherT.right(_),
-              EitherT.left(Task.now(MissingFileSystem(Path(path, None), conf))))
+            backendDef(conf).leftMap {
+              case MissingBackend(_) => MissingFileSystem(Path(path, None), conf)
+              case otherwise         => otherwise
+            }
 
           case dir :: dirs =>
             rec0(base.get(dir).getOrElse(NestedBackend(Map())), dirs, conf)

--- a/core/src/main/scala/quasar/mounter.scala
+++ b/core/src/main/scala/quasar/mounter.scala
@@ -17,36 +17,38 @@
 package quasar
 
 import quasar.Predef._
-import quasar.Errors._
 import quasar.Evaluator._
 import quasar.config._
 import quasar.fs._
 
-import scalaz._
+import scalaz._, Scalaz._
 import scalaz.concurrent._
 
 object Mounter {
-  def defaultMount(config: Config): ETask[EnvironmentError, Backend] =
+  def defaultMount(config: Config): EnvTask[Backend] =
     mount(config, BackendDefinitions.All)
 
-  def mount(config: Config, backendDef: BackendDefinition): ETask[EnvironmentError, Backend] = {
-    def rec(backend: Backend, path: List[DirNode], conf: BackendConfig): ETask[EnvironmentError, Backend] =
+  def mount(config: Config, backendDef: BackendDefinition): EnvTask[Backend] = {
+    def rec0(backend: Backend, path: List[DirNode], conf: BackendConfig): EnvTask[Backend] =
       backend match {
-        case NestedBackend(base) =>
-          path match {
-            case Nil => backendDef(conf).fold[EitherT[Task, EnvironmentError, Backend]](
-              EitherT.left(Task.now(MissingFileSystem(Path(path, None), conf))))(
-              EitherT.right)
-            case dir :: dirs =>
-              rec(base.get(dir).getOrElse(NestedBackend(Map())), dirs, conf).map(rez => NestedBackend(base + (dir -> rez)))
-          }
+        case NestedBackend(base) => path match {
+          case Nil =>
+            backendDef(conf).cata(
+              EitherT.right(_),
+              EitherT.left(Task.now(MissingFileSystem(Path(path, None), conf))))
+
+          case dir :: dirs =>
+            rec0(base.get(dir).getOrElse(NestedBackend(Map())), dirs, conf)
+              .map(rez => NestedBackend(base + (dir -> rez)))
+        }
+
         case _ => EitherT.left(Task.now(InvalidConfig("attempting to mount a backend within an existing backend.")))
       }
 
-    config.mountings.foldLeft[ETask[EnvironmentError, Backend]](
-      EitherT.right(Task.now(NestedBackend(Map())))) {
-      case (root, (path, config)) =>
-        root.flatMap(rec(_, path.asAbsolute.asDir.dir, config))
+    def rec(backend: Backend, mount: (Path, BackendConfig)): EnvTask[Backend] = mount match {
+      case (path, config) => rec0(backend, path.asAbsolute.asDir.dir, config)
     }
+
+    config.mountings.toList.foldLeftM(NestedBackend(Map()): Backend)(rec)
   }
 }

--- a/core/src/main/scala/quasar/physical/mongodb/filesystem.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/filesystem.scala
@@ -26,6 +26,12 @@ import scalaz.concurrent._
 import scalaz.stream._
 import scalaz.stream.io._
 
+import com.mongodb.{WriteError => _, _}
+import com.mongodb.client._
+import com.mongodb.client.model._
+import org.bson._
+import scala.collection.JavaConverters._
+
 trait MongoDbFileSystem extends PlannerBackend[Workflow.Crystallized] {
   protected def server: MongoWrapper
 
@@ -116,7 +122,7 @@ trait MongoDbFileSystem extends PlannerBackend[Workflow.Crystallized] {
       dstCol =>
       if (src.pureDir)
         liftP(for {
-          cols    <- server.listCollections
+          cols    <- server.collections
           renames <- cols.map { s => target(s).map(server.rename(s, _, rs)) }.flatten.sequenceU
         } yield ())
       else
@@ -130,7 +136,7 @@ trait MongoDbFileSystem extends PlannerBackend[Workflow.Crystallized] {
       server.dropAllDatabases,
       server.dropDatabase,
       κ(for {
-        all     <- server.listCollections
+        all     <- server.collections
         deletes <- all.map(col => col.asPath.rebase(path.dirOf).fold(
           κ(().point[Task]),
           file =>  {
@@ -144,7 +150,7 @@ trait MongoDbFileSystem extends PlannerBackend[Workflow.Crystallized] {
   // and "foo.baz", in which case "foo" acts as both a directory and a file, as
   // far as Quasar is concerned.
   def ls0(dir: Path): PathTask[Set[FilesystemNode]] = liftP(for {
-    cols <- server.listCollections
+    cols <- server.collections
     allPaths = cols.map(_.asPath)
   } yield allPaths.map(_.rebase(dir).toOption.map(p => FilesystemNode(p.head, Plain))).flatten.toSet)
 }
@@ -162,14 +168,7 @@ object RenameSemantics {
 
 
 sealed trait MongoWrapper {
-  import com.mongodb._
-  import com.mongodb.client._
-  import com.mongodb.client.model._
-  import org.bson._
-  import scala.collection.JavaConverters._
-
   protected def client: MongoClient
-  def defaultDB: Option[String]
 
   def genTempName(col: Collection): Task[Collection] = for {
     start <- SequenceNameGenerator.startUnique
@@ -188,7 +187,9 @@ sealed trait MongoWrapper {
       case RenameSemantics.Overwrite => true
       case RenameSemantics.FailIfExists => false
     }
-    if (src.equals(dst)) Task.now(())
+
+    if (src.equals(dst))
+      Task.now(())
     else
       for {
         s <- get(src)
@@ -206,33 +207,48 @@ sealed trait MongoWrapper {
   def dropDatabase(name: String): Task[Unit] = Task.delay(db(name).drop)
 
   val dropAllDatabases: Task[Unit] =
-    listDatabases.flatMap(_.traverse_(dropDatabase))
+    databaseNames.flatMap(_.traverse_(dropDatabase))
 
   def insert(col: Collection, data: Vector[Document]): Task[Unit] = for {
     c <- get(col)
     _ = c.bulkWrite(data.map(new InsertOneModel(_)).asJava)
   } yield ()
 
-  private def listDatabases: Task[List[String]] =
-    Task.delay(client.listDatabaseNames.asScala.toList).handle {
-      case _: MongoCommandException => defaultDB.toList
-    }
+  def databaseNames: Task[List[String]] =
+    MongoWrapper.databaseNames(client)
 
-  val listCollections: Task[List[Collection]] = listDatabases.map(dbs => for {
-    dbName  <- dbs
-    colName <- db(dbName).listCollectionNames.asScala.toList
-  } yield Collection(dbName, colName))
+  def collections: Task[List[Collection]] =
+    databaseNames.flatMap(_.traverse(MongoWrapper.collections(_, client)))
+      .map(_.join)
 }
+
 object MongoWrapper {
-  def apply(client0: com.mongodb.MongoClient, defaultDb0: Option[String]) = new MongoWrapper {
-    def client = client0
-    def defaultDB = defaultDb0
-  }
+  def apply(client0: com.mongodb.MongoClient) =
+    new MongoWrapper { val client = client0 }
+
+  def liftTask: (Task ~> ETask[EvaluationError, ?]) =
+    new (Task ~> ETask[EvaluationError, ?]) {
+      def apply[A](t: Task[A]) =
+        EitherT(t.attempt.map(_.leftMap(e => CommandFailed(e.getMessage))))
+    }
 
   /**
    Defer an action to be performed against MongoDB, capturing exceptions
    in EvaluationError.
    */
   def delay[A](a: => A): ETask[EvaluationError, A] =
-    EitherT(Task.delay(a).attempt.map(_.leftMap(e => CommandFailed(e.getMessage))))
+    liftTask(Task.delay(a))
+
+  def databaseNames(client: MongoClient): Task[List[String]] =
+    Task.delay(try {
+      client.listDatabaseNames.asScala.toList
+    } catch {
+      case _: MongoCommandException =>
+        client.getCredentialsList.asScala.toList.map(_.getSource)
+    })
+
+  def collections(dbName: String, client: MongoClient): Task[List[Collection]] =
+    Task.delay(client.getDatabase(dbName)
+      .listCollectionNames.asScala.toList
+      .map(Collection(dbName, _)))
 }

--- a/core/src/main/scala/quasar/physical/mongodb/filesystem.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/filesystem.scala
@@ -229,7 +229,7 @@ object MongoWrapper {
   def liftTask: (Task ~> EvaluationTask) =
     new (Task ~> EvaluationTask) {
       def apply[A](t: Task[A]) =
-        EitherT(t.attempt.map(_.leftMap(e => CommandFailed(e.getMessage))))
+        EitherT(t.attempt).leftMap(e => CommandFailed(e.getMessage))
     }
 
   /**

--- a/core/src/main/scala/quasar/repl/repl.scala
+++ b/core/src/main/scala/quasar/repl/repl.scala
@@ -369,7 +369,6 @@ object Repl {
         fsPath  <- pathStr.fold[Task[Option[FsPath[pathy.Path.File, pathy.Path.Sandboxed]]]](Task.now(None))(s => parsePath(s).map(Some(_)))
         cfg     <- (Config.fromFileOrEmpty(fsPath)
                       .flatMap(Mounter.defaultMount(_))
-                      .flatMap(b => b.checkCompatibility.as(b))
                       .fold(e => Task.fail(new RuntimeException(e.message)), Task.now _)
                       .join)
                     .onFinish(_.cata(printErrorAndFail, Task.now(())))

--- a/it/src/test/scala/quasar/backendtest.scala
+++ b/it/src/test/scala/quasar/backendtest.scala
@@ -72,8 +72,10 @@ trait BackendTest extends Specification {
   lazy val AllBackends: Task[NonEmptyList[(String, Backend)]] = {
     def backendNamed(name: String): OptionT[Task, Backend] =
       TestConfig.loadConfig(name).flatMapF(bcfg =>
-        BackendDefinitions.All(bcfg).getOrElse(Task.fail(
-          new RuntimeException("Invalid config for backend " + name + ": " + bcfg))))
+        BackendDefinitions.All(bcfg).fold(
+          e => Task.fail(new RuntimeException(
+            "Invalid config for backend " + name + ": " + bcfg + ", error: " + e.message)),
+          Task.now(_)).join)
 
     def noBackendsFound: Throwable = new RuntimeException(
       "No backend to test. Consider setting one of these environment variables: " +


### PR DESCRIPTION
For certain operations in the MongoDB backend (like checking the `mongod` version) and when faced with a query that doesn't read from a path, we need to be able to supply a database in order to proceed. Previously, we used the authentication db from the mongo connection URI for this, but this doesn't work when using mongo without authentication (or if the user doesn't have permission to write to the authentication db).

This removes the restriction by attempting to find a database the user has access to when needed. For checking the version, we just attempt the `buildinfo` command on the databases the user has access to until one works and error otherwise. For the case when we need a database for temp collections, we try and find the first one that we can create a collection in, again erroring if this fails.

Backend validation is also moved into `BackendDefinition` eliminating the need for `Backend#checkCompatibility`.