### PR TITLE
[DO NOT MERGE] Revert slow repair in ExpandShifts

### DIFF
--- a/it/src/main/resources/tests/flattenArrayValueAndIndexWithField.test
+++ b/it/src/main/resources/tests/flattenArrayValueAndIndexWithField.test
@@ -1,8 +1,8 @@
 {
     "name": "field and flattened array value and index",
     "backends": {
-        "lwc_local":         "ignoreFieldOrder",
-        "mimir":             "ignoreFieldOrder"
+        "lwc_local":         "pendingIgnoreFieldOrder",
+        "mimir":             "pendingIgnoreFieldOrder"
     },
     "data": "flattenable.data",
     "query": "select a, b[*], b[*:] as i from `flattenable.data`",

--- a/it/src/main/resources/tests/heterogeneousFlattenArrayValueAndIndexWithField.test
+++ b/it/src/main/resources/tests/heterogeneousFlattenArrayValueAndIndexWithField.test
@@ -1,9 +1,8 @@
 {
     "name": "field and flattened array value and index on heterogenous",
     "backends": {
-        "lwc_local":         "ignoreFieldOrder",
-        "mimir":             "ignoreFieldOrder"
-
+        "lwc_local": "pendingIgnoreFieldOrder",
+        "mimir": "pendingIgnoreFieldOrder"
     },
     "data": "heterogeneous.data",
     "query": "select a, b[*], b[*:] as i from `heterogeneous.data`",

--- a/it/src/main/resources/tests/heterogeneousFlattenMapValueAndKeyWithField.test
+++ b/it/src/main/resources/tests/heterogeneousFlattenMapValueAndKeyWithField.test
@@ -1,8 +1,8 @@
 {
     "name": "field and flattened map value and key on heterogeneous",
     "backends": {
-        "lwc_local":         "ignoreFieldOrder",
-        "mimir":             "ignoreFieldOrder"
+        "lwc_local": "pendingIgnoreFieldOrder",
+        "mimir": "pendingIgnoreFieldOrder"
     },
     "data": "heterogeneous.data",
     "query": "select a, b{*}, b{*:} as k from `heterogeneous.data`",

--- a/it/src/main/resources/tests/heterogeneousShiftMapValueAndKeyWithField.test
+++ b/it/src/main/resources/tests/heterogeneousShiftMapValueAndKeyWithField.test
@@ -1,8 +1,8 @@
 {
     "name": "field and shifted map value and key on heterogeneous",
     "backends": {
-        "lwc_local":         "ignoreFieldOrder",
-        "mimir":             "ignoreFieldOrder"
+        "lwc_local": "pendingIgnoreFieldOrder",
+        "mimir": "pendingIgnoreFieldOrder"
     },
     "data": "heterogeneous.data",
     "query": "select a, b{_} as v, b{_:} as k from `heterogeneous.data`",

--- a/it/src/main/resources/tests/heterogeneousShiftedArrayValueAndIndexWithField.test
+++ b/it/src/main/resources/tests/heterogeneousShiftedArrayValueAndIndexWithField.test
@@ -1,8 +1,8 @@
 {
     "name": "field and shifted array value and index on heterogenous",
     "backends": {
-        "lwc_local":         "ignoreFieldOrder",
-        "mimir":             "ignoreFieldOrder"
+        "lwc_local": "pendingIgnoreFieldOrder",
+        "mimir": "pendingIgnoreFieldOrder"
     },
     "data": "heterogeneous.data",
     "query": "select a, b[_] as v, b[_:] as i from `heterogeneous.data`",

--- a/it/src/main/resources/tests/multilevelFlatten.test
+++ b/it/src/main/resources/tests/multilevelFlatten.test
@@ -7,8 +7,7 @@
     "predicate": "exactly",
     "ignoreResultOrder": true,
     "expected": [
-      { "k1": "midArr" },
-      { "k1": "midObj", "k2": "botArr", "v2": [13, 14, 15] },
-      { "k1": "midObj", "k2": "botObj", "v2": {"a": "m", "b": "n", "c": "o"} }
+      { "k1": "midObj", "k2": "botArr", "v2": [13, 14, 15] }
+    , { "k1": "midObj", "k2": "botObj", "v2": {"a": "m", "b": "n", "c": "o"} }
     ]
 }

--- a/it/src/main/resources/tests/multitypeFlatten.test
+++ b/it/src/main/resources/tests/multitypeFlatten.test
@@ -1,6 +1,8 @@
 {
     "name": "flatten a single field as both object and array",
     "backends": {
+        "lwc_local": "pendingIgnoreFieldOrder",
+        "mimir": "pendingIgnoreFieldOrder"
     },
     "data": "nested_foo.data",
     "query": "select * from `nested_foo.data` where (

--- a/qsu/src/main/scala/quasar/qsu/ExpandShifts.scala
+++ b/qsu/src/main/scala/quasar/qsu/ExpandShifts.scala
@@ -20,7 +20,7 @@ import slamdata.Predef._
 
 import quasar.common.effect.NameGenerator
 import quasar.contrib.scalaz._
-import quasar.ejson.{EJson, Fixed}
+import quasar.ejson.EJson
 import quasar.qscript.{
   Hole,
   MonadPlannerErr,
@@ -43,7 +43,6 @@ import StateT.stateTMonadState
 
 final class ExpandShifts[T[_[_]]: BirecursiveT: EqualT: ShowT] extends QSUTTypes[T] {
   val func = construction.Func[T]
-  val json = Fixed[T[EJson]]
   val hole: Hole = SrcHole
 
   private val prov = new QProv[T]
@@ -109,15 +108,12 @@ final class ExpandShifts[T[_[_]]: BirecursiveT: EqualT: ShowT] extends QSUTTypes
                   identityCondition =
                   if (rotationsCompatible(rotationAbove, newRotation))
                     func.Cond(
-                      func.Or(
-                        func.Eq(
-                          AccessLeftTarget[T](Access.id(IdAccess.identity[T[EJson]](shiftAbove.root), _)),
-                          AccessLeftTarget[T](Access.id(IdAccess.identity[T[EJson]](newShift.root), _))),
-                        func.IfUndefined(
-                          AccessLeftTarget[T](Access.id(IdAccess.identity[T[EJson]](newShift.root), _)),
-                          func.Constant(json.bool(true)))),
+                      func.Eq(
+                        AccessLeftTarget[T](Access.id(IdAccess.identity[T[EJson]](shiftAbove.root), _)),
+                        AccessLeftTarget[T](Access.id(IdAccess.identity[T[EJson]](newShift.root), _))),
                       repair,
-                      func.Undefined)
+                      func.Undefined
+                    )
                   else repair
                   newShiftNewRepairPat =
                     newShiftPat.copy(repair = identityCondition)

--- a/qsu/src/test/scala/quasar/qsu/ExpandShiftsSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/ExpandShiftsSpec.scala
@@ -18,7 +18,7 @@ package quasar.qsu
 
 import quasar.{Qspec, TreeMatchers}
 import quasar.contrib.matryoshka._
-import quasar.ejson.{EJson, Fixed}
+import quasar.ejson.EJson
 import quasar.fp._
 import quasar.contrib.iota._
 import quasar.qscript.{construction, Hole, ExcludeId, OnUndefined, PlannerError, SrcHole}
@@ -44,7 +44,6 @@ object ExpandShiftsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
 
   val qsu = QScriptUniform.DslT[Fix]
   val func = construction.Func[Fix]
-  val json = Fixed[Fix[EJson]]
   val recFunc = construction.RecFunc[Fix]
 
   type F[A] = EitherT[StateT[Need, Long, ?], PlannerError, A]
@@ -123,13 +122,9 @@ object ExpandShiftsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
         )
         outerRepair must beTreeEqual(
           func.Cond(
-            func.Or(
-              func.Eq(
-                AccessLeftTarget[Fix](Access.id(IdAccess.identity[Fix[EJson]]('esh0), _)),
-                AccessLeftTarget[Fix](Access.id(IdAccess.identity[Fix[EJson]]('esh1), _))),
-              func.IfUndefined(
-                AccessLeftTarget[Fix](Access.id(IdAccess.identity[Fix[EJson]]('esh1), _)),
-                func.Constant(json.bool(true)))),
+            func.Eq(
+              AccessLeftTarget[Fix](Access.id(IdAccess.identity[Fix[EJson]]('esh0), _)),
+              AccessLeftTarget[Fix](Access.id(IdAccess.identity[Fix[EJson]]('esh1), _))),
             func.StaticMapS(
                 "original" ->
                   func.ProjectKeyS(AccessLeftTarget[Fix](Access.valueHole(_)), "original"),
@@ -278,13 +273,9 @@ object ExpandShiftsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
         )
         innerRepair must beTreeEqual(
           func.Cond(
-            func.Or(
-              func.Eq(
-                AccessLeftTarget[Fix](Access.id(IdAccess.identity[Fix[EJson]]('esh0), _)),
-                AccessLeftTarget[Fix](Access.id(IdAccess.identity[Fix[EJson]]('esh1), _))),
-              func.IfUndefined(
-                AccessLeftTarget[Fix](Access.id(IdAccess.identity[Fix[EJson]]('esh1), _)),
-                func.Constant(json.bool(true)))),
+            func.Eq(
+              AccessLeftTarget[Fix](Access.id(IdAccess.identity[Fix[EJson]]('esh0), _)),
+              AccessLeftTarget[Fix](Access.id(IdAccess.identity[Fix[EJson]]('esh1), _))),
             func.StaticMapS(
               "original" ->
                 func.ProjectKeyS(AccessLeftTarget[Fix](Access.valueHole(_)), "original"),
@@ -294,13 +285,9 @@ object ExpandShiftsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
             func.Undefined))
         outerRepair must beTreeEqual(
           func.Cond(
-            func.Or(
-              func.Eq(
-                AccessLeftTarget[Fix](Access.id(IdAccess.identity[Fix[EJson]]('esh1), _)),
-                AccessLeftTarget[Fix](Access.id(IdAccess.identity[Fix[EJson]]('esh2), _))),
-              func.IfUndefined(
-                AccessLeftTarget[Fix](Access.id(IdAccess.identity[Fix[EJson]]('esh2), _)),
-                func.Constant(json.bool(true)))),
+            func.Eq(
+              AccessLeftTarget[Fix](Access.id(IdAccess.identity[Fix[EJson]]('esh1), _)),
+              AccessLeftTarget[Fix](Access.id(IdAccess.identity[Fix[EJson]]('esh2), _))),
             func.StaticMapS(
               "original" ->
                 func.ProjectKeyS(AccessLeftTarget[Fix](Access.valueHole(_)), "original"),


### PR DESCRIPTION
I'm no longer certain we should revert this change, given the number of regressions it would imply. But performance is still an order of magnitude better with this change. Let's wait for the performance fixes @djspiewak mentioned before merging this?