### PR TITLE
support setting mode in repl

### DIFF
--- a/repl/src/main/scala/quasar/repl/Command.scala
+++ b/repl/src/main/scala/quasar/repl/Command.scala
@@ -95,7 +95,7 @@ object Command {
       case SetPhaseFormatPattern(format)            => SetPhaseFormat(PhaseFormat.fromString(format) | PhaseFormat.Tree)
       case SetTimingFormatPattern(format)           => SetTimingFormat(TimingFormat.fromString(format) | TimingFormat.OnlyTotal)
       case SummaryCountPattern(rows)                => SummaryCount(rows.toInt)
-      case FormatPattern(format)                    => Format(OutputFormat.fromString(format) | OutputFormat.Table)
+      case FormatPattern(format)                    => Format(OutputFormat.fromString(format) | OutputFormat.Precise)
       case ModePattern(mode)                        => Mode(OutputMode.fromString(mode) | OutputMode.Console)
       case HelpPattern()                            => Help
       case SetVarPattern(name, value)               => SetVar(VarName(name), VarValue(value))

--- a/repl/src/main/scala/quasar/repl/Command.scala
+++ b/repl/src/main/scala/quasar/repl/Command.scala
@@ -44,6 +44,7 @@ object Command {
   private val DebugPattern                 = "(?i)(?:set +)?debug *= *(0|1|2)".r
   private val SummaryCountPattern          = """(?i)(?:set +)?summaryCount *= *(\d+)""".r
   private val FormatPattern                = "(?i)(?:set +)?format *= *((?:table)|(?:precise)|(?:readable)|(?:csv))".r
+  private val ModePattern                  = "(?i)(?:set +)?mode *= *((?:console)|(?:file))".r
   private val SetVarPattern                = """(?i)(?:set +)?(\w+) *= *(.*\S)""".r
   private val UnsetVarPattern              = """(?i)unset +(\w+)""".r
   private val ListVarPattern               = "(?i)env".r
@@ -67,6 +68,7 @@ object Command {
   final case class Debug(level: DebugLevel) extends Command
   final case class SummaryCount(rows: Int) extends Command
   final case class Format(format: OutputFormat) extends Command
+  final case class Mode(mode: OutputMode) extends Command
   final case class SetPhaseFormat(format: PhaseFormat) extends Command
   final case class SetTimingFormat(format: TimingFormat) extends Command
   final case class SetVar(name: VarName, value: VarValue) extends Command
@@ -94,6 +96,7 @@ object Command {
       case SetTimingFormatPattern(format)           => SetTimingFormat(TimingFormat.fromString(format) | TimingFormat.OnlyTotal)
       case SummaryCountPattern(rows)                => SummaryCount(rows.toInt)
       case FormatPattern(format)                    => Format(OutputFormat.fromString(format) | OutputFormat.Table)
+      case ModePattern(mode)                        => Mode(OutputMode.fromString(mode) | OutputMode.Console)
       case HelpPattern()                            => Help
       case SetVarPattern(name, value)               => SetVar(VarName(name), VarValue(value))
       case UnsetVarPattern(name)                    => UnsetVar(VarName(name))

--- a/repl/src/main/scala/quasar/repl/Evaluator.scala
+++ b/repl/src/main/scala/quasar/repl/Evaluator.scala
@@ -32,10 +32,13 @@ import quasar.fp.ski._
 import quasar.frontend.data.DataCodec
 import quasar.impl.schema.{SstConfig, SstSchema}
 import quasar.mimir.MimirRepr
+import quasar.precog.common.{ColumnRef, CNull}
 import quasar.run.{QuasarError, MonadQuasarErr, Sql2QueryEvaluator, SqlQuery}
 import quasar.run.ResourceRouter.DatasourceResourcePrefix
 import quasar.run.optics.{stringUuidP => UuidString}
 import quasar.sst._
+import quasar.yggdrasil.table.{Column, CScanner}
+
 
 import java.lang.Exception
 import java.nio.CharBuffer
@@ -414,7 +417,9 @@ final class Evaluator[F[_]: Effect: MonadQuasarErr: PhaseResultListen: PhaseResu
         case OutputFormat.Readable =>
           convert(repr.table.renderJson(precise = false))
         case OutputFormat.Csv =>
-          convert(repr.table.renderCsv(assumeHomogeneous = true))
+            import repr.P.trans._
+            val table2 = repr.table.transform(Scan(TransSpec1.Id, NullRemover): TransSpec[Source1])
+            convert(table2.renderCsv(assumeHomogeneous = true))
       }
     }
 
@@ -433,6 +438,23 @@ final class Evaluator[F[_]: Effect: MonadQuasarErr: PhaseResultListen: PhaseResu
       s.through(fs2.text.utf8Encode)
         .through(fs2.io.file.writeAll(path))
         .compile.drain
+
+    // duplicated from slamdata-backend
+    // someday, this should probably move into mimir...
+    private object NullRemover extends CScanner {
+      type A = Unit
+      val init = ()
+
+      def scan(u: Unit, cols: Map[ColumnRef, Column], range: Range): (Unit, Map[ColumnRef, Column]) = {
+        val cols2 = cols flatMap {
+          case (ColumnRef(_, CNull), _) => Nil
+          case pair => List(pair)
+        }
+
+        ((), cols2)
+      }
+    }
+
 }
 
 object Evaluator {

--- a/repl/src/main/scala/quasar/repl/Evaluator.scala
+++ b/repl/src/main/scala/quasar/repl/Evaluator.scala
@@ -139,6 +139,10 @@ final class Evaluator[F[_]: Effect: MonadQuasarErr: PhaseResultListen: PhaseResu
         stateRef.modify(_.copy(format = fmt)) *>
           F.pure(s"Set output format: $fmt".some)
 
+      case Mode(mode) =>
+        stateRef.modify(_.copy(mode = mode)) *>
+          F.pure(s"Set output mode: $mode".some)
+
       case SetPhaseFormat(fmt) =>
         stateRef.modify(_.copy(phaseFormat = fmt)) *>
           F.pure(s"Set phase format: $fmt".some)
@@ -417,6 +421,7 @@ object Evaluator {
       |  (explain | compile) [query]
       |  set debug = 0 | 1 | 2
       |  set format = table | precise | readable | csv
+      |  set mode = console | file
       |  set summaryCount = [rows]
       |  set [var] = [value]
       |  env

--- a/repl/src/main/scala/quasar/repl/Main.scala
+++ b/repl/src/main/scala/quasar/repl/Main.scala
@@ -67,9 +67,7 @@ object Main extends StreamApp[PhaseResultCatsT[IO, ?]] {
       : F[ExitCode] =
     for {
       ref <- Ref[F, ReplState](ReplState.mk)
-      repl <- Repl.mk[F](ref,
-        q.datasources,
-        q.queryEvaluator.map(_.flatMap(mimir.tableToData(_).translate(λ[FunctionK[IO, F]](_.to[F])))))
+      repl <- Repl.mk[F](ref, q.datasources, q.queryEvaluator)
       l <- repl.loop
     } yield l
 

--- a/repl/src/main/scala/quasar/repl/OutputFormat.scala
+++ b/repl/src/main/scala/quasar/repl/OutputFormat.scala
@@ -16,7 +16,7 @@
 
 package quasar.repl
 
-import slamdata.Predef.{Option, Some, String}
+import slamdata.Predef._
 
 sealed abstract class OutputFormat
 object OutputFormat {
@@ -31,5 +31,13 @@ object OutputFormat {
       case "precise"  => Precise
       case "readable" => Readable
       case "csv"      => Csv
+    }
+
+  def headerLines(format: OutputFormat): Int =
+    format match {
+      case Table => 2
+      case Precise => 0
+      case Readable => 0
+      case Csv => 1
     }
 }

--- a/repl/src/main/scala/quasar/repl/OutputMode.scala
+++ b/repl/src/main/scala/quasar/repl/OutputMode.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.repl
+
+import slamdata.Predef._
+
+import scalaz._, Scalaz._
+
+sealed abstract class OutputMode
+
+object OutputMode {
+  final case object Console extends OutputMode
+  final case object File extends OutputMode
+
+  def fromString(str: String): Option[OutputMode] = str.toLowerCase match {
+    case "console" => Console.some
+    case "file"    => File.some
+    case _         => none
+  }
+}

--- a/repl/src/main/scala/quasar/repl/Paths.scala
+++ b/repl/src/main/scala/quasar/repl/Paths.scala
@@ -20,7 +20,7 @@ package repl
 import slamdata.Predef._
 
 import java.lang.System
-import java.nio.file.{Path => JPath, Paths => JPaths}
+import java.nio.file.{Files => JFiles, Path => JPath, Paths => JPaths}
 
 import cats.effect.Sync
 import scalaz._, Scalaz._
@@ -33,6 +33,10 @@ object Paths {
   val QuasarDirNames = NonEmptyList(".config", "quasar")
   val QuasarDataDirName = "data"
   val QuasarPluginsDirName = "plugins"
+
+  def createTempFile[F[_]](prefix: String, suffix: String)(implicit F: Sync[F])
+      : F[JPath] =
+    F.delay(JFiles.createTempFile(prefix, suffix))
 
   def getBasePath[F[_]](implicit F: Sync[F]): F[JPath] =
     getUserHome.map(h => h.map(_.resolve(getPath(QuasarDirNames)))

--- a/repl/src/main/scala/quasar/repl/Repl.scala
+++ b/repl/src/main/scala/quasar/repl/Repl.scala
@@ -22,9 +22,9 @@ import quasar.api.QueryEvaluator
 import quasar.api.datasource.Datasources
 import quasar.build.BuildInfo
 import quasar.common.{PhaseResultListen, PhaseResultTell}
-import quasar.common.data.Data
 import quasar.ejson.EJson
 import quasar.impl.schema.SstConfig
+import quasar.mimir.MimirRepr
 import quasar.run.{MonadQuasarErr, SqlQuery}
 
 import java.io.File
@@ -77,7 +77,7 @@ object Repl {
   def mk[F[_]: ConcurrentEffect: MonadQuasarErr: PhaseResultListen: PhaseResultTell](
       ref: Ref[F, ReplState],
       datasources: Datasources[F, Stream[F, ?], UUID, Json, SstConfig[Fix[EJson], Double]],
-      queryEvaluator: QueryEvaluator[F, SqlQuery, Stream[F, Data]])
+      queryEvaluator: QueryEvaluator[F, SqlQuery, Stream[F, MimirRepr]])
       : F[Repl[F]] = {
     val evaluator = Evaluator[F](ref, datasources, queryEvaluator)
     historyFile[F].map(f => Repl[F](prompt, mkLineReader(f), evaluator.evaluate))

--- a/repl/src/main/scala/quasar/repl/ReplState.scala
+++ b/repl/src/main/scala/quasar/repl/ReplState.scala
@@ -34,6 +34,7 @@ import scalaz._, Scalaz._
     phaseFormat:        PhaseFormat,
     summaryCount:       Option[Int Refined Positive],
     format:             OutputFormat,
+    mode:               OutputMode,
     variables:          Variables,
     timingFormat:       TimingFormat,
     supportedTypes:     Option[ISet[DatasourceType]]
@@ -48,6 +49,7 @@ object ReplState {
     PhaseFormat.Tree,
     Some(10),
     OutputFormat.Table,
+    OutputMode.Console,
     Variables(Map()),
     TimingFormat.OnlyTotal,
     none

--- a/repl/src/main/scala/quasar/repl/ReplState.scala
+++ b/repl/src/main/scala/quasar/repl/ReplState.scala
@@ -48,7 +48,7 @@ object ReplState {
     DebugLevel.Normal,
     PhaseFormat.Tree,
     Some(10),
-    OutputFormat.Table,
+    OutputFormat.Precise,
     OutputMode.Console,
     Variables(Map()),
     TimingFormat.OnlyTotal,


### PR DESCRIPTION
* repl is now expecting stream of `MimirRepr` instead of `Data`
* new command `set mode = file | console`;  `console` is the default and more or less the same as before (though rewritten in terms of `MimirRepr`); `file` will stream the results to a temp file and should not be memory bound, except when `format = table`
* default `format` is now `precise` instead of `table`