### PR TITLE
Enable MockDataSourcesSpec

### DIFF
--- a/api/src/test/scala/quasar/api/MockDataSourcesSpec.scala
+++ b/api/src/test/scala/quasar/api/MockDataSourcesSpec.scala
@@ -24,14 +24,12 @@ import quasar.fp.numeric.Positive
 import cats.effect.IO
 import eu.timepit.refined.auto._
 import scalaz.{IMap, ISet, Id, StateT, ~>}, Id.Id
-//import scalaz.std.string._
+import scalaz.std.string._
 import shims._
 
 import MockDataSourcesSpec.DefaultM
 
-// FIXME: Disabled due to being a suspect in the case of
-//        https://app.clubhouse.io/data/story/270/soe-on-travis-trace-through-specs2
-final class MockDataSourcesSpec /*extends DataSourcesSpec[DefaultM, String]*/ {
+final class MockDataSourcesSpec extends DataSourcesSpec[DefaultM, String] {
   val s3: DataSourceType    = DataSourceType("s3", Positive(3).get)
   val azure: DataSourceType = DataSourceType("azure", Positive(3).get)
   val mongo: DataSourceType = DataSourceType("mongodb", Positive(3).get)


### PR DESCRIPTION
This test was previously coincidentally triggering the specs2 SOE ch270, so it was disabled. That bug turned out to be a bug in specs2 itself, so I'd like to try enabling this test again.

If it triggers the SOE maybe we can leave this PR open until the specs2 fix is merged, just so we don't forget about this test.