### PR TITLE
Flatten out the quasar dependency hierarchy a bit more

### DIFF
--- a/api/src/main/scala/quasar/api/datasource/DatasourceError.scala
+++ b/api/src/main/scala/quasar/api/datasource/DatasourceError.scala
@@ -17,7 +17,7 @@
 package quasar.api.datasource
 
 import slamdata.Predef._
-import quasar.common.resource.ResourcePath
+import quasar.api.resource.ResourcePath
 
 import monocle.Prism
 import scalaz.{Cord, Equal, ISet, NonEmptyList, Show}

--- a/api/src/main/scala/quasar/api/datasource/Datasources.scala
+++ b/api/src/main/scala/quasar/api/datasource/Datasources.scala
@@ -18,7 +18,7 @@ package quasar.api.datasource
 
 import slamdata.Predef.{Boolean, Exception}
 import quasar.Condition
-import quasar.common.resource._
+import quasar.api.resource._
 
 import scalaz.{\/, ISet}
 

--- a/api/src/main/scala/quasar/api/resource/ResourceName.scala
+++ b/api/src/main/scala/quasar/api/resource/ResourceName.scala
@@ -14,22 +14,21 @@
  * limitations under the License.
  */
 
-package quasar.connector
+package quasar.api.resource
 
-import quasar.Disposable
-import quasar.api.datasource.DatasourceType
-import quasar.api.datasource.DatasourceError.InitializationError
-import quasar.api.resource.ResourcePath
-import quasar.common.data.Data
+import slamdata.Predef.String
 
-import argonaut.Json
-import cats.effect.{ConcurrentEffect, Timer}
-import fs2.Stream
-import scalaz.\/
+import scalaz.{Order, Show}
+import scalaz.std.string._
 
