### PR TITLE
Update argonaut to 6.2.2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ import sbt._
 
 object Dependencies {
   private val algebraVersion      = "0.7.0"
-  private val argonautVersion     = "6.2"
+  private val argonautVersion     = "6.2.2"
   private val disciplineVersion   = "0.7.2"
   private val doobieVersion       = "0.4.4"
   private val jawnVersion         = "0.11.1"


### PR DESCRIPTION
We need 6.2.2 over in slamdata-backend and apparently it isn't binary compatible with 6.2 (turns out making implicit ops classes into value classes introduces binary incompatibilities).