### PR TITLE
Add Datasources#resourceSchema to the API

### DIFF
--- a/api/src/main/scala/quasar/api/SchemaConfig.scala
+++ b/api/src/main/scala/quasar/api/SchemaConfig.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.api
+
+/** Configuration required in order to obtain a information about the structure
+  * of a dataset.
+  */
+trait SchemaConfig {
+  /** Representation describing of the structure of a dataset. */
+  type Schema
+}
+
+object SchemaConfig {
+  type Aux[Schema0] = SchemaConfig { type Schema = Schema0 }
+}

--- a/api/src/main/scala/quasar/api/datasource/DatasourceError.scala
+++ b/api/src/main/scala/quasar/api/datasource/DatasourceError.scala
@@ -53,6 +53,9 @@ object DatasourceError extends DatasourceErrorInstances {
   final case class PathNotFound(path: ResourcePath)
     extends DiscoveryError[Nothing]
 
+  final case class PathNotAResource(path: ResourcePath)
+    extends DiscoveryError[Nothing]
+
   sealed trait ExistentialError[+I] extends DiscoveryError[I]
 
   final case class DatasourceNotFound[I](datasourceId: I)
@@ -102,6 +105,12 @@ object DatasourceError extends DatasourceErrorInstances {
       case (t, c, r) => MalformedConfiguration(t, c, r)
     }
 
+  def pathNotAResource[E >: DiscoveryError[Nothing] <: DatasourceError[_, _]]
+      : Prism[E, ResourcePath] =
+    Prism.partial[E, ResourcePath] {
+      case PathNotAResource(p) => p
+    } (PathNotAResource(_))
+
   def pathNotFound[E >: DiscoveryError[Nothing] <: DatasourceError[_, _]]
       : Prism[E, ResourcePath] =
     Prism.partial[E, ResourcePath] {
@@ -123,6 +132,7 @@ sealed abstract class DatasourceErrorInstances {
       datasourceUnsupported[DatasourceError[I, C]].getOption(de),
       invalidConfiguration[C, DatasourceError[I, C]].getOption(de),
       malformedConfiguration[C, DatasourceError[I, C]].getOption(de),
+      pathNotAResource[DatasourceError[I, C]].getOption(de),
       pathNotFound[DatasourceError[I, C]].getOption(de)
     )}
   }
