### PR TITLE
Corrected future-derived IO continuations remaining on wrong pool

### DIFF
--- a/foundation/src/main/scala/quasar/contrib/cats/effect/package.scala
+++ b/foundation/src/main/scala/quasar/contrib/cats/effect/package.scala
@@ -16,16 +16,26 @@
 
 package quasar.contrib.cats
 
+import slamdata.Predef.AnyVal
+
 import cats.effect._
+import cats.syntax.functor._
+
+import scala.concurrent.Future
 
 package object effect {
 
-  implicit class toOps[F[_], A](fa: F[A]) {
+  implicit class toOps[F[_], A](val fa: F[A]) extends AnyVal {
     def to[G[_]](implicit F: Effect[F], G: Async[G]): G[A] =
       Async[G].async { l =>
         Effect[F].runAsync(fa)(c =>
           IO(l(c))
         ).unsafeRunSync
       }
+  }
+
+  implicit class IOOps(val self: IO.type) extends AnyVal {
+    def fromFutureShift[A](iofa: IO[Future[A]])(implicit T: Timer[IO]): IO[A] =
+      IO.fromFuture(iofa).flatMap(a => IO.shift.as(a))
   }
 }

--- a/it/src/test/scala/quasar/physical/mimir/MimirStdLibSpec.scala
+++ b/it/src/test/scala/quasar/physical/mimir/MimirStdLibSpec.scala
@@ -44,6 +44,8 @@ import scalaz.{\/, Id}
 import scalaz.syntax.applicative._
 import scalaz.syntax.either._
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 import java.nio.file.Files
 
 class MimirStdLibSpec extends StdLibSpec with PrecogCake {

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/nihdb/NIHDBProjection.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/nihdb/NIHDBProjection.scala
@@ -16,9 +16,9 @@
 
 package quasar.yggdrasil.nihdb
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.control.NonFatal
 
+import quasar.contrib.cats.effect._
 import quasar.precog.common._
 import quasar.niflheim._
 import quasar.yggdrasil._
@@ -28,6 +28,7 @@ import org.slf4s.Logging
 
 import cats.effect.IO
 
+import scala.concurrent.ExecutionContext
 
 final class NIHDBProjection(snapshot: NIHDBSnapshot, projectionId: Int) extends ProjectionLike[Slice] with Logging {
   type Key = Long
@@ -69,7 +70,9 @@ final class NIHDBProjection(snapshot: NIHDBSnapshot, projectionId: Int) extends 
 }
 
 object NIHDBProjection {
-  def wrap(nihdb: NIHDB): IO[NIHDBProjection] = IO.fromFuture(IO(nihdb.getSnapshot map { snap =>
-    new NIHDBProjection(snap, nihdb.projectionId)
-  }))
+  def wrap(nihdb: NIHDB)(implicit ec: ExecutionContext): IO[NIHDBProjection] = {
+    IO.fromFutureShift(IO(nihdb.getSnapshot map { snap =>
+      new NIHDBProjection(snap, nihdb.projectionId)
+    }))
+  }
 }


### PR DESCRIPTION
This turned out to be quite easy to knock off. General rule: whenever we're touching `ExecutionContext`-involved code, try to keep pushing it towards the boundaries. Ultimately, we want to create these things when we create `Quasar` and thread them all the way through. We're using `global` in quite a few places right now, which is definitely not ideal, though not an urgent thing to fix.

[ch591]