### PR TITLE
More flexible resource discovery types

### DIFF
--- a/api/src/main/scala/quasar/api/QueryEvaluator.scala
+++ b/api/src/main/scala/quasar/api/QueryEvaluator.scala
@@ -22,7 +22,7 @@ import scalaz.{\/, Applicative, Contravariant, Functor, Profunctor, Strong, ProC
 import scalaz.syntax.applicative._
 import scalaz.syntax.either._
 
-trait QueryEvaluator[F[_], Q, R] extends ResourceDiscovery[F] {
+trait QueryEvaluator[F[_], G[_], Q, R] extends ResourceDiscovery[F, G] {
   /** Returns the results of evaluating the given query. */
   def evaluate(query: Q): F[ReadError \/ R]
 }
@@ -30,29 +30,29 @@ trait QueryEvaluator[F[_], Q, R] extends ResourceDiscovery[F] {
 object QueryEvaluator extends QueryEvaluatorInstances
 
 sealed abstract class QueryEvaluatorInstances extends QueryEvaluatorInstances0 {
-  implicit def contravariant[F[_], R]: Contravariant[QueryEvaluator[F, ?, R]] =
-    new Contravariant[QueryEvaluator[F, ?, R]] {
-      def contramap[A, B](fa: QueryEvaluator[F, A, R])(f: B => A) =
-        DelegatingQueryEvaluator[F, A, R, B, R](fa)(_ compose f)
+  implicit def contravariant[F[_], G[_], R]: Contravariant[QueryEvaluator[F, G, ?, R]] =
+    new Contravariant[QueryEvaluator[F, G, ?, R]] {
+      def contramap[A, B](fa: QueryEvaluator[F, G, A, R])(f: B => A) =
+        DelegatingQueryEvaluator[F, G, A, R, B, R](fa)(_ compose f)
     }
 
-  implicit def functor[F[_]: Functor, Q]: Functor[QueryEvaluator[F, Q, ?]] =
-    new Functor[QueryEvaluator[F, Q, ?]] {
-      def map[A, B](fa: QueryEvaluator[F, Q, A])(f: A => B) =
-        DelegatingQueryEvaluator[F, Q, A, Q, B](fa)(_ andThen (_.map(_.map(f))))
+  implicit def functor[F[_]: Functor, G[_], Q]: Functor[QueryEvaluator[F, G, Q, ?]] =
+    new Functor[QueryEvaluator[F, G, Q, ?]] {
+      def map[A, B](fa: QueryEvaluator[F, G, Q, A])(f: A => B) =
+        DelegatingQueryEvaluator[F, G, Q, A, Q, B](fa)(_ andThen (_.map(_.map(f))))
     }
 
-  implicit def proChoice[F[_]: Applicative]: ProChoice[QueryEvaluator[F, ?, ?]] =
-    new QueryEvaluatorProfunctor[F] with ProChoice[QueryEvaluator[F, ?, ?]] {
-      def left[A, B, C](fa: QueryEvaluator[F, A, B]) =
-        DelegatingQueryEvaluator[F, A, B, (A \/ C), (B \/ C)](fa) { eval => { q =>
+  implicit def proChoice[F[_]: Applicative, G[_]]: ProChoice[QueryEvaluator[F, G, ?, ?]] =
+    new QueryEvaluatorProfunctor[F, G] with ProChoice[QueryEvaluator[F, G, ?, ?]] {
+      def left[A, B, C](fa: QueryEvaluator[F, G, A, B]) =
+        DelegatingQueryEvaluator[F, G, A, B, (A \/ C), (B \/ C)](fa) { eval => { q =>
           q.fold(
             a => eval(a).map(_.map(_.left[C])),
             c => c.right[B].right[ReadError].point[F])
         }}
 
-      def right[A, B, C](fa: QueryEvaluator[F, A, B]) =
-        DelegatingQueryEvaluator[F, A, B, (C \/ A), (C \/ B)](fa) { eval => {q =>
+      def right[A, B, C](fa: QueryEvaluator[F, G, A, B]) =
+        DelegatingQueryEvaluator[F, G, A, B, (C \/ A), (C \/ B)](fa) { eval => {q =>
           q.fold(
             c => c.left[B].right[ReadError].point[F],
             a => eval(a).map(_.map(_.right[C])))
@@ -61,34 +61,34 @@ sealed abstract class QueryEvaluatorInstances extends QueryEvaluatorInstances0 {
 }
 
 sealed abstract class QueryEvaluatorInstances0 {
-  implicit def strong[F[_]: Functor]: Strong[QueryEvaluator[F, ?, ?]] =
-    new QueryEvaluatorProfunctor[F] with Strong[QueryEvaluator[F, ?, ?]] {
-      def first[A, B, C](fa: QueryEvaluator[F, A, B]) =
-        DelegatingQueryEvaluator[F, A, B, (A, C), (B, C)](fa) { eval => {
+  implicit def strong[F[_]: Functor, G[_]]: Strong[QueryEvaluator[F, G, ?, ?]] =
+    new QueryEvaluatorProfunctor[F, G] with Strong[QueryEvaluator[F, G, ?, ?]] {
+      def first[A, B, C](fa: QueryEvaluator[F, G, A, B]) =
+        DelegatingQueryEvaluator[F, G, A, B, (A, C), (B, C)](fa) { eval => {
           case (a, c) => eval(a).map(_.strengthR(c))
         }}
 
-      def second[A, B, C](fa: QueryEvaluator[F, A, B]) =
-        DelegatingQueryEvaluator[F, A, B, (C, A), (C, B)](fa) { eval => {
+      def second[A, B, C](fa: QueryEvaluator[F, G, A, B]) =
+        DelegatingQueryEvaluator[F, G, A, B, (C, A), (C, B)](fa) { eval => {
           case (c, a) => eval(a).map(_.strengthL(c))
         }}
     }
 }
 
-private[api] abstract class QueryEvaluatorProfunctor[F[_]: Functor]
-    extends Profunctor[QueryEvaluator[F, ?, ?]] {
+private[api] abstract class QueryEvaluatorProfunctor[F[_]: Functor, G[_]]
+    extends Profunctor[QueryEvaluator[F, G, ?, ?]] {
 
-  def mapfst[A, B, C](fa: QueryEvaluator[F, A, B])(f: C => A) =
-    Contravariant[QueryEvaluator[F, ?, B]].contramap(fa)(f)
+  def mapfst[A, B, C](fa: QueryEvaluator[F, G, A, B])(f: C => A) =
+    Contravariant[QueryEvaluator[F, G, ?, B]].contramap(fa)(f)
 
-  def mapsnd[A, B, C](fa: QueryEvaluator[F, A, B])(f: B => C) =
-    Functor[QueryEvaluator[F, A, ?]].map(fa)(f)
+  def mapsnd[A, B, C](fa: QueryEvaluator[F, G, A, B])(f: B => C) =
+    Functor[QueryEvaluator[F, G, A, ?]].map(fa)(f)
 }
 
-private[api] final class DelegatingQueryEvaluator[F[_], Q, R, S, T](
-    underlying: QueryEvaluator[F, Q, R],
+private[api] final class DelegatingQueryEvaluator[F[_], G[_], Q, R, S, T](
+    underlying: QueryEvaluator[F, G, Q, R],
     f: (Q => F[ReadError \/ R]) => (S => F[ReadError \/ T]))
-    extends QueryEvaluator[F, S, T] {
+    extends QueryEvaluator[F, G, S, T] {
 
   def evaluate(query: S) = f(underlying.evaluate)(query)
   def children(path: ResourcePath) = underlying.children(path)
@@ -97,9 +97,9 @@ private[api] final class DelegatingQueryEvaluator[F[_], Q, R, S, T](
 }
 
 private[api] object DelegatingQueryEvaluator {
-  def apply[F[_], Q, R, S, T](
-      u: QueryEvaluator[F, Q, R])(
+  def apply[F[_], G[_], Q, R, S, T](
+      u: QueryEvaluator[F, G, Q, R])(
       f: (Q => F[ReadError \/ R]) => (S => F[ReadError \/ T]))
-      : QueryEvaluator[F, S, T] =
+      : QueryEvaluator[F, G, S, T] =
     new  DelegatingQueryEvaluator(u, f)
 }

--- a/api/src/main/scala/quasar/api/ResourceDiscovery.scala
+++ b/api/src/main/scala/quasar/api/ResourceDiscovery.scala
@@ -16,23 +16,23 @@
 
 package quasar.api
 
-import slamdata.Predef.{Boolean, Stream}
+import slamdata.Predef.Boolean
 import quasar.api.ResourceError.CommonError
 
-import scalaz.{\/, IMap, Tree}
+import scalaz.\/
 
 /** Provides for discovering the resources in a datasource. */
-trait ResourceDiscovery[F[_]] {
+trait ResourceDiscovery[F[_], G[_]] {
 
   /** Returns the children of the specified resource path or an error if it
     * does not exist.
     */
-  def children(path: ResourcePath): F[CommonError \/ IMap[ResourceName, ResourcePathType]]
+  def children(path: ResourcePath): F[CommonError \/ G[(ResourceName, ResourcePathType)]]
 
   /** Returns the descendants of the specified resource path or an error if it
     * does not exist.
     */
-  def descendants(path: ResourcePath): F[CommonError \/ Stream[Tree[ResourceName]]]
+  def descendants(path: ResourcePath): F[CommonError \/ G[ResourcePath]]
 
   /** Returns whether the specified resource path refers to a resource. */
   def isResource(path: ResourcePath): F[Boolean]

--- a/api/src/test/scala/quasar/api/MockResourceDiscoverySpec.scala
+++ b/api/src/test/scala/quasar/api/MockResourceDiscoverySpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.api
+
+import slamdata.Predef.Stream
+import quasar.fp.reflNT
+
+import scalaz.{Id, IList, Tree}, Id.Id
+
+final class MockResourceDiscoverySpec extends ResourceDiscoverySpec[Id, IList] {
+  val discovery =
+    MockQueryEvaluator.resourceDiscovery[Id, IList](
+      Stream(
+        Tree.Node(
+          ResourceName("a"),
+          Stream(
+            Tree.Leaf(ResourceName("b")),
+            Tree.Node(
+              ResourceName("c"),
+              Stream(
+                Tree.Leaf(ResourceName("d")))),
+            Tree.Node(
+              ResourceName("e"),
+              Stream(
+                Tree.Leaf(ResourceName("f")))))),
+        Tree.Leaf(ResourceName("g")),
+        Tree.Node(
+          ResourceName("h"),
+          Stream(
+            Tree.Leaf(ResourceName("i")),
+            Tree.Leaf(ResourceName("j"))))))
+
+  val nonExistentPath = ResourcePath.root() / ResourceName("does") / ResourceName("not") / ResourceName("exist")
+
+  val run = reflNT[Id]
+}

--- a/api/src/test/scala/quasar/api/ResourceDiscoverySpec.scala
+++ b/api/src/test/scala/quasar/api/ResourceDiscoverySpec.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.api
+
+import slamdata.Predef.String
+import quasar.Qspec
+
+import org.specs2.execute.AsResult
+import org.specs2.matcher.Matcher
+import org.specs2.specification.core.Fragment
+import scalaz.{\/, ~>, Foldable, Id, ISet, Monad}, Id.Id
+import scalaz.std.tuple._
+import scalaz.syntax.either._
+import scalaz.syntax.foldable._
+import scalaz.syntax.monad._
+
+abstract class ResourceDiscoverySpec[F[_]: Monad, G[_]: Foldable]
+    extends Qspec {
+
+  import ResourceError._
+
+  def discovery: ResourceDiscovery[F, G]
+
+  def nonExistentPath: ResourcePath
+
+  def run: F ~> Id
+
+  "ResourceDiscovery" >> {
+    "must not be empty" >>* {
+      discovery
+        .children(ResourcePath.root())
+        .map(_.any(g => !g.empty))
+    }
+
+    "children of non-existent is not found" >>* {
+      discovery.children(nonExistentPath).map(_ must beNotFound(nonExistentPath))
+    }
+
+    "descendants of non-existent is not found" >>* {
+      discovery.descendants(nonExistentPath).map(_ must beNotFound(nonExistentPath))
+    }
+
+    "non-existent is not a resource" >>* {
+      discovery.isResource(nonExistentPath).map(_ must beFalse)
+    }
+
+    "all descendants are resources" >>* {
+      discovery
+        .descendants(ResourcePath.root())
+        .flatMap(_.anyM(_.allM(discovery.isResource)))
+    }
+
+    "child status agrees with isResource" >>* {
+      discovery
+        .children(ResourcePath.root())
+        .flatMap(_.anyM(_.allM {
+          case (n, ResourcePathType.Resource) =>
+            discovery.isResource(ResourcePath.root() / n)
+
+          case (n, ResourcePathType.ResourcePrefix) =>
+            discovery
+              .isResource(ResourcePath.root() / n)
+              .map(!_)
+        }))
+    }
+
+    "descendants and children agree" >>* {
+      (
+        discovery.descendants(ResourcePath.root()) |@|
+        descendantsFromChildren(ResourcePath.root())
+      )((ds, cs) => ds.map(ISet.fromFoldable(_)) must_= cs.right)
+    }
+  }
+
+  ////
+
+  val orG = Foldable[CommonError \/ ?].compose[G]
+
+  def descendantsFromChildren(path: ResourcePath): F[ISet[ResourcePath]] =
+    for {
+      progeny <- discovery.children(path)
+
+      (leaves, prefixes) = orG.foldMap(progeny) {
+        case (n, ResourcePathType.Resource) =>
+          (ISet.singleton(path / n), ISet.empty[ResourcePath])
+
+        case (n, ResourcePathType.ResourcePrefix) =>
+          (ISet.empty[ResourcePath], ISet.singleton(path / n))
+      }
+
+      rest <- prefixes.foldMapM(descendantsFromChildren)
+
+    } yield leaves union rest
+
+  def beNotFound[A](path: ResourcePath): Matcher[CommonError \/ A] =
+    be_-\/(equal[ResourceError](PathNotFound(path)))
+
+  implicit class RunExample(s: String) {
+    def >>*[A: AsResult](fa: => F[A]): Fragment =
+      s >> run(fa)
+  }
+}

--- a/connector/src/main/scala/quasar/connector/DataSource.scala
+++ b/connector/src/main/scala/quasar/connector/DataSource.scala
@@ -19,7 +19,7 @@ package quasar.connector
 import slamdata.Predef.Unit
 import quasar.api.{DataSourceType, QueryEvaluator}
 
-trait DataSource[F[_], Q, R] extends QueryEvaluator[F, Q, R] {
+trait DataSource[F[_], G[_], Q, R] extends QueryEvaluator[F, G, Q, R] {
   def kind: DataSourceType
   def shutdown: F[Unit]
 }

--- a/connector/src/main/scala/quasar/connector/HeavyweightDataSourceModule.scala
+++ b/connector/src/main/scala/quasar/connector/HeavyweightDataSourceModule.scala
@@ -36,5 +36,5 @@ trait HeavyweightDataSourceModule {
       F[_]: Async: PlannerErrorME,
       G[_]: Async](
       config: Json)
-      : F[InitializationError[Json] \/ HeavyweightDataSource[T, F, Disposable[G, Stream[G, Data]]]]
+      : F[InitializationError[Json] \/ HeavyweightDataSource[T, F, Stream[G, ?], Disposable[G, Stream[G, Data]]]]
 }

--- a/connector/src/main/scala/quasar/connector/LightweightDataSourceModule.scala
+++ b/connector/src/main/scala/quasar/connector/LightweightDataSourceModule.scala
@@ -33,5 +33,5 @@ trait LightweightDataSourceModule {
       F[_]: Async,
       G[_]: Async](
       config: Json)
-      : F[InitializationError[Json] \/ LightweightDataSource[F, Disposable[G, Stream[G, Data]]]]
+      : F[InitializationError[Json] \/ LightweightDataSource[F, Stream[G, ?], Disposable[G, Stream[G, Data]]]]
 }

--- a/connector/src/main/scala/quasar/connector/datasource/LightweightDataSource.scala
+++ b/connector/src/main/scala/quasar/connector/datasource/LightweightDataSource.scala
@@ -20,4 +20,4 @@ import quasar.api.ResourcePath
 import quasar.connector.DataSource
 
 /** A DataSource capable of returning the contents of resources. */
-trait LightweightDataSource[F[_], R] extends DataSource[F, ResourcePath, R]
+trait LightweightDataSource[F[_], G[_], R] extends DataSource[F, G, ResourcePath, R]

--- a/core/src/test/scala/quasar/evaluate/FederatingQueryEvaluatorSpec.scala
+++ b/core/src/test/scala/quasar/evaluate/FederatingQueryEvaluatorSpec.scala
@@ -17,10 +17,10 @@
 package quasar.evaluate
 
 import slamdata.Predef._
-import quasar.{Qspec, TreeMatchers}
+import quasar.TreeMatchers
 import quasar.api._, ResourceError._
 import quasar.contrib.pathy.{ADir, AFile}
-import quasar.fp.{constEqual, coproductEqual}
+import quasar.fp.{constEqual, coproductEqual, reflNT}
 import quasar.qscript._
 
 import matryoshka._
@@ -33,7 +33,9 @@ import scalaz.std.tuple._
 import scalaz.syntax.applicative._
 import scalaz.syntax.either._
 
-final class FederatingQueryEvaluatorSpec extends Qspec with TreeMatchers {
+final class FederatingQueryEvaluatorSpec
+    extends ResourceDiscoverySpec[Id, IList]
+    with TreeMatchers {
 
   implicit val showTree: Show[Tree[ResourceName]] =
     Show.shows(_.drawTree)
@@ -63,6 +65,11 @@ final class FederatingQueryEvaluatorSpec extends Qspec with TreeMatchers {
     FederatingQueryEvaluator(qfed, IMap(
       ResourceName("abs") -> ((abs, 1)),
       ResourceName("xys") -> ((xys, 2))).point[Id])
+
+  // ResourceDiscoverySpec
+  val discovery = fqe
+  val nonExistentPath = ResourcePath.root() / ResourceName("non") / ResourceName("existent")
+  val run = reflNT[Id]
 
   "children" >> {
     "returns possible keys for root" >> {


### PR DESCRIPTION
Abstracts over the return type of `ResourceDiscovery#{children, descendants}`, simplifying the interface and allowing us to specialize to `fs2.Stream` in datasource modules, allowing more efficient implementations than the strict data structures permitted.