### PR TITLE
A few improvments on the SQL side.

### DIFF
--- a/core/src/main/scala/quasar/compiler.scala
+++ b/core/src/main/scala/quasar/compiler.scala
@@ -587,7 +587,7 @@ trait Compiler[F[_]] {
 
           case NullLiteral() => emit(LogicalPlan.Constant(Data.Null))
           case Vari(name) =>
-            fail(GenericError("variable \"" + name + "\" is not bound"))
+            fail(GenericError("variable “" + name + "” is not bound"))
         }
     })
   }

--- a/core/src/main/scala/quasar/compiler.scala
+++ b/core/src/main/scala/quasar/compiler.scala
@@ -586,6 +586,8 @@ trait Compiler[F[_]] {
           case BoolLiteral(value) => emit(LogicalPlan.Constant(Data.Bool(value)))
 
           case NullLiteral() => emit(LogicalPlan.Constant(Data.Null))
+          case Vari(name) =>
+            fail(GenericError("variable \"" + name + "\" is not bound"))
         }
     })
   }

--- a/core/src/main/scala/quasar/sql/parser.scala
+++ b/core/src/main/scala/quasar/sql/parser.scala
@@ -327,15 +327,13 @@ class SQLParser extends StandardTokenParsers {
   private def stripQuotes(s:String) = s.substring(1, s.length-1)
 
   def parseExpr(exprSql: String): ParsingError \/ Expr =
-    parse(Query(exprSql))
-
-  def parse(sql: Query): ParsingError \/ Expr = {
-    phrase(command)(new lexical.Scanner(sql.value)) match {
+    phrase(command)(new lexical.Scanner(exprSql)) match {
       case Success(r, q)        => \/.right(r)
       case Error(msg, input)    => \/.left(GenericParsingError(msg))
       case Failure(msg, input)  => \/.left(GenericParsingError(msg + "; " + input.first))
     }
-  }
+
+  def parse(sql: Query): ParsingError \/ Expr = parseExpr(sql.value)
 }
 
 object SQLParser {

--- a/core/src/test/scala/quasar/compiler.scala
+++ b/core/src/test/scala/quasar/compiler.scala
@@ -1212,6 +1212,12 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "fail with ambiguous reference in else" in {
       compile("select (case when bar.a = 1 then 'ok' else foo end) from bar, baz") must beLeftDisjunction
     }
+
+    // NB: This should eventually succeed, when we push var handling down to LP
+    "fail with free variable" in {
+      compile("select name from zips where age < :age") must
+        beLeftDisjunction
+    }
   }
 
   "reduceGroupKeys" should {

--- a/core/src/test/scala/quasar/sql/SqlParserSpec.scala
+++ b/core/src/test/scala/quasar/sql/SqlParserSpec.scala
@@ -280,6 +280,11 @@ class SQLParserSpec extends Specification with ScalaCheck with DisjunctionMatche
       parser.parse(q) must beLeftDisjunction
     }
 
+    "parse array literal at top level" in {
+      parser.parse("['X', 'Y']") must beRightDisjunction(
+        ArrayLiteral(List(StringLiteral("X"), StringLiteral("Y"))))
+    }
+
     "round-trip to SQL and back" ! prop { (node: Expr) =>
       val parsed = parser.parse(pprint(node))
 


### PR DESCRIPTION
* A better error when faced with an unbound SQL var,
* avoid wrapping/unwrapping a string in `parse`/`parseExpr`,
* a test to show that we can parse `primary_expr` at the top level.

This doesn’t fix any issues, but hopefully provides some clarity on
SD-1044 and SD-1046.