### PR TITLE
Leftshift benchmark

### DIFF
--- a/yggdrasilPerf/src/main/scala/quasar/yggdrasil/perf/LeftShiftBenchmark.scala
+++ b/yggdrasilPerf/src/main/scala/quasar/yggdrasil/perf/LeftShiftBenchmark.scala
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar
+package yggdrasil
+package perf
+
+import quasar.contrib.cats.effect.liftio._
+import quasar.fp.ski.κ
+import quasar.precog.common.{CLong, CPath, RArray, RObject, RValue}
+import quasar.yggdrasil.table.TestColumnarTableModule
+
+import cats.effect.IO
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations.{Benchmark, BenchmarkMode, Mode, OutputTimeUnit, Param, Scope, State}
+import org.openjdk.jmh.infra.Blackhole
+
+import scalaz._, Scalaz._
+import shims._
+
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@BenchmarkMode(Array(Mode.AverageTime))
+@State(Scope.Benchmark)
+class LeftShiftBenchmark {
+
+  val P = new TestColumnarTableModule {}
+
+  @Param(Array("5"))
+  var chunks: Int = _
+
+  @Param(Array("10000"))
+  var chunkSize: Int = _
+
+  @Param(Array("10"))
+  var arraySize: Int = _
+
+  @Param(Array("10"))
+  var nrKeysPerObject: Int = _
+
+  // make sure that: totalNrKeys >= nrKeysPerObject
+  @Param(Array("14"))
+  var totalNrKeys: Int = _
+
+  def leftShiftRow(key: Int, value: Option[RValue]): RValue =
+    value match {
+      case None => RArray(CLong(key))
+      case Some(v) => RArray(CLong(key), v)
+    }
+
+  def leftShiftTestData(value: Int => Option[RValue]): Stream[List[RValue]] =
+    Stream.tabulate(chunks)(c =>
+      List.tabulate(chunkSize){ s =>
+        val i = (c * chunkSize) + s
+        leftShiftRow(i, value(i))
+      })
+
+  def mkTable(module: TestColumnarTableModule)(data: Stream[List[RValue]]): IO[module.Table] =
+    module.Table.fromRValueStream[WriterT[IO, List[IO[Unit]], ?]](
+      fs2.Stream.fromIterator[IO, fs2.Stream[IO, RValue]](
+        data.iterator.map(fs2.Stream.emits(_).covary[IO])
+      ).join).run.map(_._2)
+
+  def leftShift(table: P.Table, emitOnUndef: Boolean): P.Table =
+    table.leftShift(CPath.Identity \ 1, emitOnUndef)
+
+  def doTest(v: Int => Option[RValue], bh: Blackhole): Unit = {
+    val table: IO[P.Table] = mkTable(P)(leftShiftTestData(v))
+    val tableAfter: IO[P.Table] = table.map(t => leftShift(t, true))
+    tableAfter.map(t => SliceTools.consumeTable(P)(t, bh)).unsafeRunSync
+  }
+
+  @Benchmark
+  def arrays(bh: Blackhole): Unit = {
+    val v: Int => Option[RValue] =
+      κ(RArray(List.tabulate(arraySize)(i => CLong(i + 42))).some)
+    doTest(v, bh)
+  }
+
+  @Benchmark
+  def objects(bh: Blackhole): Unit = {
+    val v: Int => Option[RValue] =
+      κ(RObject(List.tabulate(nrKeysPerObject)(i => ("k" + i) -> CLong(i + 42)).toMap).some)
+    doTest(v, bh)
+  }
+
+  @Benchmark
+  def distinctFieldsObjects(bh: Blackhole): Unit = {
+    val v: Int => Option[RValue] = { r =>
+      RObject(List.tabulate(nrKeysPerObject)(i => ("k" + r + i) -> CLong(i + r + 42)).toMap).some
+    }
+    doTest(v, bh)
+  }
+
+  @Benchmark
+  def scrollingFieldsObjects(bh: Blackhole): Unit = {
+    assert(totalNrKeys >= nrKeysPerObject)
+    val v: Int => Option[RValue] = { r =>
+      RObject(List.tabulate(nrKeysPerObject)(i => ("k" + ((r + i) % totalNrKeys)) -> CLong(i + r + 42)).toMap).some
+    }
+    doTest(v, bh)
+  }
+
+  @Benchmark
+  def heterogeneous(bh: Blackhole): Unit = {
+    val v: Int => Option[RValue] = { i =>
+      (i % 4) match {
+        case 0 => none
+        case 1 => CLong(i + 42).some
+        case 2 => RArray(List.tabulate(arraySize)(i => CLong(i + 42))).some
+        case _ => RObject(List.tabulate(nrKeysPerObject)(i => ("k" + i) -> CLong(i + 42)).toMap).some
+      }
+    }
+    doTest(v, bh)
+  }
+
+  @Benchmark
+  def scalarOrUndefined(bh: Blackhole): Unit = {
+    val v: Int => Option[RValue] = { i =>
+      (i % 2) match {
+        case 0 => none
+        case _ => CLong(i + 42).some
+      }
+    }
+    doTest(v, bh)
+  }
+}

