### PR TITLE
Persist slices in bulk in NIHDB (bypassing JValue)

### DIFF
--- a/mimir/src/main/scala/quasar/mimir/storage/storage/MimirPTableStore.scala
+++ b/mimir/src/main/scala/quasar/mimir/storage/storage/MimirPTableStore.scala
@@ -24,6 +24,7 @@ import quasar.contrib.pathy.{ADir, AFile}
 import quasar.contrib.scalaz.MonadError_
 import quasar.mimir.MimirCake.Cake
 import quasar.yggdrasil.ExactSize
+import quasar.yggdrasil.nihdb.SegmentsWrapper
 import quasar.yggdrasil.vfs.ResourceError
 import quasar.niflheim.NIHDB
 import quasar.yggdrasil.nihdb.NIHDBProjection
@@ -61,15 +62,16 @@ final class MimirPTableStore[F[_]: Monad: LiftIO] private (
       case Some((_, _, db)) =>
         fromStreamT(table.slices).zipWithIndex evalMap {
           case (slice, offset) =>
-            val jvs = slice.toJsonElements
-            IO.fromFutureShift(IO(db.insertVerified(NIHDB.Batch(offset, jvs.toList) :: Nil)))
+            val segments = SegmentsWrapper.sliceToSegments(offset.toLong, slice)
+            IO.fromFutureShift(
+              IO(db.insertSegmentsVerified(offset.toLong, slice.size, segments)))
         }
 
       case None =>
         Stream.empty
     }, {
       case Some((blob, version, db)) =>
-        IO.fromFutureShift(IO(db.cook)) *> cake.commitDB(blob, version, db)
+        cake.commitDB(blob, version, db)
 
       case None =>
         IO.pure(())

--- a/niflheim/src/main/scala/quasar/niflheim/Chef.scala
+++ b/niflheim/src/main/scala/quasar/niflheim/Chef.scala
@@ -63,7 +63,7 @@ final case class Chef(blockFormat: CookedBlockFormat, format: SegmentFormat) ext
       val mdFile = File.createTempFile("block-%08x".format(id), ".cookedmeta", root)
       val channel = new FileOutputStream(mdFile).getChannel()
       try {
-        blockFormat.writeCookedBlock(channel, metadata).toValidationNel map { _ : Unit =>
+        blockFormat.writeCookedBlock(channel, metadata).toValidationNel map { _: Unit =>
           new File(mdFile.getName)
         }
       } finally {

--- a/niflheim/src/main/scala/quasar/niflheim/Chef.scala
+++ b/niflheim/src/main/scala/quasar/niflheim/Chef.scala
@@ -40,29 +40,29 @@ final case class Chef(blockFormat: CookedBlockFormat, format: SegmentFormat) ext
     "segment-" + id.blockid + "-" + pathHash + "-" + typeCode(id.ctype)
   }
 
-  def cook(root: File, reader: StorageReader): ValidationNel[IOException, File] = {
+  def cookSegments(root: File, id: Long, length: Int, segments: List[Segment]): ValidationNel[IOException, File] ={
     assert(root.exists)
     assert(root.isDirectory)
     assert(root.canWrite)
-    val files0 = reader.snapshot(None).segments map { seg =>
+
+    val files = segments traverse { seg =>
       val file = File.createTempFile(prefix(seg), ".cooked", root)
       val relativized = new File(file.getName)
       val channel: WritableByteChannel = new FileOutputStream(file).getChannel()
       val result = try {
-        format.writer.writeSegment(channel, seg) map { _ => (seg.id, relativized) }
+        format.writer.writeSegment(channel, seg).map(_ => (seg.id, relativized))
       } finally {
         channel.close()
       }
       result.toValidationNel
     }
 
-    val files = files0.toList.sequence[({ type λ[α] = ValidationNel[IOException, α] })#λ, (SegmentId, File)]
     files flatMap { segs =>
-      val metadata = CookedBlockMetadata(reader.id, reader.length, segs.toArray)
-      val mdFile = File.createTempFile("block-%08x".format(reader.id), ".cookedmeta", root)
+      val metadata = CookedBlockMetadata(id, length, segs.toArray)
+      val mdFile = File.createTempFile("block-%08x".format(id), ".cookedmeta", root)
       val channel = new FileOutputStream(mdFile).getChannel()
       try {
-        blockFormat.writeCookedBlock(channel, metadata).toValidationNel.map { _ : Unit =>
+        blockFormat.writeCookedBlock(channel, metadata).toValidationNel map { _ : Unit =>
           new File(mdFile.getName)
         }
       } finally {
@@ -70,6 +70,9 @@ final case class Chef(blockFormat: CookedBlockFormat, format: SegmentFormat) ext
       }
     }
   }
+
+  def cook(root: File, reader: StorageReader): ValidationNel[IOException, File] =
+    cookSegments(root, reader.id, reader.length, reader.snapshot(None).segments.toList)
 
   def receive = {
     case Prepare(blockid, seqId, root, source, onComplete) =>

--- a/niflheim/src/main/scala/quasar/niflheim/NIHDBActor.scala
+++ b/niflheim/src/main/scala/quasar/niflheim/NIHDBActor.scala
@@ -48,6 +48,7 @@ import scala.collection.immutable.SortedMap
 import shapeless._
 
 case class Insert(batch: Seq[NIHDB.Batch], responseRequested: Boolean)
+case class InsertSegments(offset: Long, length: Int, segments: List[Segment], responseRequested: Boolean)
 
 case object GetSnapshot
 
@@ -84,6 +85,14 @@ trait NIHDB {
   def insert(batch: Seq[NIHDB.Batch]): IO[Unit]
 
   def insertVerified(batch: Seq[NIHDB.Batch]): Future[InsertResult]
+
+  /**
+   * Please don't mix segment insertion with value insertion on the same dataset. The results may be
+   * somewhat odd and *definitely* out of order. Also note that segment insertion doesn't obey the
+   * same atomicity guarantees as value insertion (naturally, since it bypasses the append log).
+   * External atomicity guarantees should be used to avoid corruption in all cases.
+   */
+  def insertSegmentsVerified(offset: Long, length: Int, segments: List[Segment]): Future[InsertResult]
 
   def getSnapshot(): Future[NIHDBSnapshot]
 
@@ -131,6 +140,9 @@ private[niflheim] class NIHDBImpl private[niflheim] (actor: ActorRef, timeout: T
 
   def insertVerified(batch: Seq[NIHDB.Batch]): Future[InsertResult] =
     (actor ? Insert(batch, true)).mapTo[InsertResult]
+
+  def insertSegmentsVerified(offset: Long, length: Int, segments: List[Segment]): Future[InsertResult] =
+    (actor ? InsertSegments(offset, length, segments, true)).mapTo[InsertResult]
 
   def getSnapshot(): Future[NIHDBSnapshot] =
     (actor ? GetSnapshot).mapTo[NIHDBSnapshot]
@@ -402,6 +414,27 @@ private[niflheim] class NIHDBActor private (private var currentState: Projection
           log.debug("Insert complete on %d rows at offset %d for %s".format(values.length, offset, baseDir.getCanonicalPath))
           if (responseRequested) sender ! Inserted(offset, values.length)
         }
+      }
+
+    case InsertSegments(offset, length, segments, responseRequested) =>
+      if (length == 0) {
+        log.warn("Skipping insert with an empty batch on %s".format(baseDir.getCanonicalPath))
+        if (responseRequested) sender ! Skipped
+      } else if (offset > currentState.maxOffset) {
+        log.warn("Skipping insert with already-inserted offset on %s".format(baseDir.getCanonicalPath))
+        if (responseRequested) sender ! Skipped
+      } else {
+        log.debug("Inserting from segments %d rows at offset %d for %s".format(length, offset, baseDir.getCanonicalPath))
+
+        currentState = currentState.copy(maxOffset = offset)
+
+        val target = sender
+        val onComplete = if (responseRequested)
+          () => target ! (())
+        else
+          () => ()
+
+        chef ! PrepareSegments(offset, cookSequence.getAndIncrement, cookedDir, offset, length, segments, onComplete)
       }
 
     case Cook =>

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/ArrayColumn.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/ArrayColumn.scala
@@ -40,6 +40,10 @@ object ArrayColumn {
   }
 }
 
+trait AccessibleArrayColumn[@specialized(Boolean, Long, Double) A] extends ArrayColumn[A] {
+  def values: Array[A]
+}
+
 class ArrayHomogeneousArrayColumn[@specialized(Boolean, Long, Double) A](val defined: BitSet, val values: Array[Array[A]])(implicit val tpe: CArrayType[A])
     extends BitsetColumn(defined)
     with HomogeneousArrayColumn[A]
@@ -111,7 +115,7 @@ object ArrayBoolColumn {
     new ArrayBoolColumn(new BitSet(size), new BitSet(size))
 }
 
-class ArrayLongColumn(val defined: BitSet, val values: Array[Long]) extends BitsetColumn(defined) with ArrayColumn[Long] with LongColumn {
+class ArrayLongColumn(val defined: BitSet, val values: Array[Long]) extends BitsetColumn(defined) with AccessibleArrayColumn[Long] with LongColumn {
   def apply(row: Int) = values(row)
 
   def update(row: Int, value: Long) = {
@@ -138,7 +142,7 @@ object ArrayLongColumn {
     new ArrayLongColumn(new BitSet, new Array[Long](size))
 }
 
-class ArrayDoubleColumn(val defined: BitSet, val values: Array[Double]) extends BitsetColumn(defined) with ArrayColumn[Double] with DoubleColumn {
+class ArrayDoubleColumn(val defined: BitSet, val values: Array[Double]) extends BitsetColumn(defined) with AccessibleArrayColumn[Double] with DoubleColumn {
   def apply(row: Int) = values(row)
 
   def update(row: Int, value: Double) = {
@@ -165,7 +169,7 @@ object ArrayDoubleColumn {
     new ArrayDoubleColumn(new BitSet, new Array[Double](size))
 }
 
-class ArrayNumColumn(val defined: BitSet, val values: Array[BigDecimal]) extends BitsetColumn(defined) with ArrayColumn[BigDecimal] with NumColumn {
+class ArrayNumColumn(val defined: BitSet, val values: Array[BigDecimal]) extends BitsetColumn(defined) with AccessibleArrayColumn[BigDecimal] with NumColumn {
   def apply(row: Int) = values(row)
 
   def update(row: Int, value: BigDecimal) = {
@@ -192,7 +196,7 @@ object ArrayNumColumn {
     new ArrayNumColumn(new BitSet, new Array[BigDecimal](size))
 }
 
-class ArrayStrColumn(val defined: BitSet, val values: Array[String]) extends BitsetColumn(defined) with ArrayColumn[String] with StrColumn {
+class ArrayStrColumn(val defined: BitSet, val values: Array[String]) extends BitsetColumn(defined) with AccessibleArrayColumn[String] with StrColumn {
   def apply(row: Int) = values(row)
 
   def update(row: Int, value: String) = {
@@ -219,7 +223,7 @@ object ArrayStrColumn {
     new ArrayStrColumn(new BitSet, new Array[String](size))
 }
 
-class ArrayOffsetDateTimeColumn(val defined: BitSet, val values: Array[OffsetDateTime]) extends BitsetColumn(defined) with ArrayColumn[OffsetDateTime] with OffsetDateTimeColumn {
+class ArrayOffsetDateTimeColumn(val defined: BitSet, val values: Array[OffsetDateTime]) extends BitsetColumn(defined) with AccessibleArrayColumn[OffsetDateTime] with OffsetDateTimeColumn {
   def apply(row: Int) = values(row)
 
   def update(row: Int, value: OffsetDateTime) = {
@@ -246,7 +250,7 @@ object ArrayOffsetDateTimeColumn {
     new ArrayOffsetDateTimeColumn(new BitSet, new Array[OffsetDateTime](size))
 }
 
-class ArrayOffsetTimeColumn(val defined: BitSet, val values: Array[OffsetTime]) extends BitsetColumn(defined) with ArrayColumn[OffsetTime] with OffsetTimeColumn {
+class ArrayOffsetTimeColumn(val defined: BitSet, val values: Array[OffsetTime]) extends BitsetColumn(defined) with AccessibleArrayColumn[OffsetTime] with OffsetTimeColumn {
   def apply(row: Int) = values(row)
 
   def update(row: Int, value: OffsetTime) = {
@@ -273,7 +277,7 @@ object ArrayOffsetTimeColumn {
     new ArrayOffsetTimeColumn(new BitSet, new Array[OffsetTime](size))
 }
 
-class ArrayOffsetDateColumn(val defined: BitSet, val values: Array[OffsetDate]) extends BitsetColumn(defined) with ArrayColumn[OffsetDate] with OffsetDateColumn {
+class ArrayOffsetDateColumn(val defined: BitSet, val values: Array[OffsetDate]) extends BitsetColumn(defined) with AccessibleArrayColumn[OffsetDate] with OffsetDateColumn {
   def apply(row: Int) = values(row)
 
   def update(row: Int, value: OffsetDate) = {
@@ -300,7 +304,7 @@ object ArrayOffsetDateColumn {
     new ArrayOffsetDateColumn(new BitSet, new Array[OffsetDate](size))
 }
 
-class ArrayLocalDateTimeColumn(val defined: BitSet, val values: Array[LocalDateTime]) extends BitsetColumn(defined) with ArrayColumn[LocalDateTime] with LocalDateTimeColumn {
+class ArrayLocalDateTimeColumn(val defined: BitSet, val values: Array[LocalDateTime]) extends BitsetColumn(defined) with AccessibleArrayColumn[LocalDateTime] with LocalDateTimeColumn {
   def apply(row: Int) = values(row)
 
   def update(row: Int, value: LocalDateTime) = {
@@ -327,7 +331,7 @@ object ArrayLocalDateTimeColumn {
     new ArrayLocalDateTimeColumn(new BitSet, new Array[LocalDateTime](size))
 }
 
-class ArrayLocalTimeColumn(val defined: BitSet, val values: Array[LocalTime]) extends BitsetColumn(defined) with ArrayColumn[LocalTime] with LocalTimeColumn {
+class ArrayLocalTimeColumn(val defined: BitSet, val values: Array[LocalTime]) extends BitsetColumn(defined) with AccessibleArrayColumn[LocalTime] with LocalTimeColumn {
   def apply(row: Int) = values(row)
 
   def update(row: Int, value: LocalTime) = {
@@ -354,7 +358,7 @@ object ArrayLocalTimeColumn {
     new ArrayLocalTimeColumn(new BitSet, new Array[LocalTime](size))
 }
 
-class ArrayLocalDateColumn(val defined: BitSet, val values: Array[LocalDate]) extends BitsetColumn(defined) with ArrayColumn[LocalDate] with LocalDateColumn {
+class ArrayLocalDateColumn(val defined: BitSet, val values: Array[LocalDate]) extends BitsetColumn(defined) with AccessibleArrayColumn[LocalDate] with LocalDateColumn {
   def apply(row: Int) = values(row)
 
   def update(row: Int, value: LocalDate) = {
@@ -381,7 +385,7 @@ object ArrayLocalDateColumn {
     new ArrayLocalDateColumn(new BitSet, new Array[LocalDate](size))
 }
 
-class ArrayIntervalColumn(val defined: BitSet, val values: Array[DateTimeInterval]) extends BitsetColumn(defined) with ArrayColumn[DateTimeInterval] with IntervalColumn {
+class ArrayIntervalColumn(val defined: BitSet, val values: Array[DateTimeInterval]) extends BitsetColumn(defined) with AccessibleArrayColumn[DateTimeInterval] with IntervalColumn {
   def apply(row: Int) = values(row)
 
   def update(row: Int, value: DateTimeInterval) = {

--- a/yggdrasil/src/test/scala/quasar/yggdrasil/nihdb/SegmentsWrapperSpec.scala
+++ b/yggdrasil/src/test/scala/quasar/yggdrasil/nihdb/SegmentsWrapperSpec.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.yggdrasil
+package nihdb
+
+import quasar.contrib.cats.effect._
+import quasar.niflheim.{Chef, NIHDB, V1CookedBlockFormat, V1SegmentFormat, VersionedCookedBlockFormat, VersionedSegmentFormat}
+import quasar.precog.common._
+import quasar.precog.util.IOUtils
+import quasar.yggdrasil.table._
+
+import akka.actor.{ActorRef, ActorSystem, Props}
+
+import cats.effect.IO
+
+import org.scalacheck._
+import org.specs2.ScalaCheck
+import org.specs2.mutable._
+
+import scalaz.std.list._
+import scalaz.syntax.traverse._
+
+import shims._
+
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import java.nio.file.Files
+import java.util.concurrent.{ScheduledThreadPoolExecutor, ThreadFactory}
+import java.util.concurrent.atomic.AtomicInteger
+
+object SegmentsWrapperSpec extends Specification with ScalaCheck {
+  import ArbitrarySlice._
+
+  // cargo-culted all this setup, mostly from Precog
+  val CookThreshold = 1
+  val Timeout = 300.seconds
+
+  private val TxLogScheduler = new ScheduledThreadPoolExecutor(20,
+    new ThreadFactory {
+      private val counter = new AtomicInteger(0)
+
+      def newThread(r: Runnable): Thread = {
+        val t = new Thread(r)
+        t.setName("HOWL-sched-%03d".format(counter.getAndIncrement()))
+
+        t
+      }
+    })
+
+  implicit val actorSystem = ActorSystem(
+    "nihdbExecutorActorSystem",
+    classLoader = Some(getClass.getClassLoader))
+
+  private val props: Props = Props(Chef(
+    VersionedCookedBlockFormat(Map(1 -> V1CookedBlockFormat)),
+    VersionedSegmentFormat(Map(1 -> V1SegmentFormat))))
+
+  val masterChef: ActorRef = actorSystem.actorOf(props)
+
+  "direct columnmar table persistence" should {
+    val paths = Vector(
+      CPath("0") -> CLong,
+      CPath("1") -> CBoolean,
+      CPath("2") -> CString,
+      CPath("3") -> CDouble,
+      CPath("4") -> CNum,
+      CPath("5") -> CEmptyObject,
+      CPath("6") -> CEmptyArray,
+      CPath("7") -> CNum)
+
+    val pd = paths.toList map {
+      case (cpath, ctype) =>
+        ColumnRef(cpath, ctype)
+    }
+
+    implicit def arbSlice = Arbitrary(for {
+      badSize <- Arbitrary.arbitrary[Int]
+      size = scala.math.abs(badSize % 100).toInt
+      slice <- genSlice(pd, size)
+    } yield slice)
+
+    "persist arbitrary tables" in prop { slices: List[Slice] =>
+      val dir = Files.createTempDirectory("SegmentsWrapperSpec").toFile
+      try {
+        val ioa = for {
+          nihdbV <- IO {
+            NIHDB.create(masterChef, dir, CookThreshold, Timeout, TxLogScheduler).unsafePerformIO
+          }
+
+          _ = nihdbV.toEither must beRight
+          nihdb = nihdbV.toEither.right.get
+
+          _ <- slices.zipWithIndex traverse {
+            case (slice, index) =>
+              val segments = SegmentsWrapper.sliceToSegments(index.toLong, slice)
+
+              IO.fromFutureShift(
+                IO(nihdb.insertSegmentsVerified(index.toLong, slice.size, segments)))
+          }
+
+          proj <- NIHDBProjection.wrap(nihdb)
+          stream <- proj.getBlockStream(None).toStream
+        } yield {
+          val slices2 = stream.toList.map(_.deref("value"))
+
+          slices.flatMap(_.toRValues) mustEqual slices2.flatMap(_.toRValues)
+        }
+
+        ioa.unsafeRunSync
+      } finally {
+        IOUtils.recursiveDelete(dir).unsafePerformIO
+      }
+    }.set(
+      minTestsOk = Runtime.getRuntime.availableProcessors * 2,
+      workers = Runtime.getRuntime.availableProcessors)    // these take a long time
+  }
+
+  protected def afterAll() = {
+    actorSystem.terminate
+  }
+}


### PR DESCRIPTION
This gives us, among other things, type preservation in preparation results. It should also be orders of magnitude faster.

This relies on the new API, `NIHDB.insertSegmentsVerified`. This API is, in isolation, safe, but you cannot mix it with `NIHDB.insert` or `insertVerified`. If you mix the two, you'll end up losing uncooked data in the append logs. If we need mixing, we can add it down the line, it's just more complicated than what I wanted to deal with right now.

[ch1331]