### PR TITLE
Disable MockDataSourcesSpec as it might be the cause of a SOE

### DIFF
--- a/impl/src/test/scala/quasar/impl/datasources/MockDataSourcesSpec.scala
+++ b/impl/src/test/scala/quasar/impl/datasources/MockDataSourcesSpec.scala
@@ -26,11 +26,11 @@ import quasar.impl.datasources.MockDataSourcesSpec.DefaultM
 
 import eu.timepit.refined.auto._
 import scalaz.{IMap, ISet, Id, StateT, ~>}, Id.Id
-import scalaz.std.string._
+//import scalaz.std.string._
 import cats.effect.IO
 import shims._
 
-final class MockDataSourcesSpec extends DataSourcesSpec[DefaultM, String] {
+final class MockDataSourcesSpec /*extends DataSourcesSpec[DefaultM, String]*/ {
 
   def datasources: DataSources[DefaultM, String] = quasar.api.MockDataSources[DefaultM, String](acceptedSet, errorCondition)
   def supportedType = DataSourceType("s3", 3L)


### PR DESCRIPTION
This is my current best guess for which test is causing the SOE [ch270]. 

I'd like to restart the unit test build a few times in this PR to see if the SOE happens. If it doesn't happen after a few restarts, then let's merge this and I'll dig in to figure out what the problem is. If it does happen, I'll close this PR.

I've been unable to reproduce it locally so we might have to iterate with Travis a bit to track this down.