--- a/yggdrasilPerf/src/main/scala/quasar/yggdrasil/perf/LeftShiftBenchmark.scala
+++ b/yggdrasilPerf/src/main/scala/quasar/yggdrasil/perf/LeftShiftBenchmark.scala
@@ -133,38 +133,32 @@ class LeftShiftBenchmark {
     table.leftShift(CPath.Identity \ 1, emitOnUndef)
 
   def doTestForce(state: BenchmarkState, bh: Blackhole): Unit = {
-    val table: P.Table = state.table
-    val tableAfter: P.Table = leftShift(table, state.emitOnUndef)
+    val tableAfter: P.Table = leftShift(state.table, state.emitOnUndef)
     SliceTools.consumeTable(P)(tableAfter, bh).unsafeRunSync
   }
 
   @Benchmark
-  def arrays(state: BenchmarkState_arrays, bh: Blackhole): Unit = {
+  def arrays(state: BenchmarkState_arrays, bh: Blackhole): Unit =
     doTestForce(state, bh)
-  }
 
   @Benchmark
-  def objects(state: BenchmarkState_objects, bh: Blackhole): Unit = {
+  def objects(state: BenchmarkState_objects, bh: Blackhole): Unit =
     doTestForce(state, bh)
-  }
 
   @Benchmark
-  def distinctFieldsObjects(state: BenchmarkState_distinctFields, bh: Blackhole): Unit = {
+  def distinctFieldsObjects(state: BenchmarkState_distinctFields, bh: Blackhole): Unit =
     doTestForce(state, bh)
-  }
 
   @Benchmark
-  def scrollingFields(state: BenchmarkState_scrolling, bh: Blackhole): Unit = {
+  def scrollingFields(state: BenchmarkState_scrolling, bh: Blackhole): Unit =
     doTestForce(state, bh)
-  }
 
   @Benchmark
-  def heterogeneous(state: BenchmarkState_heterogeneous, bh: Blackhole): Unit = {
+  def heterogeneous(state: BenchmarkState_heterogeneous, bh: Blackhole): Unit =
     doTestForce(state, bh)
-  }
 
   @Benchmark
-  def scalarOrUndefined(state: BenchmarkState_scalarUndefined, bh: Blackhole): Unit = {
+  def scalarOrUndefined(state: BenchmarkState_scalarUndefined, bh: Blackhole): Unit =
     doTestForce(state, bh)
-  }
+
 }

