### PR TITLE
[SD-895] Don't require auth db in mongo connection string

### DIFF
--- a/core/src/main/scala/quasar/evaluator.scala
+++ b/core/src/main/scala/quasar/evaluator.scala
@@ -72,7 +72,6 @@ object Evaluator {
     final case class MissingFileSystem(path: Path, config: quasar.config.BackendConfig) extends EnvironmentError {
       def message = "No data source could be mounted at the path " + path + " using the config " + config
     }
-    final case class MissingDatabase(message: String) extends EnvironmentError
     final case class InvalidConfig(message: String) extends EnvironmentError
     final case class ConnectionFailed(message: String) extends EnvironmentError
     final case class InvalidCredentials(message: String) extends EnvironmentError
@@ -96,7 +95,6 @@ object Evaluator {
         Json(("error" := message) :: detail.toList.map("errorDetail" := _): _*)
 
       EncodeJson[EnvironmentError] {
-        case MissingDatabase(msg)         => format("Database not found.", Some(msg))
         case ConnectionFailed(msg)        => format("Connection failed.", Some(msg))
         case InvalidCredentials(msg)      => format("Invalid username and/or password specified.", Some(msg))
         case InsufficientPermissions(msg) => format("Database user does not have permissions on database.", Some(msg))
@@ -122,13 +120,6 @@ object Evaluator {
     def unapply(obj: EnvironmentError): Option[(Path, quasar.config.BackendConfig)] = obj match {
       case EnvironmentError.MissingFileSystem(path, config) => Some((path, config))
       case _                       => None
-    }
-  }
-  object MissingDatabase {
-    def apply(message: String): EnvironmentError = EnvironmentError.MissingDatabase(message)
-    def unapply(obj: EnvironmentError): Option[String] = obj match {
-      case EnvironmentError.MissingDatabase(message) => Some(message)
-      case _                     => None
     }
   }
   object InvalidConfig {

--- a/core/src/main/scala/quasar/physical/mongodb/filesystem.scala
+++ b/core/src/main/scala/quasar/physical/mongodb/filesystem.scala
@@ -206,7 +206,7 @@ sealed trait MongoWrapper {
 
   def dropDatabase(name: String): Task[Unit] = Task.delay(db(name).drop)
 
-  val dropAllDatabases: Task[Unit] =
+  def dropAllDatabases: Task[Unit] =
     databaseNames.flatMap(_.traverse_(dropDatabase))
 
   def insert(col: Collection, data: Vector[Document]): Task[Unit] = for {

--- a/core/src/main/scala/quasar/repl/repl.scala
+++ b/core/src/main/scala/quasar/repl/repl.scala
@@ -369,7 +369,6 @@ object Repl {
         fsPath  <- pathStr.fold[Task[Option[FsPath[pathy.Path.File, pathy.Path.Sandboxed]]]](Task.now(None))(s => parsePath(s).map(Some(_)))
         cfg     <- (Config.fromFileOrEmpty(fsPath)
                       .flatMap(Mounter.defaultMount(_))
-                      .flatMap(b => b.checkCompatibility.as(b))
                       .fold(e => Task.fail(new RuntimeException(e.message)), Task.now _)
                       .join)
                     .onFinish(_.cata(printErrorAndFail, Task.now(())))

--- a/it/src/test/scala/quasar/backendtest.scala
+++ b/it/src/test/scala/quasar/backendtest.scala
@@ -72,8 +72,10 @@ trait BackendTest extends Specification {
   lazy val AllBackends: Task[NonEmptyList[(String, Backend)]] = {
     def backendNamed(name: String): OptionT[Task, Backend] =
       TestConfig.loadConfig(name).flatMapF(bcfg =>
-        BackendDefinitions.All(bcfg).getOrElse(Task.fail(
-          new RuntimeException("Invalid config for backend " + name + ": " + bcfg))))
+        BackendDefinitions.All(bcfg).fold(
+          e => Task.fail(new RuntimeException(
+            "Invalid config for backend " + name + ": " + bcfg + ", error: " + e.message)),
+          Task.now(_)).join)
 
     def noBackendsFound: Throwable = new RuntimeException(
       "No backend to test. Consider setting one of these environment variables: " +


### PR DESCRIPTION
For certain operations in the MongoDB backend (like checking the `mongod` version) and when faced with a query that doesn't read from a path, we need to be able to supply a database in order to proceed. Previously, we used the authentication db from the mongo connection URI for this, but this doesn't work when using mongo without authentication (or if the user doesn't have permission to write to the authentication db).

This removes the restriction by attempting to find a database the user has access to when needed. For checking the version, we just attempt the `buildinfo` command on the databases the user has access to until one works and error otherwise. For the case when we need a database for temp collections, we try and find the first one that we can create a collection in, again erroring if this fails.

Backend validation is also moved into `BackendDefinition` eliminating the need for `Backend#checkCompatibility`.

SD-895 #done