### PR TITLE
Remove 'SlamData' from the configuration file path

### DIFF
--- a/core/src/main/scala/quasar/config/config.scala
+++ b/core/src/main/scala/quasar/config/config.scala
@@ -122,8 +122,7 @@ object Config {
     val dirPath: RelDir[Sandboxed] = os.fold(
       currentDir,
       dir("Library") </> dir("Application Support"),
-      dir(".config")
-    ) </> dir("SlamData")
+      dir(".config"))
 
     val baseDir = OptionT.some[Task, Boolean](os.isWin)
       .ifM(localAppData, OptionT.none)
@@ -140,10 +139,10 @@ object Config {
    * NB: Paths read from environment/props are assumed to be absolute.
    */
   private def defaultPath: Task[FsPath[File, Sandboxed]] =
-    OS.currentOS >>= defaultPathForOS(file("quasar-config.json"))
+    OS.currentOS >>= defaultPathForOS(dir("quasar") </> file("quasar-config.json"))
 
   private def alternatePath: Task[FsPath[File, Sandboxed]] =
-    OS.currentOS >>= defaultPathForOS(file("slamengine-config.json"))
+    OS.currentOS >>= defaultPathForOS(dir("SlamData") </> file("slamengine-config.json"))
 
   def fromFile(path: FsPath[File, Sandboxed]): EnvTask[Config] = {
     import java.nio.file._

--- a/core/src/test/scala/quasar/config/config.scala
+++ b/core/src/test/scala/quasar/config/config.scala
@@ -114,7 +114,7 @@ class ConfigSpec extends Specification with DisjunctionMatchers {
   // NB: Not possible to test windows deterministically at this point as cannot
   //     programatically set environment variables like we can with properties.
   "defaultPath" should {
-    val comp = "SlamData/quasar-config.json"
+    val comp = "quasar-config.json"
     val macp = "Library/Application Support"
     val posixp = ".config"
 

--- a/scripts/testJar
+++ b/scripts/testJar
@@ -6,7 +6,7 @@ IFS=$'\n\t'       # http://redsymbol.net/articles/unofficial-bash-strict-mode/
 source "$(dirname $0)/constants"
 
 # NB: This assumes Linux
-CONFIG_DIR=$HOME/.config/SlamData
+CONFIG_DIR=$HOME/.config/quasar
 CONFIG_FILE=$CONFIG_DIR/quasar-config.json
 
 if [ ! -e $CONFIG_FILE ]


### PR DESCRIPTION
Removes another instance of "SlamData" that slipped by, the name of the parent dir of the config file.