@@ -141,6 +151,9 @@ sealed abstract class DatasourceErrorInstances {
 
   implicit def showDiscoveryError[I: Show]: Show[DiscoveryError[I]] =
     Show.show {
+      case PathNotAResource(p) =>
+        Cord("PathNotAResource(") ++ p.show ++ Cord(")")
+
       case PathNotFound(p) =>
         Cord("PathNotFound(") ++ p.show ++ Cord(")")
 

--- a/api/src/main/scala/quasar/api/datasource/Datasources.scala
+++ b/api/src/main/scala/quasar/api/datasource/Datasources.scala
@@ -16,8 +16,9 @@
 
 package quasar.api.datasource
 
-import slamdata.Predef.{Boolean, Exception}
+import slamdata.Predef.{Boolean, Exception, Option}
 import quasar.Condition
+import quasar.api.SchemaConfig
 import quasar.api.resource._
 
 import scalaz.{\/, ISet}
@@ -27,7 +28,7 @@ import scalaz.{\/, ISet}
   * @tparam I identity
   * @tparam C configuration
   */
-trait Datasources[F[_], G[_], I, C] {
+trait Datasources[F[_], G[_], I, C, S <: SchemaConfig] {
   import DatasourceError._
 
   /** Adds the datasource described by the given `DatasourceRef` to the
@@ -56,7 +57,7 @@ trait Datasources[F[_], G[_], I, C] {
       : F[ExistentialError[I] \/ Boolean]
 
   /** Returns the name and type of the `ResourcePath`s within the specified
-    * Datasource implied by concatenating each name to `prefixPath`.
+    * datasource implied by concatenating each name to `prefixPath`.
     */
   def prefixedChildPaths(datasourceId: I, prefixPath: ResourcePath)
       : F[DiscoveryError[I] \/ G[(ResourceName, ResourcePathType)]]
@@ -67,6 +68,14 @@ trait Datasources[F[_], G[_], I, C] {
   /** Replaces the reference to the specified datasource. */
   def replaceDatasource(datasourceId: I, ref: DatasourceRef[C])
       : F[Condition[DatasourceError[I, C]]]
+
+  /** Retrieves the schema of the resource at the given `path` with the
+    * specified datasource according to the provided `schemaConfig`.
+    *
+    * Returns `None` if the resource exists but a schema is not available.
+    */
+  def resourceSchema(datasourceId: I, path: ResourcePath, schemaConfig: S)
+      : F[DiscoveryError[I] \/ Option[schemaConfig.Schema]]
 
   /** The set of supported datasource types. */
   def supportedDatasourceTypes: F[ISet[DatasourceType]]

--- a/api/src/test/scala/quasar/api/MockSchemaConfig.scala
+++ b/api/src/test/scala/quasar/api/MockSchemaConfig.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.api
+
+object MockSchemaConfig extends SchemaConfig {
+  object MockSchema
+  type Schema = MockSchema.type
+}

--- a/api/src/test/scala/quasar/api/datasource/DatasourcesSpec.scala
+++ b/api/src/test/scala/quasar/api/datasource/DatasourcesSpec.scala
@@ -18,6 +18,7 @@ package quasar.api.datasource
 
 import slamdata.Predef._
 import quasar.{Condition, ConditionMatchers, EffectfulQSpec}
+import quasar.api.SchemaConfig
 import quasar.api.resource.ResourcePath
 
 import scala.Predef.assert
@@ -35,19 +36,22 @@ import scalaz.syntax.equal._
 import scalaz.syntax.foldable._
 import scalaz.std.list._
 
-abstract class DatasourcesSpec[F[_], G[_], I: Order: Show, C: Equal: Show](
+abstract class DatasourcesSpec[
+    F[_], G[_], I: Order: Show, C: Equal: Show, S <: SchemaConfig](
     implicit F: Effect[F], ec: ExecutionContext)
     extends EffectfulQSpec[F]
     with ConditionMatchers {
 
   import DatasourceError._
 
-  def datasources: Datasources[F, G, I, C]
+  def datasources: Datasources[F, G, I, C, S]
 
   def supportedType: DatasourceType
 
   // Must be distinct.
   def validConfigs: (C, C)
+
+  val schemaConfig: S
 
   def gatherMultiple[A](fga: G[A]): F[List[A]]
 
@@ -237,6 +241,10 @@ abstract class DatasourcesSpec[F[_], G[_], I: Order: Show, C: Equal: Show](
         metaAfter.any(_._1 ≟ i) must beFalse
       }
     }
+  }
+
+  "resource schema" >> {
+    discoveryExamples(datasources.resourceSchema(_, _, schemaConfig))
   }
 
   ////

--- a/api/src/test/scala/quasar/api/datasource/MockDatasourcesSpec.scala
+++ b/api/src/test/scala/quasar/api/datasource/MockDatasourcesSpec.scala
@@ -18,6 +18,7 @@ package quasar.api.datasource
 
 import slamdata.Predef.{Int, List, String, Stream => SStream}
 import quasar.Condition
+import quasar.api.MockSchemaConfig
 import quasar.contrib.cats.stateT._
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -35,20 +36,22 @@ import shims._
 import MockDatasourcesSpec._
 
 final class MockDatasourcesSpec
-  extends DatasourcesSpec[MockM, List, Int, String] {
+  extends DatasourcesSpec[MockM, List, Int, String, MockSchemaConfig.type] {
 
   val s3: DatasourceType    = DatasourceType("s3", 1L)
   val azure: DatasourceType = DatasourceType("azure", 1L)
   val mongo: DatasourceType = DatasourceType("mongodb", 1L)
   val acceptedSet: ISet[DatasourceType] = ISet.fromList(List(s3, azure, mongo))
 
-  def datasources: Datasources[MockM, List, Int, String] =
+  def datasources: Datasources[MockM, List, Int, String, MockSchemaConfig.type] =
     MockDatasources[String, MockM, List](
       acceptedSet, _ => Condition.normal(), SStream.empty)
 
   def supportedType = DatasourceType("s3", 1L)
 
   def validConfigs = ("bucket1", "bucket2")
+
+  val schemaConfig = MockSchemaConfig
 
   def gatherMultiple[A](xs: List[A]) = xs.pure[MockM]
 }

--- a/build.sbt
+++ b/build.sbt
@@ -309,7 +309,8 @@ lazy val impl = project
   .settings(name := "quasar-impl-internal")
   .dependsOn(
     api % BothScopes,
-    connector % BothScopes)
+    connector % BothScopes,
+    sst)
   .settings(commonSettings)
   .settings(targetSettings)
   .settings(libraryDependencies ++= Dependencies.impl)

--- a/ejson/src/main/scala/quasar/ejson/EncodeEJsonK.scala
+++ b/ejson/src/main/scala/quasar/ejson/EncodeEJsonK.scala
@@ -20,6 +20,7 @@ import slamdata.Predef._
 import quasar.ejson.implicits._
 import quasar.contrib.iota.copkTraverse
 
+import iotaz.{CopK, TListK}
 import matryoshka._
 import matryoshka.implicits._
 import matryoshka.patterns.EnvT
@@ -65,12 +66,17 @@ sealed abstract class EncodeEJsonKInstances {
     }
 
   implicit def coproductEncodeEJsonK[F[_], G[_]](
-    implicit
-    F: EncodeEJsonK[F],
-    G: EncodeEJsonK[G]
-  ): EncodeEJsonK[Coproduct[F, G, ?]] =
+      implicit
+      F: EncodeEJsonK[F],
+      G: EncodeEJsonK[G])
+      : EncodeEJsonK[Coproduct[F, G, ?]] =
     new EncodeEJsonK[Coproduct[F, G, ?]] {
       def encodeK[J](implicit JC: Corecursive.Aux[J, EJson], JR: Recursive.Aux[J, EJson]): Algebra[Coproduct[F, G, ?], J] =
         _.run.fold(F.encodeK[J], G.encodeK[J])
     }
+
+  implicit def copkEncodeEJsonK[LL <: TListK](
+      implicit M: EncodeEJsonKMaterializer[LL])
+      : EncodeEJsonK[CopK[LL, ?]] =
+    M.materialize(offset = 0)
 }

--- a/ejson/src/main/scala/quasar/ejson/EncodeEJsonKMaterializer.scala
+++ b/ejson/src/main/scala/quasar/ejson/EncodeEJsonKMaterializer.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.ejson
+
+import slamdata.Predef.{Array, Int => SInt, SuppressWarnings}
+
+import quasar.contrib.iota._
+
+import iotaz.TListK.:::
+import iotaz.{CopK, TListK, TNilK}
+import matryoshka.{Algebra, Corecursive, Recursive}
+
+sealed trait EncodeEJsonKMaterializer[LL <: TListK] {
+  def materialize(offset: SInt): EncodeEJsonK[CopK[LL, ?]]
+}
+
+object EncodeEJsonKMaterializer {
+  implicit def base[F[_]](implicit F: EncodeEJsonK[F]): EncodeEJsonKMaterializer[F ::: TNilK] =
+    new EncodeEJsonKMaterializer[F ::: TNilK] {
+      def materialize(offset: SInt): EncodeEJsonK[CopK[F ::: TNilK, ?]] = {
+        val I = mkInject[F, F ::: TNilK](offset)
+
+        new EncodeEJsonK[CopK[F ::: TNilK, ?]] {
+          def encodeK[J](
+              implicit
+              JC: Corecursive.Aux[J, EJson],
+              JR: Recursive.Aux[J, EJson])
+              : Algebra[CopK[F ::: TNilK, ?], J] = {
+
+            case I(fa) => F.encodeK[J].apply(fa)
+          }
+        }
+      }
+    }
+
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+  implicit def induct[F[_], LL <: TListK](
+      implicit
+      F: EncodeEJsonK[F],
+      LL: EncodeEJsonKMaterializer[LL])
+      : EncodeEJsonKMaterializer[F ::: LL] =
+    new EncodeEJsonKMaterializer[F ::: LL] {
+      def materialize(offset: SInt): EncodeEJsonK[CopK[F ::: LL, ?]] = {
+        val I = mkInject[F, F ::: LL](offset)
+
+        new EncodeEJsonK[CopK[F ::: LL, ?]] {
+          def encodeK[J](
+              implicit
+              JC: Corecursive.Aux[J, EJson],
+              JR: Recursive.Aux[J, EJson])
+              : Algebra[CopK[F ::: LL, ?], J] = {
+
+            case I(fa) =>
+              F.encodeK[J].apply(fa)
+
+            case other =>
+              LL.materialize(offset + 1)
+                .encodeK[J].apply(other.asInstanceOf[CopK[LL, J]])
+          }
+        }
+      }
+    }
+}

--- a/impl/src/main/scala/quasar/impl/datasources/DatasourceControl.scala
+++ b/impl/src/main/scala/quasar/impl/datasources/DatasourceControl.scala
@@ -16,8 +16,9 @@
 
 package quasar.impl.datasources
 
-import slamdata.Predef.{Boolean, Unit}
+import slamdata.Predef.{Boolean, Option, Unit}
 import quasar.Condition
+import quasar.api.SchemaConfig
 import quasar.api.datasource.{DatasourceRef, DatasourceType}
 import quasar.api.datasource.DatasourceError.{CreateError, DiscoveryError, ExistentialError}
 import quasar.api.resource.{ResourceName, ResourcePath, ResourcePathType}
@@ -31,7 +32,7 @@ import scalaz.{\/, ISet}
   * to be used as a dependency in another context, such as `DefaultDatasources`,
   * that decides whether doing so is appropriate.
   */
-trait DatasourceControl[F[_], G[_], I, C] {
+trait DatasourceControl[F[_], G[_], I, C, S <: SchemaConfig] {
   /** Initialize a datasource as `datasourceId` using the provided `ref`. If a
     * datasource exists at `datasourceId`, it is shut down.
     */
@@ -49,6 +50,14 @@ trait DatasourceControl[F[_], G[_], I, C] {
     */
   def prefixedChildPaths(datasourceId: I, prefixPath: ResourcePath)
       : F[DiscoveryError[I] \/ G[(ResourceName, ResourcePathType)]]
+
+  /** Retrieves the schema of the resource at the given `path` with the
+    * specified datasource according to the provided `schemaConfig`.
+    *
+    * Returns `None` if the resource exists but a schema is not available.
+    */
+  def resourceSchema(datasourceId: I, path: ResourcePath, schemaConfig: S)
+      : F[DiscoveryError[I] \/ Option[schemaConfig.Schema]]
 
   /** Stop the named datasource, discarding it and freeing any resources it may
     * be using.

--- a/impl/src/main/scala/quasar/impl/datasources/DatasourceManagement.scala
+++ b/impl/src/main/scala/quasar/impl/datasources/DatasourceManagement.scala
@@ -28,11 +28,17 @@ import quasar.api.datasource.DatasourceError.{
 import quasar.api.resource.{ResourceName, ResourcePath, ResourcePathType}
 import quasar.common.data.Data
 import quasar.connector.{Datasource, MonadResourceErr}
+import quasar.contrib.iota._
 import quasar.contrib.scalaz.MonadError_
+import quasar.ejson.EJson
+import quasar.ejson.implicits._
+import quasar.fp.numeric.Positive
 import quasar.fp.ski.{κ, κ2}
 import quasar.impl.DatasourceModule
 import quasar.impl.datasource.{ByNeedDatasource, ConditionReportingDatasource, FailedDatasource}
-import quasar.qscript.{MonadPlannerErr, QScriptEducated}
+import quasar.impl.schema._
+import quasar.qscript._
+import quasar.sst._
 
 import scala.concurrent.ExecutionContext
 
@@ -41,17 +47,22 @@ import cats.effect.{ConcurrentEffect, Timer}
 import fs2.{Scheduler, Stream}
 import fs2.async.{immutable, mutable, Ref}
 import matryoshka.{BirecursiveT, EqualT, ShowT}
+import pathy.Path
 import scalaz.{\/, EitherT, IMap, ISet, Monad, OptionT, Order, Scalaz}, Scalaz._
 import shims._
+import spire.algebra.Field
+import spire.math.ConvertableTo
 
 final class DatasourceManagement[
     T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT,
     F[_]: ConcurrentEffect: MonadPlannerErr: MonadResourceErr: Timer,
-    I: Order] private (
+    I: Order,
+    N: ConvertableTo: Field: Order] private (
     modules: DatasourceManagement.Modules,
     errors: Ref[F, IMap[I, Exception]],
-    running: mutable.Signal[F, DatasourceManagement.Running[I, T, F]])
-    extends DatasourceControl[F, Stream[F, ?], I, Json]
+    running: mutable.Signal[F, DatasourceManagement.Running[I, T, F]],
+    sstSampleSize: Positive)
+    extends DatasourceControl[F, Stream[F, ?], I, Json, SstConfig[T[EJson], N]]
     with DatasourceErrors[F, I] {
 
   import DatasourceManagement.withErrorReporting
@@ -106,6 +117,45 @@ final class DatasourceManagement[
       _.prefixedChildPaths(prefixPath))
       .map(_.flatMap(_ \/> DatasourceError.pathNotFound[DiscoveryError[I]](prefixPath)))
 
+  def resourceSchema(
+      datasourceId: I,
+      path: ResourcePath,
+      sstConfig: SstConfig[T[EJson], N])
+      : F[DiscoveryError[I] \/ Option[sstConfig.Schema]] = {
+
+    type TS = TypeStat[N]
+    type P[X] = StructuralType[T[EJson], X]
+
+    def sampleQuery =
+      dsl.Subset(
+        dsl.Unreferenced,
+        freeDsl.LeftShift(
+          Path.refineType(path.toPath)
+            .fold(freeDsl.Read(_), freeDsl.Read(_)),
+          recFunc.Hole,
+          ExcludeId,
+          ShiftType.Map,
+          OnUndefined.Omit,
+          func.RightSide),
+        Take,
+        freeDsl.Map(
+          freeDsl.Unreferenced,
+          recFunc.Constant(EJson.int(sstSampleSize.value))))
+
+    withDs[DiscoveryError[I], Option[sstConfig.Schema]](datasourceId) { ds =>
+      val dataStream = ds.fold(
+        lw => lw.evaluate(path).map(_.take(sstSampleSize.value)),
+        hw => hw.evaluate(sampleQuery))
+
+      val k = ConvertableTo[N].fromLong(sstSampleSize.value)
+
+      Stream.force(dataStream)
+        .through(extractSst(sstConfig))
+        .map(s => SstSchema((SST.size(s) < k) either Population.subst[P, TS](s) or s))
+        .compile.last
+    }
+  }
+
   def shutdownDatasource(datasourceId: I): F[Unit] =
     modifyAndShutdown(_.updateLookupWithKey(datasourceId, κ2(None)) match {
       case (v, m) => (m, v strengthL datasourceId)
@@ -126,6 +176,11 @@ final class DatasourceManagement[
 
   ////
 
+  private val dsl = construction.mkGeneric[T, QScriptEducated[T, ?]]
+  private val freeDsl = construction.mkFree[T, QScriptEducated[T, ?]]
+  private val func = construction.Func[T]
+  private val recFunc = construction.RecFunc[T]
+
   private def modifyAndShutdown(f: Running => (Running, Option[(I, Disposable[F, DS])])): F[Unit] =
     for {
       t <- running.modify2(f)
@@ -139,9 +194,13 @@ final class DatasourceManagement[
       datasourceId: I)(
       f: Datasource[F, Stream[F, ?], _, _] => F[A])
       : F[E \/ A] =
+    withDs[E, A](datasourceId)(ds => f(ds.merge))
+
+  private def withDs[E >: ExistentialError[I] <: DatasourceError[I, Json], A](
+      datasourceId: I)(f: DS => F[A]): F[E \/ A] =
     running.get.flatMap(_.lookup(datasourceId) match {
       case Some(ds) =>
-        f(ds.unsafeValue.merge).map(_.right[E])
+        f(ds.unsafeValue).map(_.right[E])
 
       case None =>
         DatasourceError.datasourceNotFound[I, E](datasourceId)
@@ -156,17 +215,20 @@ object DatasourceManagement {
   type DS[T[_[_]], F[_]] = LDS[F] \/ HDS[T, F]
   type Running[I, T[_[_]], F[_]] = IMap[I, Disposable[F, DS[T, F]]]
 
+  type MgmtControl[T[_[_]], F[_], I, N] =
+      DatasourceControl[F, Stream[F, ?], I, Json, SstConfig[T[EJson], N]]
+
   def apply[
       T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT,
       F[_]: ConcurrentEffect: MonadPlannerErr: MonadResourceErr: MonadError_[?[_], CreateError[Json]]: Timer,
-      I: Order](
+      I: Order,
+      N: ConvertableTo: Field: Order](
       modules: Modules,
       configured: IMap[I, DatasourceRef[Json]],
-      pool: ExecutionContext,
-      scheduler: Scheduler)
-      : F[(DatasourceControl[F, Stream[F, ?], I, Json] with DatasourceErrors[F, I], immutable.Signal[F, Running[I, T, F]])] = {
-
-    implicit val ec: ExecutionContext = pool
+      sstSampleSize: Positive,
+      scheduler: Scheduler)(
+      implicit ec: ExecutionContext)
+      : F[(MgmtControl[T, F, I, N] with DatasourceErrors[F, I], immutable.Signal[F, Running[I, T, F]])] = {
 
     for {
       errors <- Ref[F, IMap[I, Exception]](IMap.empty)
@@ -182,7 +244,7 @@ object DatasourceManagement {
               (id, ds.left[HDS[T, F]].point[Disposable[F, ?]]).point[F]
 
             case Some(mod) =>
-              lazyDatasource[T, F](mod, ref, pool, scheduler).strengthL(id)
+              lazyDatasource[T, F](mod, ref, scheduler).strengthL(id)
           }
       }
 
@@ -194,7 +256,7 @@ object DatasourceManagement {
 
       runningS <- mutable.Signal[F, Running[I, T, F]](running)
 
-      mgmt = new DatasourceManagement[T, F, I](modules, errors, runningS)
+      mgmt = new DatasourceManagement[T, F, I, N](modules, errors, runningS, sstSampleSize)
     } yield (mgmt, runningS)
   }
 
@@ -213,8 +275,8 @@ object DatasourceManagement {
       F[_]: ConcurrentEffect: MonadPlannerErr: MonadResourceErr: MonadError_[?[_], CreateError[Json]]: Timer](
       module: DatasourceModule,
       ref: DatasourceRef[Json],
-      pool: ExecutionContext,
-      scheduler: Scheduler)
+      scheduler: Scheduler)(
+      implicit ec: ExecutionContext)
       : F[Disposable[F, DS[T, F]]] =
     module match {
       case DatasourceModule.Lightweight(lw) =>
@@ -223,7 +285,7 @@ object DatasourceManagement {
             .map(_.leftMap(ie => ie: CreateError[Json]))
         }
 
-        ByNeedDatasource(ref.kind, mklw, pool, scheduler)
+        ByNeedDatasource(ref.kind, mklw, scheduler)
           .map(_.map(_.left))
 
       case DatasourceModule.Heavyweight(hw) =>
@@ -232,7 +294,7 @@ object DatasourceManagement {
             .map(_.leftMap(ie => ie: CreateError[Json]))
         }
 
-        ByNeedDatasource(ref.kind, mkhw, pool, scheduler)
+        ByNeedDatasource(ref.kind, mkhw, scheduler)
           .map(_.map(_.right))
     }
 }

--- a/impl/src/main/scala/quasar/impl/datasources/DefaultDatasources.scala
+++ b/impl/src/main/scala/quasar/impl/datasources/DefaultDatasources.scala
@@ -16,8 +16,9 @@
 
 package quasar.impl.datasources
 
-import slamdata.Predef.{Boolean, Exception, Unit}
+import slamdata.Predef.{Boolean, Exception, Option, Unit}
 import quasar.Condition
+import quasar.api.SchemaConfig
 import quasar.api.datasource._
 import quasar.api.datasource.DatasourceError._
 import quasar.api.resource._
@@ -32,12 +33,13 @@ import scalaz.syntax.monad._
 import scalaz.syntax.std.boolean._
 import shims._
 
-final class DefaultDatasources[F[_]: Sync, I: Equal, C: Equal] private (
+final class DefaultDatasources[
+    F[_]: Sync, I: Equal, C: Equal, S <: SchemaConfig] private (
     freshId: F[I],
     refs: IndexedStore[F, I, DatasourceRef[C]],
     errors: DatasourceErrors[F, I],
-    control: DatasourceControl[F, Stream[F, ?], I, C])
-    extends Datasources[F, Stream[F, ?], I, C] {
+    control: DatasourceControl[F, Stream[F, ?], I, C, S])
+    extends Datasources[F, Stream[F, ?], I, C, S] {
 
   def addDatasource(ref: DatasourceRef[C]): F[CreateError[C] \/ I] =
     for {
@@ -83,6 +85,10 @@ final class DefaultDatasources[F[_]: Sync, I: Equal, C: Equal] private (
 
       case -\/(err) => Condition.abnormal(err).point[F]
     }
+
+  def resourceSchema(datasourceId: I, path: ResourcePath, schemaConfig: S)
+      : F[DiscoveryError[I] \/ Option[schemaConfig.Schema]] =
+    control.resourceSchema(datasourceId, path, schemaConfig)
 
   def supportedDatasourceTypes: F[ISet[DatasourceType]] =
     control.supportedDatasourceTypes
@@ -152,11 +158,11 @@ final class DefaultDatasources[F[_]: Sync, I: Equal, C: Equal] private (
 }
 
 object DefaultDatasources {
-  def apply[F[_]: Sync, I: Equal, C: Equal](
+  def apply[F[_]: Sync, I: Equal, C: Equal, S <: SchemaConfig](
       freshId: F[I],
       refs: IndexedStore[F, I, DatasourceRef[C]],
       errors: DatasourceErrors[F, I],
-      control: DatasourceControl[F, Stream[F, ?], I, C])
-      : Datasources[F, Stream[F, ?], I, C] =
+      control: DatasourceControl[F, Stream[F, ?], I, C, S])
+      : Datasources[F, Stream[F, ?], I, C, S] =
     new DefaultDatasources(freshId, refs, errors, control)
 }

--- a/impl/src/main/scala/quasar/impl/external/ExternalDatasources.scala
+++ b/impl/src/main/scala/quasar/impl/external/ExternalDatasources.scala
@@ -55,10 +55,9 @@ object ExternalDatasources extends Logging {
   val PluginChunkSize = 8192
 
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-  def apply[F[_]: Timer](config: ExternalConfig, pool: ExecutionContext)(implicit F: Effect[F])
+  def apply[F[_]: Timer](config: ExternalConfig)(
+      implicit F: Effect[F], ec: ExecutionContext)
       : Stream[F, IMap[DatasourceType, DatasourceModule]] = {
-
-    implicit val ec: ExecutionContext = pool
 
     val moduleStream = config match {
       case PluginDirectory(directory) =>

--- a/impl/src/main/scala/quasar/impl/schema/SstConfig.scala
+++ b/impl/src/main/scala/quasar/impl/schema/SstConfig.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.impl.schema
+
+import quasar.api.SchemaConfig
+import quasar.fp.numeric.{Natural, Positive}
+
+import eu.timepit.refined.auto._
+
+/** Configuration for SST-based schema, allowing for control over various aspects
+  * of compression.
+  *
+  * @param arrayMaxLength  arrays larger than this will be compressed
+  * @param mapMaxSize      maps larger than this will be compressed
+  * @param stringMaxLength all strings longer than this are compressed to char[]
+  * @param unionMaxSize    unions larger than this will be compressed
+  */
+final case class SstConfig[J, A](
+    arrayMaxLength:  Natural,
+    mapMaxSize:      Natural,
+    stringMaxLength: Natural,
+    unionMaxSize:    Positive)
+    extends SchemaConfig {
+
+  type Schema = SstSchema[J, A]
+}
+
+object SstConfig {
+  val DefaultArrayMaxLength:  Natural  = 10L
+  val DefaultMapMaxSize:      Natural  = 32L
+  val DefaultStringMaxLength: Natural  =  0L
+  val DefaultUnionMaxSize:    Positive =  1L
+
+  def Default[J, A]: SstConfig[J, A] =
+    SstConfig[J, A](
+      arrayMaxLength  = DefaultArrayMaxLength,
+      mapMaxSize      = DefaultMapMaxSize,
+      stringMaxLength = DefaultStringMaxLength,
+      unionMaxSize    = DefaultUnionMaxSize)
+}

--- a/impl/src/main/scala/quasar/impl/schema/SstSchema.scala
+++ b/impl/src/main/scala/quasar/impl/schema/SstSchema.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.impl.schema
+
+import quasar.sst._
+
+import scalaz.{\/, Equal, Show}
+import scalaz.syntax.show._
+import spire.algebra.{Field, NRoot}
+
+final case class SstSchema[J, A](sst: SST[J, A] \/ PopulationSST[J, A])
+
+object SstSchema {
+  implicit def equal[J: Equal, A: Equal]: Equal[SstSchema[J, A]] =
+    Equal.equalBy(
+      _.sst.map(Population.unsubst[StructuralType[J, ?], TypeStat[A]]))
+
+  implicit def show[J: Show, A: Equal: Field: NRoot: Show]: Show[SstSchema[J, A]] =
+    Show.show(_.sst.fold(
+      s => s,
+      Population.unsubst[StructuralType[J, ?], TypeStat[A]]).show)
+}

--- a/impl/src/main/scala/quasar/impl/schema/package.scala
+++ b/impl/src/main/scala/quasar/impl/schema/package.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.impl
+
+import slamdata.Predef._
+import quasar.common.data.Data
+import quasar.contrib.matryoshka._
+import quasar.ejson.EJson
+import quasar.contrib.iota.copkTraverse
+import quasar.sst._
+
+import fs2.Pipe
+import matryoshka._
+import matryoshka.implicits._
+import scalaz._, Scalaz._
+import scalaz.syntax.tag._
+import spire.algebra.Field
+import spire.math.ConvertableTo
+
+package object schema {
+
+  /** Reduces the input to an `SST` summarizing its structure. */
+  def extractSst[F[_], J: Order, A: ConvertableTo: Field: Order](
+      config: SstConfig[J, A])(
+      implicit
+      JC: Corecursive.Aux[J, EJson],
+      JR: Recursive.Aux[J, EJson])
+      : Pipe[F, Data, SST[J, A]] = {
+
+    type W[A] = Writer[Boolean @@ Tags.Disjunction, A]
+
+    val thresholding: ElgotCoalgebra[SST[J, A] \/ ?, SSTF[J, A, ?], SST[J, A]] = {
+      val independent =
+        orOriginal(applyTransforms(
+          compression.z85EncodedBinary[J, A],
+          compression.limitStrings[J, A](config.stringMaxLength)))
+
+      compression.limitArrays[J, A](config.arrayMaxLength)
+        .andThen(_.bimap(_.transAna[SST[J, A]](independent), independent))
+    }
+
+    val reduction: SSTF[J, A, SST[J, A]] => W[SSTF[J, A, SST[J, A]]] = {
+      val f = applyTransforms(
+        compression.coalesceWithUnknown[J, A],
+        compression.coalesceKeys[J, A](config.mapMaxSize),
+        compression.coalescePrimary[J, A],
+        compression.narrowUnion[J, A](config.unionMaxSize))
+
+      sstf => f(sstf).fold(sstf.point[W])(r => WriterT.writer((true.disjunction, r)))
+    }
+
+    def iterate(sst: SST[J, A]): Option[SST[J, A]] = {
+      val (changed, compressed) =
+        sst.transAnaM[W, SST[J, A], SSTF[J, A, ?]](reduction).run
+
+      changed.unwrap option compressed
+    }
+
+    _.map(d => SST.fromData[J, A](Field[A].one, d).elgotApo[SST[J, A]](thresholding))
+      .reduce((x, y) => repeatedly(iterate)(x |+| y))
+  }
+}

--- a/impl/src/test/scala/quasar/impl/datasources/DefaultDatasourcesSpec.scala
+++ b/impl/src/test/scala/quasar/impl/datasources/DefaultDatasourcesSpec.scala
@@ -18,6 +18,7 @@ package quasar.impl.datasources
 
 import slamdata.Predef.{Stream => _, _}
 import quasar.Condition
+import quasar.api.MockSchemaConfig
 import quasar.api.datasource._
 import quasar.api.datasource.DatasourceError._
 import quasar.contrib.cats.stateT._
@@ -44,7 +45,7 @@ import scalaz.std.string._
 import shims._
 
 final class DefaultDatasourcesSpec
-    extends DatasourcesSpec[DefaultM, Stream[DefaultM, ?], Int, String] {
+    extends DatasourcesSpec[DefaultM, Stream[DefaultM, ?], Int, String, MockSchemaConfig.type] {
 
   val monadIdx: MonadState_[DefaultM, Int] =
     MonadState_.zoom[DefaultM](DefaultState.idx)
@@ -61,12 +62,14 @@ final class DefaultDatasourcesSpec
 
   def validConfigs = ("one", "two")
 
+  val schemaConfig = MockSchemaConfig
+
   def gatherMultiple[A](as: Stream[DefaultM, A]) = as.compile.toList
 
   def mkDatasources(
       errs: IMap[Int, Exception])(
       init: String => Option[InitializationError[String]])
-      : Datasources[DefaultM, Stream[DefaultM, ?], Int, String] = {
+      : Datasources[DefaultM, Stream[DefaultM, ?], Int, String, MockSchemaConfig.type] = {
 
     val freshId =
       for {

--- a/impl/src/test/scala/quasar/impl/schema/ExtractSstSpec.scala
+++ b/impl/src/test/scala/quasar/impl/schema/ExtractSstSpec.scala
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.impl.schema
+
+import slamdata.Predef.{Int => SInt, Stream => _, _}
+import quasar.common.data.Data
+import quasar.contrib.algebra._
+import quasar.contrib.iota._
+import quasar.contrib.matryoshka._
+import quasar.ejson.{EJson, Fixed}
+import quasar.ejson.implicits._
+import quasar.fp._
+import quasar.fp.numeric.SampleStats
+import quasar.sst._
+import quasar.tpe._
+
+import scala.Byte
+
+import eu.timepit.refined.auto._
+import fs2.Stream
+import matryoshka.data.Fix
+import matryoshka.implicits._
+import scalaz._, Scalaz._
+import spire.std.double._
+import spire.math.Real
+
+final class ExtractSstSpec extends quasar.Qspec {
+  import Data._, StructuralType.{TagST, TypeST}
+
+  type J = Fix[EJson]
+  type S = SST[J, Real]
+
+  implicit val showReal: Show[Real] =
+    Show.showFromToString
+
+  val J = Fixed[J]
+  val config = SstConfig[J, Real](1000L, 1000L, 1000L, 1000L)
+
+  def verify(cfg: SstConfig[J, Real], input: List[Data], expected: S) =
+    Stream.emits(input)
+      .through(extractSst(cfg))
+      .covary[cats.effect.IO]
+      .compile.last.unsafeRunSync
+      .must(beSome(equal(expected)))
+
+  def ints(n: SInt, ns: SInt*): NonEmptyList[S] =
+    NonEmptyList(n, ns: _*) map (n =>
+      envT(
+        TypeStat.int(SampleStats.one(Real(n)), BigInt(n), BigInt(n)),
+        TypeST(TypeF.const[J, S](J.int(BigInt(n))))).embed)
+
+  def strSS(s: String): SampleStats[Real] =
+    SampleStats.fromFoldable(s.map(c => Real(c.toInt)).toList)
+
+  "compress arrays" >> {
+    val input = List(
+      _obj(ListMap("foo" -> _arr(List(_int(1), _int(2))))),
+      _obj(ListMap("bar" -> _arr(List(_int(1), _int(2), _int(3)))))
+    )
+
+    val expected = envT(
+      TypeStat.coll(Real(2), Real(1).some, Real(1).some),
+      TypeST(TypeF.map[J, S](IMap(
+        J.str("foo") -> envT(
+          TypeStat.coll(Real(1), Real(2).some, Real(2).some),
+          TypeST(TypeF.arr[J, S](ints(1, 2).list.left))).embed,
+
+        J.str("bar") -> envT(
+          TypeStat.coll(Real(1), Real(3).some, Real(3).some),
+          TypeST(TypeF.arr[J, S](ints(1, 2, 3).suml1.right))).embed
+      ), None))).embed
+
+    verify(config.copy(arrayMaxLength = 2L), input, expected)
+  }
+
+  "compress long strings" >> {
+    val input = List(
+      _obj(ListMap("foo" -> _str("abcdef"))),
+      _obj(ListMap("bar" -> _str("abcde")))
+    )
+
+    val expected = envT(
+      TypeStat.coll(Real(2), Real(1).some, Real(1).some),
+      TypeST(TypeF.map[J, S](IMap(
+        J.str("foo") -> envT(
+          TypeStat.coll(Real(1), Real(6).some, Real(6).some),
+          TagST[J](Tagged(
+            strings.StructuralString,
+            envT(
+              TypeStat.coll(Real(1), Real(6).some, Real(6).some),
+              TypeST(TypeF.arr[J, S](envT(
+                TypeStat.char(strSS("abcdef"), 'a', 'f'),
+                TypeST(TypeF.simple[J, S](SimpleType.Char))).embed.right))
+            ).embed))
+          ).embed,
+
+        J.str("bar") -> envT(
+          TypeStat.coll(Real(1), Real(5).some, Real(5).some),
+          TypeST(TypeF.const[J, S](J.str("abcde")))
+        ).embed
+      ), None))).embed
+
+    verify(config.copy(stringMaxLength = 5L), input, expected)
+  }
+
+  "compress encoded binary strings" >> {
+    val b1 = ImmutableArray.fromArray("".getBytes)
+    val l1 = Real(b1.length)
+    val b2 = ImmutableArray.fromArray("abcdef".getBytes)
+    val l2 = Real(b2.length)
+
+    val input = List(
+      _obj(ListMap("foo" -> _binary(b1))),
+      _obj(ListMap("bar" -> _binary(b2)))
+    )
+
+    val expected = envT(
+      TypeStat.coll(Real(2), Real(1).some, Real(1).some),
+      TypeST(TypeF.map[J, S](IMap(
+        J.str("foo") -> envT(
+          TypeStat.coll(Real(1), l1.some, l1.some),
+          TypeST(TypeF.arr[J, S](envT(
+            TypeStat.byte(Real(1), Byte.MinValue, Byte.MaxValue),
+            TypeST(TypeF.simple[J, S](SimpleType.Byte))
+          ).embed.right))).embed,
+
+        J.str("bar") -> envT(
+          TypeStat.coll(Real(1), l2.some, l2.some),
+          TypeST(TypeF.arr[J, S](envT(
+            TypeStat.byte(Real(1), Byte.MinValue, Byte.MaxValue),
+            TypeST(TypeF.simple[J, S](SimpleType.Byte))
+          ).embed.right))).embed
+      ), None))).embed
+
+    verify(config, input, expected)
+  }
+
+  "coalesce map keys until <= max size" >> {
+    val input = List(
+      _obj(ListMap("foo" -> _int(1))),
+      _obj(ListMap("bar" -> _int(1))),
+      _obj(ListMap("baz" -> _int(1))),
+      _obj(ListMap("quux" -> _int(1)))
+    )
+
+    val fooSS =
+      SampleStats.fromFoldable("foo".map(_.toDouble).toList)
+
+    val expected = envT(
+      TypeStat.coll(Real(4), Real(1).some, Real(1).some),
+      TypeST(TypeF.map[J, S](IMap.empty[J, S], Some((
+        envT(
+          TypeStat.coll(Real(4), Real(3).some, Real(4).some),
+          TagST[J](Tagged(
+            strings.StructuralString,
+            envT(
+              TypeStat.coll(Real(4), Real(3).some, Real(4).some),
+              TypeST(TypeF.arr[J, S](IList(
+                envT(
+                  TypeStat.char(strSS("fbbq"), 'b', 'q'),
+                  TypeST(TypeF.simple[J, S](SimpleType.Char))).embed,
+                envT(
+                  TypeStat.char(strSS("oaau"), 'a', 'u'),
+                  TypeST(TypeF.simple[J, S](SimpleType.Char))).embed,
+                envT(
+                  TypeStat.char(strSS("orzu"), 'o', 'z'),
+                  TypeST(TypeF.simple[J, S](SimpleType.Char))).embed,
+                envT(
+                  TypeStat.char(strSS("x"), 'x', 'x'),
+                  TypeST(TypeF.const[J, S](J.char('x')))).embed
+              ).left))).embed))).embed,
+        envT(
+          TypeStat.int(SampleStats.freq(Real(4), Real(1)), BigInt(1), BigInt(1)),
+          TypeST(TypeF.const[J, S](J.int(1)))
+        ).embed
+      ))))).embed
+
+    verify(config.copy(mapMaxSize = 3L, unionMaxSize = 1L), input, expected)
+  }
+
+  "coalesce new map keys when primary type in unknown key" >> {
+    val input = List(
+      _obj(ListMap("foo" -> _int(1))),
+      _obj(ListMap("bar" -> _int(1))),
+      _obj(ListMap("baz" -> _int(1))),
+      _obj(ListMap("quux" -> _int(1)))
+    )
+
+    val expected = envT(
+      TypeStat.coll(Real(4), Real(1).some, Real(1).some),
+      TypeST(TypeF.map[J, S](IMap.empty[J, S], Some((
+        envT(
+          TypeStat.coll(Real(4), Real(3).some, Real(4).some),
+          TagST[J](Tagged(
+            strings.StructuralString,
+            envT(
+              TypeStat.coll(Real(4), Real(3).some, Real(4).some),
+              TypeST(TypeF.arr[J, S](IList(
+                envT(
+                  TypeStat.char(strSS("fbbq"), 'b', 'q'),
+                  TypeST(TypeF.simple[J, S](SimpleType.Char))).embed,
+                envT(
+                  TypeStat.char(strSS("oaau"), 'a', 'u'),
+                  TypeST(TypeF.simple[J, S](SimpleType.Char))).embed,
+                envT(
+                  TypeStat.char(strSS("orzu"), 'o', 'z'),
+                  TypeST(TypeF.simple[J, S](SimpleType.Char))).embed,
+                envT(
+                  TypeStat.char(strSS("x"), 'x', 'x'),
+                  TypeST(TypeF.const[J, S](J.char('x')))).embed
+              ).left))).embed))).embed,
+        envT(
+          TypeStat.int(SampleStats.freq(Real(4), Real(1)), BigInt(1), BigInt(1)),
+          TypeST(TypeF.const[J, S](J.int(1)))
+        ).embed
+      ))))).embed
+
+    verify(config.copy(mapMaxSize = 2L, unionMaxSize = 1L), input, expected)
+  }
+
+  "narrow unions until <= max size" >> {
+    val input = List(
+      _obj(ListMap("foo" -> _int(1))),
+      _obj(ListMap("foo" -> _int(2))),
+      _obj(ListMap("foo" -> _bool(true))),
+      _obj(ListMap("foo" -> _bool(false)))
+    )
+
+    val expected = envT(
+      TypeStat.coll(Real(4), Real(1).some, Real(1).some),
+      TypeST(TypeF.map[J, S](IMap(
+        J.str("foo") -> envT(
+          TypeStat.count(Real(4)),
+          TypeST(TypeF.coproduct[J, S](
+            envT(
+              TypeStat.int(
+                SampleStats.fromFoldable(IList(Real(1), Real(2))),
+                BigInt(1),
+                BigInt(2)),
+              TypeST(TypeF.simple[J, S](SimpleType.Int))).embed,
+            envT(
+              TypeStat.bool(Real(1), Real(1)),
+              TypeST(TypeF.simple[J, S](SimpleType.Bool))).embed))
+        ).embed
+      ), None))).embed
+
+    verify(config.copy(unionMaxSize = 2L), input, expected)
+  }
+
+  "coalesce consts with primary types in unions" >> {
+    val input = List(
+      _obj(ListMap("foo" -> _int(1))),
+      _obj(ListMap("foo" -> _int(2))),
+      _obj(ListMap("foo" -> _bool(true))),
+      _obj(ListMap("foo" -> _int(3)))
+    )
+
+    val expected = envT(
+      TypeStat.coll(Real(4), Real(1).some, Real(1).some),
+      TypeST(TypeF.map[J, S](IMap(
+        J.str("foo") -> envT(
+          TypeStat.count(Real(4)),
+          TypeST(TypeF.coproduct[J, S](
+            envT(
+              TypeStat.int(
+                SampleStats.fromFoldable(IList(Real(1), Real(2), Real(3))),
+                BigInt(1),
+                BigInt(3)),
+              TypeST(TypeF.simple[J, S](SimpleType.Int))).embed,
+            envT(
+              TypeStat.bool(Real(1), Real(0)),
+              TypeST(TypeF.const[J, S](J.bool(true)))).embed))
+        ).embed
+      ), None))).embed
+
+    verify(config.copy(unionMaxSize = 2L), input, expected)
+  }
+}

--- a/it/src/test/scala/quasar/regression/Sql2QueryRegressionSpec.scala
+++ b/it/src/test/scala/quasar/regression/Sql2QueryRegressionSpec.scala
@@ -83,7 +83,7 @@ final class Sql2QueryRegressionSpec extends Qspec {
         Stream.emit(_),
         contribFile.deleteRecursively[IO](_))
 
-    q <- Quasar[IO](tmpPath, ExternalConfig.Empty, global)
+    q <- Quasar[IO](tmpPath, ExternalConfig.Empty, 1L)
 
     localCfg =
       ("rootDir" := posixCodec.printPath(TestDataRoot)) ->:

--- a/repl/src/main/scala/quasar/repl/Command.scala
+++ b/repl/src/main/scala/quasar/repl/Command.scala
@@ -20,7 +20,7 @@ package repl
 import slamdata.Predef._
 import quasar.api.datasource._
 import quasar.api.resource.ResourcePath
-import quasar.run.optics.{stringUUIDP => UuidString}
+import quasar.run.optics.{stringUuidP => UuidString}
 import quasar.sql.Query
 
 import java.util.UUID
@@ -51,6 +51,7 @@ object Command {
   private val DatasourceAddPattern         = s"(?i)ds(?: +)(?:add +)($NamePattern)(?: +)($NamePattern)(?: +)(.*\\S)".r
   private val DatasourceLookupPattern      = "(?i)ds(?: +)(?:lookup|get) +([\\S]+)".r
   private val DatasourceRemovePattern      = "(?i)ds(?: +)(?:remove|rm) +([\\S]+)".r
+  private val ResourceSchemaPattern        = "(?i)schema +(.+)".r
 
   final case object Exit extends Command
   final case object Help extends Command
@@ -72,6 +73,7 @@ object Command {
   final case class DatasourceLookup(id: UUID) extends Command
   final case class DatasourceAdd(name: DatasourceName, tp: DatasourceType.Name, config: String) extends Command
   final case class DatasourceRemove(id: UUID) extends Command
+  final case class ResourceSchema(path: ReplPath) extends Command
 
   implicit val equalCommand: Equal[Command] = Equal.equalA
 
@@ -98,6 +100,7 @@ object Command {
       case DatasourceAddPattern(n, DatasourceType.string(tp), cfg) =>
                                                        DatasourceAdd(DatasourceName(n), tp, cfg)
       case DatasourceRemovePattern(UuidString(u))   => DatasourceRemove(u)
+      case ResourceSchemaPattern(ReplPath(path))    => ResourceSchema(path)
       case _                                        => Select(Query(input))
     }
 }

--- a/repl/src/main/scala/quasar/repl/Main.scala
+++ b/repl/src/main/scala/quasar/repl/Main.scala
@@ -26,6 +26,7 @@ import quasar.run.{Quasar, QuasarError}
 import scala.concurrent.ExecutionContext.Implicits.global
 
 import cats.effect.IO
+import eu.timepit.refined.auto._
 import fs2.{Stream, StreamApp}, StreamApp.ExitCode
 import fs2.async.Ref
 import scalaz._, Scalaz._
@@ -46,7 +47,7 @@ object Main extends StreamApp[IO] {
       _ <- Paths.mkdirs[Stream[IO, ?]](dataDir)
       pluginDir = basePath.resolve(Paths.QuasarPluginsDirName)
       _ <- Paths.mkdirs[Stream[IO, ?]](pluginDir)
-      q <- Quasar[IO](dataDir, ExternalConfig.PluginDirectory(pluginDir), global)
+      q <- Quasar[IO](dataDir, ExternalConfig.PluginDirectory(pluginDir), 1000L)
     } yield q
 
   def repl(q: Quasar[IO]): IO[ExitCode] =

--- a/repl/src/main/scala/quasar/repl/Repl.scala
+++ b/repl/src/main/scala/quasar/repl/Repl.scala
@@ -22,6 +22,8 @@ import quasar.api.QueryEvaluator
 import quasar.api.datasource.Datasources
 import quasar.build.BuildInfo
 import quasar.common.data.Data
+import quasar.ejson.EJson
+import quasar.impl.schema.SstConfig
 import quasar.run.SqlQuery
 
 import java.io.File
@@ -32,6 +34,7 @@ import cats.effect._
 import cats.syntax.{applicative, flatMap, functor}, applicative._, flatMap._, functor._
 import fs2.{Stream, StreamApp}, StreamApp.ExitCode
 import fs2.async.Ref
+import matryoshka.data.Fix
 import org.apache.commons.io.FileUtils
 import org.jline.reader._
 import org.jline.terminal._
@@ -72,7 +75,7 @@ object Repl {
 
   def mk[F[_]: ConcurrentEffect](
       ref: Ref[F, ReplState],
-      datasources: Datasources[F, Stream[F, ?], UUID, Json],
+      datasources: Datasources[F, Stream[F, ?], UUID, Json, SstConfig[Fix[EJson], Double]],
       queryEvaluator: QueryEvaluator[F, SqlQuery, Stream[F, Data]])
       : F[Repl[F]] = {
     val evaluator = Evaluator[F](ref, datasources, queryEvaluator)

--- a/run/src/main/scala/quasar/run/ResourceRouter.scala
+++ b/run/src/main/scala/quasar/run/ResourceRouter.scala
@@ -24,7 +24,7 @@ import quasar.contrib.std.uuid._
 import quasar.impl.datasources.DatasourceManagement.Running
 import quasar.impl.evaluate.Source
 import quasar.mimir.evaluate.QueryAssociate
-import quasar.run.optics.{stringUUIDP => UuidString}
+import quasar.run.optics.{stringUuidP => UuidString}
 
 import java.util.UUID
 

--- a/run/src/main/scala/quasar/run/optics.scala
+++ b/run/src/main/scala/quasar/run/optics.scala
@@ -117,7 +117,7 @@ object optics {
     Prism(fromRValue)(toRValue)
   }
 
-  val stringUUIDP: Prism[String, UUID] =
+  val stringUuidP: Prism[String, UUID] =
     Prism[String, UUID](
       s => \/.fromTryCatchNonFatal(UUID.fromString(s)).toOption)(
       u => u.toString)

--- a/sst/src/main/scala/quasar/sst/StructuralType.scala
+++ b/sst/src/main/scala/quasar/sst/StructuralType.scala
@@ -37,14 +37,14 @@ import quasar.contrib.iota.{:<<:, ACopK}
 import quasar.fp.ski.κ
 import quasar.tpe._
 
+import iotaz.{CopK, TNilK}
+import iotaz.TListK.:::
 import matryoshka._
 import matryoshka.data._
 import matryoshka.implicits._
 import matryoshka.patterns.EnvT
 import monocle.Lens
 import scalaz._, Scalaz._
-import iotaz.{CopK, TNilK}
-import iotaz.TListK.:::
 
 /** A measure annotated Type focused on structure over semantics.
   *


### PR DESCRIPTION
Provides the ability to obtain the schema of a resource and includes an implementation based on SSTs. Exposes this functionality in the REPL via the new `schema` command.