### PR TITLE
In API tests, increase timeout to 5 seconds.

### DIFF
--- a/web/src/test/scala/quasar/api/fs.scala
+++ b/web/src/test/scala/quasar/api/fs.scala
@@ -56,7 +56,7 @@ object Utils {
     val api = FileSystemApi(updatedConfig, createBackend, tester,
                             restartServer = unexpectedRestart,
                             configChanged = recordConfigChange)
-    val srv = Server.createServer(port, 1.seconds, api.AllServices).run.run
+    val srv = Server.createServer(port, 5.seconds, api.AllServices).run.run
     try { body(client, () => reloads.toList) } finally { srv.traverse_(_.shutdown.void).run }
   }
 


### PR DESCRIPTION
SD-1052 #done 

Intermittent failure turned out to be caused by the relatively short timeout we were using in tests, and the bizarre retry behavior of the dispatch client. Simply increasing the timeout to a few seconds makes it go away.