-trait LightweightDatasourceModule {
-  def kind: DatasourceType
+final case class ResourceName(value: String)
 
-  def lightweightDatasource[F[_]: ConcurrentEffect: MonadResourceErr: Timer](config: Json)
-      : F[InitializationError[Json] \/ Disposable[F, Datasource[F, Stream[F, ?], ResourcePath, Stream[F, Data]]]]
+object ResourceName extends ResourceNameInstances
+
+sealed abstract class ResourceNameInstances {
+  implicit val order: Order[ResourceName] =
+    Order.orderBy(_.value)
+
+  implicit val show: Show[ResourceName] =
+    Show.shows(_.value)
 }

--- a/api/src/main/scala/quasar/api/resource/ResourcePath.scala
+++ b/api/src/main/scala/quasar/api/resource/ResourcePath.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package quasar.common.resource
+package quasar.api.resource
 
 import slamdata.Predef._
 import quasar.contrib.pathy.{firstSegmentName, rebaseA, stripPrefixA, AFile, APath}

--- a/api/src/main/scala/quasar/api/resource/ResourcePathType.scala
+++ b/api/src/main/scala/quasar/api/resource/ResourcePathType.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package quasar.common.resource
+package quasar.api.resource
 
 import slamdata.Predef.{Boolean, Int, Product, Serializable, Some}
 

--- a/api/src/main/scala/quasar/api/resource/package.scala
+++ b/api/src/main/scala/quasar/api/resource/package.scala
@@ -14,17 +14,11 @@
  * limitations under the License.
  */
 
-package quasar.common
+package quasar.api
 
 import slamdata.Predef.{Option, String}
-import quasar.contrib.scalaz.MonadError_
 
 package object resource {
-  type MonadResourceErr[F[_]] = MonadError_[F, ResourceError]
-
-  def MonadResourceErr[F[_]](implicit ev: MonadResourceErr[F])
-      : MonadResourceErr[F] = ev
-
   object /: {
     def unapply(p: ResourcePath): Option[(String, ResourcePath)] =
       p.uncons.map { case (ResourceName(s), p) => (s, p) }

--- a/api/src/test/scala/quasar/api/datasource/DatasourcesSpec.scala
+++ b/api/src/test/scala/quasar/api/datasource/DatasourcesSpec.scala
@@ -18,7 +18,7 @@ package quasar.api.datasource
 
 import slamdata.Predef._
 import quasar.{Condition, ConditionMatchers, EffectfulQSpec}
-import quasar.common.resource.ResourcePath
+import quasar.api.resource.ResourcePath
 
 import scala.Predef.assert
 import scala.concurrent.ExecutionContext

--- a/api/src/test/scala/quasar/api/datasource/MockDatasources.scala
+++ b/api/src/test/scala/quasar/api/datasource/MockDatasources.scala
@@ -19,7 +19,7 @@ package quasar.api.datasource
 import slamdata.Predef.{tailrec, Boolean, Exception, Int, None, Option, Some, Stream => SStream}
 import quasar.Condition
 import quasar.api.datasource.DatasourceError.InitializationError
-import quasar.common.resource._
+import quasar.api.resource._
 import quasar.contrib.scalaz.MonadState_
 
 import scalaz.{\/, ApplicativePlus, IMap, ISet, Monad, Monoid, Tags, Tree}

--- a/api/src/test/scala/quasar/api/resource/ResourceNameGenerator.scala
+++ b/api/src/test/scala/quasar/api/resource/ResourceNameGenerator.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package quasar.common.resource
+package quasar.api.resource
 
 import org.scalacheck.{Arbitrary, Gen}
 

--- a/api/src/test/scala/quasar/api/resource/ResourcePathGenerator.scala
+++ b/api/src/test/scala/quasar/api/resource/ResourcePathGenerator.scala
@@ -14,21 +14,20 @@
  * limitations under the License.
  */
 
-package quasar.common.resource
+package quasar.api.resource
 
-import slamdata.Predef.String
+import quasar.contrib.pathy.AFile
+import quasar.pkg.tests._
 
-import scalaz.{Order, Show}
-import scalaz.std.string._
+import pathy.scalacheck.PathyArbitrary._
 
-final case class ResourceName(value: String)
-
-object ResourceName extends ResourceNameInstances
-
-sealed abstract class ResourceNameInstances {
-  implicit val order: Order[ResourceName] =
-    Order.orderBy(_.value)
-
-  implicit val show: Show[ResourceName] =
-    Show.shows(_.value)
+trait ResourcePathGenerator {
+  implicit val resourcePathArbitrary: Arbitrary[ResourcePath] =
+    Arbitrary(for {
+      n <- choose(1, 10)
+      p <- if (n > 2) arbitrary[AFile].map(ResourcePath.leaf(_))
+           else const(ResourcePath.root())
+    } yield p)
 }
+
+object ResourcePathGenerator extends ResourcePathGenerator

--- a/api/src/test/scala/quasar/api/resource/ResourcePathSpec.scala
+++ b/api/src/test/scala/quasar/api/resource/ResourcePathSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package quasar.common.resource
+package quasar.api.resource
 
 import slamdata.Predef.Some
 

--- a/build.sbt
+++ b/build.sbt
@@ -182,7 +182,7 @@ lazy val foundation = project
 /** Types and interfaces describing Quasar's functionality. */
 lazy val api = project
   .settings(name := "quasar-api-internal")
-  .dependsOn(common % BothScopes)
+  .dependsOn(foundation % BothScopes)
   .settings(libraryDependencies ++= Dependencies.api)
   .settings(commonSettings)
   .settings(publishTestsSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -265,9 +265,7 @@ lazy val sql = project
 
 lazy val qscript = project
   .settings(name := "quasar-qscript-internal")
-  .dependsOn(
-    foundation % BothScopes,
-    frontend % BothScopes)
+  .dependsOn(frontend % BothScopes)
   .settings(commonSettings)
   .settings(targetSettings)
   .settings(excludeTypelevelScalaLibrary)
@@ -284,8 +282,9 @@ lazy val qsu = project
 lazy val connector = project
   .settings(name := "quasar-connector-internal")
   .dependsOn(
-    api % BothScopes,
-    qsu)
+    api,
+    foundation % "test->test",
+    qscript)
   .settings(commonSettings)
   .settings(publishTestsSettings)
   .settings(targetSettings)
@@ -295,9 +294,10 @@ lazy val connector = project
 lazy val core = project
   .settings(name := "quasar-core-internal")
   .dependsOn(
-    api     % BothScopes,
-    qscript % BothScopes,
-    sql     % BothScopes)
+    api,
+    frontend % "test->test",
+    qscript,
+    sql % BothScopes)
   .settings(commonSettings)
   .settings(publishTestsSettings)
   .settings(targetSettings)
@@ -324,7 +324,8 @@ lazy val runp = (project in file("run"))
   .dependsOn(
     core,
     impl,
-    mimir)
+    mimir,
+    qsu)
   .settings(commonSettings)
   .settings(publishTestsSettings)
   .settings(targetSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -294,9 +294,7 @@ lazy val connector = project
 lazy val core = project
   .settings(name := "quasar-core-internal")
   .dependsOn(
-    api,
-    frontend % "test->test",
-    qscript,
+    frontend % BothScopes,
     sql % BothScopes)
   .settings(commonSettings)
   .settings(publishTestsSettings)
@@ -311,8 +309,7 @@ lazy val impl = project
   .settings(name := "quasar-impl-internal")
   .dependsOn(
     api % BothScopes,
-    connector % BothScopes,
-    frontend)
+    connector % BothScopes)
   .settings(commonSettings)
   .settings(targetSettings)
   .settings(libraryDependencies ++= Dependencies.impl)
@@ -337,8 +334,7 @@ lazy val runp = (project in file("run"))
 lazy val repl = project
   .settings(name := "quasar-repl")
   .dependsOn(
-    frontend % BothScopes,
-    api,
+    common % "test->test",
     runp)
   .settings(commonSettings)
   .settings(targetSettings)
@@ -357,8 +353,8 @@ lazy val it = project
   .settings(name := "quasar-it-internal")
   .configs(ExclusiveTests)
   .dependsOn(
-    runp,
-    qscript % "test->test")
+    qscript % "test->test",
+    runp)
   .settings(commonSettings)
   .settings(publishTestsSettings)
   .settings(targetSettings)
@@ -450,7 +446,6 @@ lazy val mimir = project
   .dependsOn(
     yggdrasil % BothScopes,
     impl % BothScopes,
-    core,
     connector)
   .settings(headerLicenseSettings)
   .settings(publishSettings)

--- a/connector/src/main/scala/quasar/connector/Datasource.scala
+++ b/connector/src/main/scala/quasar/connector/Datasource.scala
@@ -19,7 +19,7 @@ package quasar.connector
 import slamdata.Predef.{Boolean, Option}
 import quasar.api.QueryEvaluator
 import quasar.api.datasource.DatasourceType
-import quasar.common.resource._
+import quasar.api.resource._
 
 /** @tparam F effects
   * @tparam G multiple results

--- a/connector/src/main/scala/quasar/connector/ResourceError.scala
+++ b/connector/src/main/scala/quasar/connector/ResourceError.scala
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-package quasar.common.resource
+package quasar.connector
 
 import slamdata.Predef.{Exception, Product, Serializable, Throwable}
+
+import quasar.api.resource._
 
 import monocle.Prism
 import scalaz.{Cord, Equal, Show}

--- a/connector/src/main/scala/quasar/connector/datasource/LightweightDatasource.scala
+++ b/connector/src/main/scala/quasar/connector/datasource/LightweightDatasource.scala
@@ -16,8 +16,8 @@
 
 package quasar.connector.datasource
 
-import quasar.common.resource.{MonadResourceErr, ResourcePath}
-import quasar.connector.Datasource
+import quasar.api.resource.ResourcePath
+import quasar.connector.{Datasource, MonadResourceErr}
 
 /** A Datasource capable of returning the contents of resources. */
 abstract class LightweightDatasource[F[_]: MonadResourceErr, G[_], R]

--- a/connector/src/main/scala/quasar/connector/package.scala
+++ b/connector/src/main/scala/quasar/connector/package.scala
@@ -14,20 +14,13 @@
  * limitations under the License.
  */
 
-package quasar.common.resource
+package quasar
 
-import quasar.contrib.pathy.AFile
-import quasar.pkg.tests._
+import quasar.contrib.scalaz.MonadError_
 
-import pathy.scalacheck.PathyArbitrary._
+package object connector {
+  type MonadResourceErr[F[_]] = MonadError_[F, ResourceError]
 
-trait ResourcePathGenerator {
-  implicit val resourcePathArbitrary: Arbitrary[ResourcePath] =
-    Arbitrary(for {
-      n <- choose(1, 10)
-      p <- if (n > 2) arbitrary[AFile].map(ResourcePath.leaf(_))
-           else const(ResourcePath.root())
-    } yield p)
+  def MonadResourceErr[F[_]](implicit ev: MonadResourceErr[F])
+      : MonadResourceErr[F] = ev
 }
-
-object ResourcePathGenerator extends ResourcePathGenerator

--- a/connector/src/test/scala/quasar/connector/DatasourceSpec.scala
+++ b/connector/src/test/scala/quasar/connector/DatasourceSpec.scala
@@ -18,7 +18,7 @@ package quasar.connector
 
 import slamdata.Predef.List
 import quasar.EffectfulQSpec
-import quasar.common.resource._
+import quasar.api.resource._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 

--- a/impl/src/main/scala/quasar/impl/datasource/ByNeedDatasource.scala
+++ b/impl/src/main/scala/quasar/impl/datasource/ByNeedDatasource.scala
@@ -19,7 +19,7 @@ package quasar.impl.datasource
 import slamdata.Predef.{Boolean, None, Option, Some, Throwable, Unit}
 import quasar.Disposable
 import quasar.api.datasource.DatasourceType
-import quasar.common.resource._
+import quasar.api.resource._
 import quasar.connector.Datasource
 
 import scala.Predef.implicitly

--- a/impl/src/main/scala/quasar/impl/datasource/ConditionReportingDatasource.scala
+++ b/impl/src/main/scala/quasar/impl/datasource/ConditionReportingDatasource.scala
@@ -19,7 +19,7 @@ package quasar.impl.datasource
 import slamdata.Predef.{Boolean, None, Option, Some, Unit}
 import quasar.Condition
 import quasar.api.datasource.DatasourceType
-import quasar.common.resource._
+import quasar.api.resource._
 import quasar.connector.Datasource
 import quasar.contrib.scalaz.MonadError_
 

--- a/impl/src/main/scala/quasar/impl/datasource/FailedDatasource.scala
+++ b/impl/src/main/scala/quasar/impl/datasource/FailedDatasource.scala
@@ -18,7 +18,7 @@ package quasar.impl.datasource
 
 import slamdata.Predef.{Boolean, Option}
 import quasar.api.datasource.DatasourceType
-import quasar.common.resource._
+import quasar.api.resource._
 import quasar.connector.Datasource
 import quasar.contrib.scalaz.MonadError_
 

--- a/impl/src/main/scala/quasar/impl/datasource/local/LocalDatasource.scala
+++ b/impl/src/main/scala/quasar/impl/datasource/local/LocalDatasource.scala
@@ -18,9 +18,9 @@ package quasar.impl.datasource.local
 
 import slamdata.Predef.{Stream => _, Seq => _, _}
 import quasar.api.datasource.DatasourceType
-import quasar.common.resource._, ResourceError._
+import quasar.api.resource._
 import quasar.common.data.Data
-import quasar.connector.Datasource
+import quasar.connector.{Datasource, MonadResourceErr, ResourceError}, ResourceError._
 import quasar.connector.datasource.LightweightDatasource
 import quasar.contrib.fs2.convert
 import quasar.contrib.scalaz.MonadError_

--- a/impl/src/main/scala/quasar/impl/datasource/local/LocalDatasourceModule.scala
+++ b/impl/src/main/scala/quasar/impl/datasource/local/LocalDatasourceModule.scala
@@ -18,9 +18,9 @@ package quasar.impl.datasource.local
 
 import quasar.Disposable
 import quasar.api.datasource.{DatasourceError, DatasourceType}, DatasourceError._
+import quasar.api.resource.ResourcePath
 import quasar.common.data.Data
-import quasar.common.resource.{MonadResourceErr, ResourcePath}
-import quasar.connector.{Datasource, LightweightDatasourceModule}
+import quasar.connector.{Datasource, LightweightDatasourceModule, MonadResourceErr}
 
 import java.nio.file.Paths
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/impl/src/main/scala/quasar/impl/datasources/DatasourceControl.scala
+++ b/impl/src/main/scala/quasar/impl/datasources/DatasourceControl.scala
@@ -20,7 +20,7 @@ import slamdata.Predef.{Boolean, Unit}
 import quasar.Condition
 import quasar.api.datasource.{DatasourceRef, DatasourceType}
 import quasar.api.datasource.DatasourceError.{CreateError, DiscoveryError, ExistentialError}
-import quasar.common.resource.{ResourceName, ResourcePath, ResourcePathType}
+import quasar.api.resource.{ResourceName, ResourcePath, ResourcePathType}
 
 import scalaz.{\/, ISet}
 

--- a/impl/src/main/scala/quasar/impl/datasources/DatasourceManagement.scala
+++ b/impl/src/main/scala/quasar/impl/datasources/DatasourceManagement.scala
@@ -25,9 +25,9 @@ import quasar.api.datasource.DatasourceError.{
   DiscoveryError,
   ExistentialError
 }
+import quasar.api.resource.{ResourceName, ResourcePath, ResourcePathType}
 import quasar.common.data.Data
-import quasar.common.resource.{MonadResourceErr, ResourceName, ResourcePath, ResourcePathType}
-import quasar.connector.Datasource
+import quasar.connector.{Datasource, MonadResourceErr}
 import quasar.contrib.scalaz.MonadError_
 import quasar.fp.ski.{κ, κ2}
 import quasar.impl.DatasourceModule

--- a/impl/src/main/scala/quasar/impl/datasources/DefaultDatasources.scala
+++ b/impl/src/main/scala/quasar/impl/datasources/DefaultDatasources.scala
@@ -20,7 +20,7 @@ import slamdata.Predef.{Boolean, Exception, Unit}
 import quasar.Condition
 import quasar.api.datasource._
 import quasar.api.datasource.DatasourceError._
-import quasar.common.resource._
+import quasar.api.resource._
 import quasar.impl.storage.IndexedStore
 
 import cats.effect.Sync

--- a/impl/src/main/scala/quasar/impl/evaluate/FederatedQuery.scala
+++ b/impl/src/main/scala/quasar/impl/evaluate/FederatedQuery.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package quasar.evaluate
+package quasar.impl.evaluate
 
 import slamdata.Predef.Option
 import quasar.contrib.pathy.AFile

--- a/impl/src/main/scala/quasar/impl/evaluate/FederatingQueryEvaluator.scala
+++ b/impl/src/main/scala/quasar/impl/evaluate/FederatingQueryEvaluator.scala
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package quasar.evaluate
+package quasar.impl.evaluate
 
 import slamdata.Predef.{None, Option, Some}
 import quasar.api.QueryEvaluator
 import quasar.common.resource.{MonadResourceErr, ResourceError, ResourcePath}
+import quasar.contrib.iota.copkTraverse
 import quasar.contrib.pathy._
 import quasar.contrib.scalaz.MonadTell_
 import quasar.fp.PrismNT
-import quasar.contrib.iota.copkTraverse
 import quasar.qscript.{Read => QRead, _}
 
 import matryoshka._

--- a/impl/src/main/scala/quasar/impl/evaluate/FederatingQueryEvaluator.scala
+++ b/impl/src/main/scala/quasar/impl/evaluate/FederatingQueryEvaluator.scala
@@ -18,7 +18,8 @@ package quasar.impl.evaluate
 
 import slamdata.Predef.{None, Option, Some}
 import quasar.api.QueryEvaluator
-import quasar.common.resource.{MonadResourceErr, ResourceError, ResourcePath}
+import quasar.api.resource.ResourcePath
+import quasar.connector.{MonadResourceErr, ResourceError}
 import quasar.contrib.iota.copkTraverse
 import quasar.contrib.pathy._
 import quasar.contrib.scalaz.MonadTell_

--- a/impl/src/main/scala/quasar/impl/evaluate/QueryFederation.scala
+++ b/impl/src/main/scala/quasar/impl/evaluate/QueryFederation.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package quasar.evaluate
+package quasar.impl.evaluate
 
 import scalaz.{Contravariant, Functor, Profunctor}
 import scalaz.syntax.functor._

--- a/impl/src/main/scala/quasar/impl/evaluate/Source.scala
+++ b/impl/src/main/scala/quasar/impl/evaluate/Source.scala
@@ -16,7 +16,7 @@
 
 package quasar.impl.evaluate
 
-import quasar.common.resource.ResourcePath
+import quasar.api.resource.ResourcePath
 
 import monocle.macros.Lenses
 import scalaz.{Applicative, Cord, Equal, Order, Show, Traverse}

--- a/impl/src/main/scala/quasar/impl/evaluate/Source.scala
+++ b/impl/src/main/scala/quasar/impl/evaluate/Source.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package quasar.evaluate
+package quasar.impl.evaluate
 
 import quasar.common.resource.ResourcePath
 

--- a/impl/src/test/scala/quasar/impl/datasource/local/LocalDatasourceSpec.scala
+++ b/impl/src/test/scala/quasar/impl/datasource/local/LocalDatasourceSpec.scala
@@ -16,8 +16,8 @@
 
 package quasar.impl.datasource.local
 
-import quasar.common.resource.{ResourceError, ResourceName, ResourcePath}
-import quasar.connector.DatasourceSpec
+import quasar.api.resource.{ResourceName, ResourcePath}
+import quasar.connector.{DatasourceSpec, ResourceError}
 import quasar.contrib.scalaz.MonadError_
 
 import java.nio.file.Paths

--- a/impl/src/test/scala/quasar/impl/datasources/DatasourceManagementSpec.scala
+++ b/impl/src/test/scala/quasar/impl/datasources/DatasourceManagementSpec.scala
@@ -20,9 +20,9 @@ import slamdata.Predef._
 import quasar.{ConditionMatchers, Disposable, RenderTreeT}
 import quasar.api.datasource._
 import quasar.api.datasource.DatasourceError._
+import quasar.api.resource._
 import quasar.common.data.Data
-import quasar.common.resource._
-import quasar.connector.{Datasource, HeavyweightDatasourceModule, LightweightDatasourceModule}
+import quasar.connector._
 import quasar.contrib.scalaz.MonadError_
 import quasar.impl.DatasourceModule
 import quasar.qscript.{MonadPlannerErr, PlannerError, QScriptEducated}

--- a/impl/src/test/scala/quasar/impl/datasources/MockDatasourceControl.scala
+++ b/impl/src/test/scala/quasar/impl/datasources/MockDatasourceControl.scala
@@ -20,7 +20,7 @@ import slamdata.Predef.{Boolean, List, None, Option, Some, Unit}
 import quasar.Condition
 import quasar.api.datasource.{DatasourceRef, DatasourceType}
 import quasar.api.datasource.DatasourceError._
-import quasar.common.resource._
+import quasar.api.resource._
 import quasar.contrib.scalaz.{MonadState_, MonadTell_}
 import MockDatasourceControl.{MonadInit, MonadShutdown}
 

--- a/impl/src/test/scala/quasar/impl/evaluate/FederatingQueryEvaluatorSpec.scala
+++ b/impl/src/test/scala/quasar/impl/evaluate/FederatingQueryEvaluatorSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package quasar.evaluate
+package quasar.impl.evaluate
 
 import slamdata.Predef._
 import quasar.{Qspec, TreeMatchers}

--- a/impl/src/test/scala/quasar/impl/evaluate/FederatingQueryEvaluatorSpec.scala
+++ b/impl/src/test/scala/quasar/impl/evaluate/FederatingQueryEvaluatorSpec.scala
@@ -18,7 +18,8 @@ package quasar.impl.evaluate
 
 import slamdata.Predef._
 import quasar.{Qspec, TreeMatchers}
-import quasar.common.resource._
+import quasar.api.resource._
+import quasar.connector.ResourceError
 import quasar.contrib.pathy.{ADir, AFile}
 import quasar.contrib.iota.{copkTraverse, copkEqual}
 import quasar.fp.constEqual

--- a/mimir/src/main/scala/quasar/mimir/evaluate/FederatedShiftedReadPlanner.scala
+++ b/mimir/src/main/scala/quasar/mimir/evaluate/FederatedShiftedReadPlanner.scala
@@ -22,7 +22,7 @@ import quasar.common.data.Data
 import quasar.contrib.iota._
 import quasar.contrib.pathy._
 import quasar.contrib.scalaz.MonadTell_
-import quasar.evaluate.{Source => EvalSource}
+import quasar.impl.evaluate.{Source => EvalSource}
 import quasar.mimir._, MimirCake._
 import quasar.precog.common.RValue
 import quasar.qscript._, PlannerError.InternalError

--- a/mimir/src/main/scala/quasar/mimir/evaluate/MimirQueryFederation.scala
+++ b/mimir/src/main/scala/quasar/mimir/evaluate/MimirQueryFederation.scala
@@ -19,7 +19,7 @@ package quasar.mimir.evaluate
 import quasar.RenderTreeT
 import quasar.common.data.Data
 import quasar.contrib.cats.effect.liftio._
-import quasar.evaluate.{FederatedQuery, QueryFederation}
+import quasar.impl.evaluate.{FederatedQuery, QueryFederation}
 import quasar.mimir._, MimirCake._
 import quasar.qscript.MonadPlannerErr
 

--- a/mimir/src/main/scala/quasar/mimir/evaluate/QueryAssociate.scala
+++ b/mimir/src/main/scala/quasar/mimir/evaluate/QueryAssociate.scala
@@ -16,8 +16,8 @@
 
 package quasar.mimir.evaluate
 
+import quasar.api.resource.ResourcePath
 import quasar.common.data.Data
-import quasar.common.resource.ResourcePath
 import quasar.qscript.QScriptEducated
 
 import fs2.Stream

--- a/mimir/src/main/scala/quasar/mimir/evaluate/package.scala
+++ b/mimir/src/main/scala/quasar/mimir/evaluate/package.scala
@@ -18,7 +18,7 @@ package quasar.mimir
 
 import slamdata.Predef.Option
 import quasar.contrib.pathy.AFile
-import quasar.evaluate.Source
+import quasar.impl.evaluate.Source
 
 import scalaz.Kleisli
 

--- a/repl/src/main/scala/quasar/repl/Command.scala
+++ b/repl/src/main/scala/quasar/repl/Command.scala
@@ -19,7 +19,7 @@ package repl
 
 import slamdata.Predef._
 import quasar.api.datasource._
-import quasar.common.resource.ResourcePath
+import quasar.api.resource.ResourcePath
 import quasar.run.optics.{stringUUIDP => UuidString}
 import quasar.sql.Query
 

--- a/repl/src/main/scala/quasar/repl/Evaluator.scala
+++ b/repl/src/main/scala/quasar/repl/Evaluator.scala
@@ -18,9 +18,8 @@ package quasar
 package repl
 
 import slamdata.Predef._
-import quasar.api._, datasource._
+import quasar.api._, datasource._, resource._
 import quasar.common.data.Data
-import quasar.common.resource._
 import quasar.contrib.pathy._
 import quasar.contrib.std.uuid._
 import quasar.fp.minspace

--- a/repl/src/main/scala/quasar/repl/ReplPath.scala
+++ b/repl/src/main/scala/quasar/repl/ReplPath.scala
@@ -17,7 +17,7 @@
 package quasar.repl
 
 import slamdata.Predef._
-import quasar.common.resource.{ResourceName, ResourcePath}
+import quasar.api.resource.{ResourceName, ResourcePath}
 
 import scalaz.{IList, Scalaz}, Scalaz._
 

--- a/repl/src/main/scala/quasar/repl/ReplState.scala
+++ b/repl/src/main/scala/quasar/repl/ReplState.scala
@@ -20,7 +20,7 @@ package repl
 import slamdata.Predef._
 
 import quasar.api.datasource.DatasourceType
-import quasar.common.resource.ResourcePath
+import quasar.api.resource.ResourcePath
 import quasar.fp.numeric.widenPositive
 
 import eu.timepit.refined.api.Refined

--- a/run/src/main/scala/quasar/run/Quasar.scala
+++ b/run/src/main/scala/quasar/run/Quasar.scala
@@ -22,10 +22,10 @@ import quasar.common.PhaseResultTell
 import quasar.common.data.Data
 import quasar.contrib.pathy.ADir
 import quasar.contrib.std.uuid._
-import quasar.evaluate.FederatingQueryEvaluator
 import quasar.impl.DatasourceModule
 import quasar.impl.datasource.local.LocalDatasourceModule
 import quasar.impl.datasources.{DatasourceManagement, DefaultDatasources}
+import quasar.impl.evaluate.FederatingQueryEvaluator
 import quasar.impl.external.{ExternalConfig, ExternalDatasources}
 import quasar.mimir.Precog
 import quasar.mimir.evaluate.MimirQueryFederation

--- a/run/src/main/scala/quasar/run/QuasarError.scala
+++ b/run/src/main/scala/quasar/run/QuasarError.scala
@@ -18,8 +18,8 @@ package quasar.run
 
 import slamdata.Predef.{Exception, Product, Serializable, Throwable}
 import quasar.api.datasource.DatasourceError.CreateError
-import quasar.common.resource.ResourceError
 import quasar.compile.SemanticErrors
+import quasar.connector.ResourceError
 import quasar.qscript.PlannerError
 import quasar.sql.ParsingError
 import quasar.yggdrasil.vfs.{ResourceError => MimirResourceError}

--- a/run/src/main/scala/quasar/run/ResourceRouter.scala
+++ b/run/src/main/scala/quasar/run/ResourceRouter.scala
@@ -21,8 +21,8 @@ import quasar.common.resource._
 import quasar.contrib.cats.effect._
 import quasar.contrib.pathy.AFile
 import quasar.contrib.std.uuid._
-import quasar.evaluate.Source
 import quasar.impl.datasources.DatasourceManagement.Running
+import quasar.impl.evaluate.Source
 import quasar.mimir.evaluate.QueryAssociate
 import quasar.run.optics.{stringUUIDP => UuidString}
 

--- a/run/src/main/scala/quasar/run/ResourceRouter.scala
+++ b/run/src/main/scala/quasar/run/ResourceRouter.scala
@@ -17,7 +17,7 @@
 package quasar.run
 
 import slamdata.Predef._
-import quasar.common.resource._
+import quasar.api.resource._
 import quasar.contrib.cats.effect._
 import quasar.contrib.pathy.AFile
 import quasar.contrib.std.uuid._

--- a/run/src/main/scala/quasar/run/implicits.scala
+++ b/run/src/main/scala/quasar/run/implicits.scala
@@ -17,9 +17,9 @@
 package quasar.run
 
 import quasar.api.datasource.DatasourceError.CreateError
-import quasar.contrib.scalaz.MonadError_
-import quasar.common.resource.ResourceError
 import quasar.compile.SemanticErrors
+import quasar.connector.ResourceError
+import quasar.contrib.scalaz.MonadError_
 import quasar.qscript.PlannerError
 import quasar.yggdrasil.vfs.{ResourceError => MimirResourceError}
 


### PR DESCRIPTION
* More precise build dependencies between projects
* Move `ResourceError` to `connector` as that is where it is introduced semantically
* Move the remaining resource-y types to `api` as they're introduced there