### PR TITLE
Remove GroupId.

### DIFF
--- a/core/src/test/scala/quasar/physical/mongodb/workflowbuilder.scala
+++ b/core/src/test/scala/quasar/physical/mongodb/workflowbuilder.scala
@@ -568,7 +568,7 @@ class WorkflowBuilderSpec
         pop <- projectField(grouped, "pop")
       } yield reduce(pop)($sum(_))
       op.map(render) must beRightDisjunction(
-        """GroupBuilder
+        """GroupBuilder(48712dc)
           |├─ ExprBuilder
           |│  ├─ CollectionBuilder(Root())
           |│  │  ├─ $Read(db; zips)
@@ -576,10 +576,9 @@ class WorkflowBuilderSpec
           |│  ╰─ ExprOp($varF(DocField(BsonField.Name("pop"))))
           |├─ By
           |│  ╰─ ValueBuilder(Int32(1))
-          |├─ Content
-          |│  ╰─ -\/
-          |│     ╰─ AccumOp($sum($varF(DocVar.ROOT())))
-          |╰─ Id(81f33d6e)""".stripMargin)
+          |╰─ Content
+          |   ╰─ -\/
+          |      ╰─ AccumOp($sum($varF(DocVar.ROOT())))""".stripMargin)
     }
 
   }

--- a/core/src/test/scala/quasar/std/set.scala
+++ b/core/src/test/scala/quasar/std/set.scala
@@ -1,0 +1,58 @@
+package quasar.std
+
+import quasar.Predef._
+import quasar.specs2.PendingWithAccurateCoverage
+
+import org.specs2.mutable._
+import org.specs2.scalaz._
+import org.specs2.ScalaCheck
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+import org.specs2.matcher.Matcher
+import org.threeten.bp.{Instant, LocalDate, LocalTime, Duration}
+import scalaz.{Validation, Success, Failure}
+
+class SetSpec extends Specification with ScalaCheck with ValidationMatchers with PendingWithAccurateCoverage {
+  import SetLib._
+  import quasar.Type
+  import quasar.Data
+  import quasar.SemanticError
+
+  "SetLib" should {
+    "type taking no results" in {
+      val expr = Take(Type.Set(Type.Int), Type.Const(Data.Int(0)))
+      expr should beSuccessful(Type.Const(Data.Set(Nil)))
+    }
+
+    "type filtering by false" in {
+      val expr = Filter(Type.Set(Type.Int), Type.Const(Data.Bool(false)))
+      expr should beSuccessful(Type.Const(Data.Set(Nil)))
+    }
+
+    "type inner join on false" in {
+      val expr = InnerJoin(Type.Set(Type.Int), Type.Set(Type.Int), Type.Const(Data.Bool(false)))
+      expr should beSuccessful(Type.Const(Data.Set(Nil)))
+    }
+
+    "type inner join with empty left" in {
+      val expr = InnerJoin(Type.Const(Data.Set(Nil)), Type.Set(Type.Int), Type.Bool)
+      expr should beSuccessful(Type.Const(Data.Set(Nil)))
+    }
+
+    "type inner join with empty right" in {
+      val expr = InnerJoin(Type.Set(Type.Int), Type.Const(Data.Set(Nil)), Type.Bool)
+      expr should beSuccessful(Type.Const(Data.Set(Nil)))
+    }
+
+    "type left outer join with empty left" in {
+      val expr = LeftOuterJoin(Type.Const(Data.Set(Nil)), Type.Set(Type.Int), Type.Bool)
+      expr should beSuccessful(Type.Const(Data.Set(Nil)))
+    }
+
+    "type right outer join with empty right" in {
+      val expr = RightOuterJoin(Type.Set(Type.Int), Type.Const(Data.Set(Nil)), Type.Bool)
+      expr should beSuccessful(Type.Const(Data.Set(Nil)))
+    }
+  }
+}


### PR DESCRIPTION
Since `GroupBuilder` started holding separate `WorkflowBuilder`s for its
keys, maintaining a `GroupId` created with the original set of keys is
no longer necessary. We still generate the ID in `render` to make it
easy to eyeball groups that should align.

Also removed a no-longer-used `merge` case.