--- a/yggdrasilPerf/src/main/scala/quasar/yggdrasil/perf/LeftShiftBenchmark.scala
+++ b/yggdrasilPerf/src/main/scala/quasar/yggdrasil/perf/LeftShiftBenchmark.scala
@@ -71,17 +71,17 @@ object LeftShiftBenchmark {
     @Param(Array("5"))
     var chunks: Int = _
 
-    @Param(Array("10", "10000", "1000000"))
+    @Param(Array("10000"))
     var chunkSize: Int = _
 
-    @Param(Array("true", "false"))
+    @Param(Array("true"))
     var emitOnUndef: Boolean = _
 
-    var table: IO[P.Table] = _
+    var table: P.Table = _
 
     @Setup
     def setup(): Unit = {
-      table = mkTable(P)(leftShiftTestData(chunks, chunkSize, v)).flatMap(_.force)
+      table = mkTable(P)(leftShiftTestData(chunks, chunkSize, v)).flatMap(_.force).unsafeRunSync
     }
   }
 
@@ -102,7 +102,7 @@ class LeftShiftBenchmark {
   @Param(Array("5"))
   var chunks: Int = _
 
-  @Param(Array("10", "10000", "1000000"))
+  @Param(Array("10000"))
   var chunkSize: Int = _
 
   @Param(Array("10"))
@@ -125,9 +125,9 @@ class LeftShiftBenchmark {
   }
 
   def doTestForce(state: BenchmarkState, bh: Blackhole): Unit = {
-    val table: IO[P.Table] = state.table
-    val tableAfter: IO[P.Table] = table.map(t => leftShift(t, state.emitOnUndef))
-    tableAfter.map(t => SliceTools.consumeTable(P)(t, bh)).unsafeRunSync
+    val table: P.Table = state.table
+    val tableAfter: P.Table = leftShift(table, state.emitOnUndef)
+    SliceTools.consumeTable(P)(tableAfter, bh).unsafeRunSync
   }
 
   @Benchmark

--- a/yggdrasilPerf/src/main/scala/quasar/yggdrasil/perf/LeftShiftBenchmark.scala
+++ b/yggdrasilPerf/src/main/scala/quasar/yggdrasil/perf/LeftShiftBenchmark.scala
@@ -33,12 +33,65 @@ import org.openjdk.jmh.infra.Blackhole
 import scalaz._, Scalaz._
 import shims._
 
+object LeftShiftBenchmark {
+  val P = new TestColumnarTableModule {}
+
+  def scrolling(nrKeysPerObject: Int, totalNrKeys: Int): Int => Option[RValue] = { r =>
+    assert(totalNrKeys >= nrKeysPerObject)
+    RObject(List.tabulate(nrKeysPerObject)(i => ("k" + ((r + i) % totalNrKeys)) -> CLong(i + r + 42)).toMap).some
+  }
+
+  val scalarUndefined: Int => Option[RValue] = { i =>
+    (i % 2) match {
+      case 0 => none
+      case _ => CLong(i + 42).some
+    }
+  }
+
+  def leftShiftRow(key: Int, value: Option[RValue]): RValue =
+    value match {
+      case None => RArray(CLong(key))
+      case Some(v) => RArray(CLong(key), v)
+    }
+
+  def leftShiftTestData(chunks: Int, chunkSize: Int, value: Int => Option[RValue]): Stream[List[RValue]] =
+    Stream.tabulate(chunks)(c =>
+      List.tabulate(chunkSize){ s =>
+        val i = (c * chunkSize) + s
+        leftShiftRow(i, value(i))
+      })
+
+  def mkTable(module: TestColumnarTableModule)(data: Stream[List[RValue]]): IO[module.Table] =
+    module.Table.fromRValueStream[WriterT[IO, List[IO[Unit]], ?]](
+      fs2.Stream.fromIterator[IO, fs2.Stream[IO, RValue]](
+        data.iterator.map(fs2.Stream.emits(_).covary[IO])
+      ).join).run.map(_._2)
+
+  abstract class BenchmarkState(chunks: Int, chunkSize: Int, v: Int => Option[RValue]) {
+    val table: IO[P.Table] = mkTable(P)(leftShiftTestData(chunks, chunkSize, v)).flatMap(_.force)
+  }
+
+  @State(Scope.Benchmark)
+  class BenchmarkState_1_10000_scrolling extends BenchmarkState(1, 10000, scrolling(nrKeysPerObject = 10, totalNrKeys = 14))
+
+  @State(Scope.Benchmark)
+  class BenchmarkState_5_10000_scrolling extends BenchmarkState(5, 10000, scrolling(nrKeysPerObject = 10, totalNrKeys = 14))
+
+  @State(Scope.Benchmark)
+  class BenchmarkState_1_10000_scalarUndefined extends BenchmarkState(1, 10000, scalarUndefined)
+
+  @State(Scope.Benchmark)
+  class BenchmarkState_1_1000000_scalarUndefined extends BenchmarkState(1, 1000000, scalarUndefined)
+
+  @State(Scope.Benchmark)
+  class BenchmarkState_5_10000_scalarUndefined extends BenchmarkState(5, 10000, scalarUndefined)
+}
+
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @BenchmarkMode(Array(Mode.AverageTime))
 @State(Scope.Benchmark)
 class LeftShiftBenchmark {
-
-  val P = new TestColumnarTableModule {}
+  import LeftShiftBenchmark._
 
   @Param(Array("5"))
   var chunks: Int = _
@@ -56,30 +109,17 @@ class LeftShiftBenchmark {
   @Param(Array("14"))
   var totalNrKeys: Int = _
 
-  def leftShiftRow(key: Int, value: Option[RValue]): RValue =
-    value match {
-      case None => RArray(CLong(key))
-      case Some(v) => RArray(CLong(key), v)
-    }
-
-  def leftShiftTestData(value: Int => Option[RValue]): Stream[List[RValue]] =
-    Stream.tabulate(chunks)(c =>
-      List.tabulate(chunkSize){ s =>
-        val i = (c * chunkSize) + s
-        leftShiftRow(i, value(i))
-      })
-
-  def mkTable(module: TestColumnarTableModule)(data: Stream[List[RValue]]): IO[module.Table] =
-    module.Table.fromRValueStream[WriterT[IO, List[IO[Unit]], ?]](
-      fs2.Stream.fromIterator[IO, fs2.Stream[IO, RValue]](
-        data.iterator.map(fs2.Stream.emits(_).covary[IO])
-      ).join).run.map(_._2)
-
   def leftShift(table: P.Table, emitOnUndef: Boolean): P.Table =
     table.leftShift(CPath.Identity \ 1, emitOnUndef)
 
   def doTest(v: Int => Option[RValue], bh: Blackhole): Unit = {
-    val table: IO[P.Table] = mkTable(P)(leftShiftTestData(v))
+    val table: IO[P.Table] = mkTable(P)(leftShiftTestData(chunks, chunkSize, v))
+    val tableAfter: IO[P.Table] = table.map(t => leftShift(t, true))
+    tableAfter.map(t => SliceTools.consumeTable(P)(t, bh)).unsafeRunSync
+  }
+
+  def doTestForce(state: BenchmarkState, bh: Blackhole): Unit = {
+    val table: IO[P.Table] = state.table
     val tableAfter: IO[P.Table] = table.map(t => leftShift(t, true))
     tableAfter.map(t => SliceTools.consumeTable(P)(t, bh)).unsafeRunSync
   }
@@ -108,11 +148,17 @@ class LeftShiftBenchmark {
 
   @Benchmark
   def scrollingFieldsObjects(bh: Blackhole): Unit = {
-    assert(totalNrKeys >= nrKeysPerObject)
-    val v: Int => Option[RValue] = { r =>
-      RObject(List.tabulate(nrKeysPerObject)(i => ("k" + ((r + i) % totalNrKeys)) -> CLong(i + r + 42)).toMap).some
-    }
-    doTest(v, bh)
+    doTest(scrolling(nrKeysPerObject, totalNrKeys), bh)
+  }
+
+  @Benchmark
+  def scrollingFieldsObjectsForced_1_10000(state: BenchmarkState_1_10000_scrolling, bh: Blackhole): Unit = {
+    doTestForce(state, bh)
+  }
+
+  @Benchmark
+  def scrollingFieldsObjectsForced_5_10000(state: BenchmarkState_5_10000_scrolling, bh: Blackhole): Unit = {
+    doTestForce(state, bh)
   }
 
   @Benchmark
@@ -130,12 +176,21 @@ class LeftShiftBenchmark {
 
   @Benchmark
   def scalarOrUndefined(bh: Blackhole): Unit = {
-    val v: Int => Option[RValue] = { i =>
-      (i % 2) match {
-        case 0 => none
-        case _ => CLong(i + 42).some
-      }
-    }
-    doTest(v, bh)
+    doTest(scalarUndefined, bh)
+  }
+
+  @Benchmark
+  def scalarOrUndefinedForced_1_10000(state: BenchmarkState_1_10000_scalarUndefined, bh: Blackhole): Unit = {
+    doTestForce(state, bh)
+  }
+
+  @Benchmark
+  def scalarOrUndefinedForced_1_1000000(state: BenchmarkState_1_1000000_scalarUndefined, bh: Blackhole): Unit = {
+    doTestForce(state, bh)
+  }
+
+  @Benchmark
+  def scalarOrUndefinedForced_5_10000(state: BenchmarkState_5_10000_scalarUndefined, bh: Blackhole): Unit = {
+    doTestForce(state, bh)
   }
 }

--- a/yggdrasilPerf/src/main/scala/quasar/yggdrasil/perf/SliceTools.scala
+++ b/yggdrasilPerf/src/main/scala/quasar/yggdrasil/perf/SliceTools.scala
@@ -18,6 +18,7 @@ package quasar
 package yggdrasil
 package perf
 
+import quasar.contrib.fs2.convert
 import quasar.yggdrasil.table._
 
 import org.openjdk.jmh.infra.Blackhole
@@ -35,6 +36,6 @@ object SliceTools {
     slices.foldLeftRec(IO.unit)((i, o) => i.flatMap(_ => consumeSlice(o, bh))).flatMap(x => x)
 
   def consumeTable(module: TestColumnarTableModule)(table: module.Table, bh: Blackhole): IO[Unit] =
-    consumeSlices(table.slices, bh) // slices.compile.fold(IO.unit)((i, o) => i.flatMap(_ => consumeSlice(o, bh))).flatMap(x => x)
+    convert.fromStreamT(table.renderJson()).compile.drain
 
 }

--- a/yggdrasilPerf/src/main/scala/quasar/yggdrasil/perf/SliceTools.scala
+++ b/yggdrasilPerf/src/main/scala/quasar/yggdrasil/perf/SliceTools.scala
@@ -36,6 +36,8 @@ object SliceTools {
     slices.foldLeftRec(IO.unit)((i, o) => i.flatMap(_ => consumeSlice(o, bh))).flatMap(x => x)
 
   def consumeTable(module: TestColumnarTableModule)(table: module.Table, bh: Blackhole): IO[Unit] =
-    convert.fromStreamT(table.renderJson()).compile.drain
+    consumeSlices(table.slices, bh)
 
+  def consumeTableJson(module: TestColumnarTableModule)(table: module.Table, bh: Blackhole): IO[Unit] =
+    convert.fromStreamT(table.renderJson()).compile.drain
 }


### PR DESCRIPTION
See https://gist.github.com/rintcius/9552dc741a547e9e5b60a7d37a1a6f10 for preliminary results (I can run with more iterations tomorrow if #3730 is ready then).

Overall the fixes in #3730 improve leftshift performance considerably. Exception is `scalarOrUndefined` - this became quite a lot slower.
