### PR TITLE
Join left shifts when necessary

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -271,6 +271,8 @@ lazy val qsu = project
   .settings(commonSettings)
   .settings(targetSettings)
   .settings(excludeTypelevelScalaLibrary)
+  .settings(
+    libraryDependencies ++= Dependencies.qsu)
   .enablePlugins(AutomateHeaderPlugin)
 
 lazy val connector = project

--- a/build.sbt
+++ b/build.sbt
@@ -271,8 +271,13 @@ lazy val qsu = project
   .settings(commonSettings)
   .settings(targetSettings)
   .settings(excludeTypelevelScalaLibrary)
-  .settings(
-    libraryDependencies ++= Dependencies.qsu)
+  .settings(libraryDependencies ++= Dependencies.qsu)
+  .settings(scalacOptions ++= {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, 12)) => Seq("-Ypatmat-exhaust-depth", "40")
+      case _ => Seq()
+    }
+  })
   .enablePlugins(AutomateHeaderPlugin)
 
 lazy val connector = project

--- a/it/src/main/resources/tests/nestedMapWildcardShiftWithShiftMap.test
+++ b/it/src/main/resources/tests/nestedMapWildcardShiftWithShiftMap.test
@@ -2,8 +2,8 @@
   "name": "wildcard shifted map key and shifted map value on nested map",
 
   "backends": {
-      "lwc_local": "pendingIgnoreFieldOrder",
-      "mimir":     "pendingIgnoreFieldOrder"
+      "lwc_local": "ignoreFieldOrder",
+      "mimir":     "ignoreFieldOrder"
   },
   "data": "nested_map.data",
 

--- a/it/src/main/resources/tests/sumFlattenedIntArrays.test
+++ b/it/src/main/resources/tests/sumFlattenedIntArrays.test
@@ -6,5 +6,5 @@
     "query": "select b[*] + c[*] from `intArrays.data`",
     "predicate": "exactly",
     "ignoreResultOrder": true,
-    "expected": [12, 14, 16, 18, 20, 22, 24, 26]
+    "expected": [12, 13, 13, 14, 16, 17, 17, 18, 20, 21, 22, 21, 22, 23, 22, 23, 24, 26]
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -80,10 +80,6 @@ object Dependencies {
     "org.typelevel"              %% "algebra-laws"  % algebraVersion % Test
   )
 
-  def effect = Seq(
-    "com.fasterxml.uuid" % "java-uuid-generator" % "3.1.4"
-  )
-
   def datagen = Seq(
     "com.github.scopt" %% "scopt"          % scoptVersion,
     "eu.timepit"       %% "refined-scalaz" % refinedVersion
@@ -92,6 +88,10 @@ object Dependencies {
   def sql = Seq(
     "com.github.julien-truffaut" %% "monocle-macro" % monocleVersion,
     "org.scala-lang.modules"     %% "scala-parser-combinators" % "1.0.6"
+  )
+
+  def qsu = Seq(
+    "org.slf4s" %% "slf4s-api" % slf4sVersion
   )
 
   def core = Seq(

--- a/qscript/src/main/scala/quasar/qscript/provenance/Dimensions.scala
+++ b/qscript/src/main/scala/quasar/qscript/provenance/Dimensions.scala
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript.provenance
+
+import slamdata.Predef.Boolean
+import quasar.fp.ski.ι
+
+import monocle.{Iso, PIso, PTraversal, Traversal}
+import scalaz.{@@, Applicative, Cord, Equal, IList, Monoid, NonEmptyList, SemiLattice, Show, Traverse}
+import scalaz.Scalaz._
+import scalaz.Tags.{Disjunction, Conjunction}
+import scalaz.syntax.tag._
+
+final case class Dimensions[A](union: IList[NonEmptyList[A]]) {
+  def isEmpty: Boolean =
+    union.isEmpty
+
+  def nonEmpty: Boolean =
+    !isEmpty
+
+  def map[B](f: A => B): Dimensions[B] =
+    Dimensions.pdimension.modify(f)(this)
+
+  def mapJoin[B](f: NonEmptyList[A] => NonEmptyList[B]): Dimensions[B] =
+    Dimensions.pjoin.modify(f)(this)
+
+  def and(rhs: Dimensions[A])(implicit A: SemiLattice[A]): Dimensions[A] =
+    if (isEmpty) rhs
+    else if (rhs.isEmpty) this
+    else Dimensions(for {
+      l <- union
+      r <- rhs.union
+    } yield {
+      l.reverse.alignWith(r.reverse)(_.fold(ι, ι, _ |+| _)).reverse
+    })
+
+  def ∧(rhs: Dimensions[A])(implicit A: SemiLattice[A]): Dimensions[A] =
+    and(rhs)
+
+  def or(rhs: Dimensions[A])(implicit A: Equal[A]): Dimensions[A] =
+    Dimensions.normalize(Dimensions(union ++ rhs.union))
+
+  def ∨(rhs: Dimensions[A])(implicit A: Equal[A]): Dimensions[A] =
+    or(rhs)
+}
+
+object Dimensions extends DimensionsInstances {
+  def empty[A]: Dimensions[A] =
+    Dimensions(IList.empty[NonEmptyList[A]])
+
+  def origin[A](a: A, as: A*): Dimensions[A] =
+    origin1(NonEmptyList.nels(a, as: _*))
+
+  def origin1[A](as: NonEmptyList[A]): Dimensions[A] =
+    Dimensions(IList(as))
+
+  def pdimension[A, B]: PTraversal[Dimensions[A], Dimensions[B], A, B] =
+    PTraversal.fromTraverse[Dimensions, A, B]
+
+  def dimension[A]: Traversal[Dimensions[A], A] =
+    pdimension[A, A]
+
+  def pjoin[A, B]: PTraversal[Dimensions[A], Dimensions[B], NonEmptyList[A], NonEmptyList[B]] =
+    punion.composeTraversal(PTraversal.fromTraverse[IList, NonEmptyList[A], NonEmptyList[B]])
+
+  def join[A]: Traversal[Dimensions[A], NonEmptyList[A]] =
+    pjoin[A, A]
+
+  def punion[A, B]: PIso[Dimensions[A], Dimensions[B], IList[NonEmptyList[A]], IList[NonEmptyList[B]]] =
+    PIso((_: Dimensions[A]).union)(apply(_))
+
+  def union[A]: Iso[Dimensions[A], IList[NonEmptyList[A]]] =
+    punion[A, A]
+
+  def normalize[A: Equal](ds: Dimensions[A]): Dimensions[A] =
+    Dimensions(ds.union.distinctE)
+}
+
+sealed abstract class DimensionsInstances {
+  // TODO: Actually a BoundedSemilattice, rewrite using type from cats.
+  implicit def disjMonoid[A: Equal]: Monoid[Dimensions[A] @@ Disjunction] =
+    Monoid.instance(
+      (l, r) => Disjunction(l.unwrap ∨ r.unwrap),
+      Disjunction(Dimensions.empty[A]))
+
+  // TODO: Actually a CommutativeMonoid, rewrite using type from cats.
+  implicit def conjMonoid[A: SemiLattice]: Monoid[Dimensions[A] @@ Conjunction] =
+    Monoid.instance(
+      (l, r) => Conjunction(l.unwrap ∧ r.unwrap),
+      Conjunction(Dimensions.empty[A]))
+
+  implicit def equal[A: Equal]: Equal[Dimensions[A]] =
+    Equal.equalBy(d => AsSet(d.union))
+
+  implicit def show[A: Show]: Show[Dimensions[A]] =
+    Show.show(d => Cord("(") ++ d.union.map(_.show).intercalate(Cord(" ∨ ")) ++ Cord(")"))
+
+  implicit val traverse: Traverse[Dimensions] =
+    new Traverse[Dimensions] {
+      val T = Traverse[IList].compose[NonEmptyList]
+      def traverseImpl[F[_]: Applicative, A, B](fa: Dimensions[A])(f: A => F[B]) =
+        T.traverse(fa.union)(f).map(Dimensions(_))
+    }
+}

--- a/qscript/src/main/scala/quasar/qscript/provenance/Dimensions.scala
+++ b/qscript/src/main/scala/quasar/qscript/provenance/Dimensions.scala
@@ -20,6 +20,7 @@ import slamdata.Predef.Boolean
 import quasar.fp.ski.ι
 
 import monocle.{Iso, PIso, PTraversal, Traversal}
+import monocle.function.Cons1
 import scalaz.{@@, Applicative, Cord, Equal, IList, Monoid, NonEmptyList, SemiLattice, Show, Traverse}
 import scalaz.Scalaz._
 import scalaz.Tags.{Disjunction, Conjunction}
@@ -79,6 +80,9 @@ object Dimensions extends DimensionsInstances {
 
   def join[A]: Traversal[Dimensions[A], NonEmptyList[A]] =
     pjoin[A, A]
+
+  def topDimension[A]: Traversal[Dimensions[A], A] =
+    join[A] composeLens Cons1.head
 
   def punion[A, B]: PIso[Dimensions[A], Dimensions[B], IList[NonEmptyList[A]], IList[NonEmptyList[B]]] =
     PIso((_: Dimensions[A]).union)(apply(_))

--- a/qscript/src/main/scala/quasar/qscript/provenance/JoinKeys.scala
+++ b/qscript/src/main/scala/quasar/qscript/provenance/JoinKeys.scala
@@ -37,15 +37,18 @@ sealed abstract class JoinKeyInstances {
 }
 
 
+/** A disjunction of a conjunction of the intersection between two sets of
+  * identities (itself represented as a disjunction of `JoinKey`s).
+  */
 @Lenses
-final case class JoinKeys[I](keys: IList[NonEmptyList[JoinKey[I]]])
+final case class JoinKeys[I](keys: IList[NonEmptyList[NonEmptyList[JoinKey[I]]]])
 
 object JoinKeys extends JoinKeysInstances {
   def empty[I]: JoinKeys[I] =
     JoinKeys(IList())
 
   def singleton[I](l: I, r: I): JoinKeys[I] =
-    JoinKeys(IList(NonEmptyList(JoinKey(l, r))))
+    JoinKeys(IList(NonEmptyList(NonEmptyList(JoinKey(l, r)))))
 }
 
 sealed abstract class JoinKeysInstances {
@@ -62,7 +65,7 @@ sealed abstract class JoinKeysInstances {
     plusEmpty.monoid[I]
 
   implicit def equal[I: Equal]: Equal[JoinKeys[I]] =
-    Equal.equalBy(jks => AsSet(jks.keys map (AsSet(_))))
+    Equal.equalBy(jks => AsSet(jks.keys.map(conjs => AsSet(conjs.map(AsSet(_))))))
 
   implicit def show[I: Show]: Show[JoinKeys[I]] =
     Show.shows(jks => "JoinKeys" + jks.keys.shows)

--- a/qscript/src/main/scala/quasar/qscript/provenance/Prov.scala
+++ b/qscript/src/main/scala/quasar/qscript/provenance/Prov.scala
@@ -37,8 +37,6 @@ trait Prov[D, I, P] {
   implicit def PC: Corecursive.Aux[P, PF]
   implicit def PR: Recursive.Aux[P, PF]
 
-  def dataId: D => I
-
   import ProvF._
   private val O = ProvF.Optics[D, I]
 
@@ -99,8 +97,8 @@ trait Prov[D, I, P] {
       case (_, Nada())          => mempty[JoinKeys, I]
       case (Proj(_), Proj(_))   => mempty[JoinKeys, I]
       case (Value(l), Value(r)) => JoinKeys.singleton(l, r)
-      case (Value(l), Proj(r))  => JoinKeys.singleton(l, dataId(r))
-      case (Proj(l), Value(r))  => JoinKeys.singleton(dataId(l), r)
+      case (Value(_), Proj(_))  => mempty[JoinKeys, I]
+      case (Proj(_), Value(_))  => mempty[JoinKeys, I]
       case (Then(_, _), _)      => joinThens(left, right)
       case (_, Then(_, _))      => joinThens(left, right)
       case (Both(_, _), _)      => joinBoths(left, right)
@@ -204,15 +202,13 @@ trait Prov[D, I, P] {
 }
 
 object Prov {
-  def apply[D, I, P]
-      (dataId0: D => I)
-      (implicit
-        TC: Corecursive.Aux[P, ProvF[D, I, ?]],
-        TR: Recursive.Aux[P, ProvF[D, I, ?]])
+  def apply[D, I, P](
+      implicit
+      TC: Corecursive.Aux[P, ProvF[D, I, ?]],
+      TR: Recursive.Aux[P, ProvF[D, I, ?]])
       : Prov[D, I, P] =
     new Prov[D, I, P] {
       val PC = TC
       val PR = TR
-      val dataId = dataId0
     }
 }

--- a/qscript/src/main/scala/quasar/qscript/provenance/Prov.scala
+++ b/qscript/src/main/scala/quasar/qscript/provenance/Prov.scala
@@ -24,8 +24,9 @@ import quasar.fp.ski.{ι, κ}
 import matryoshka._
 import matryoshka.implicits._
 import monocle.Prism
-import scalaz.Tags.Disjunction
-import scalaz.{NonEmptyList => NEL, _}, Scalaz._
+import scalaz._, Scalaz._
+import scalaz.Tags.{Conjunction, Disjunction}
+import scalaz.syntax.tag._
 
 /**
   * @tparam D type of data
@@ -43,9 +44,6 @@ trait Prov[D, I, P] {
   private val O = ProvF.Optics[D, I]
 
   // Optics
-
-  def nada: Prism[P, Unit] =
-    birecursiveIso[P, PF] composePrism O.nada[P]
 
   def fresh: Prism[P, Unit] =
     birecursiveIso[P, PF] composePrism O.fresh[P]
@@ -65,13 +63,46 @@ trait Prov[D, I, P] {
   def both: Prism[P, (P, P)] =
     birecursiveIso[P, PF] composePrism O.both[P]
 
-  def oneOf: Prism[P, (P, P)] =
-    birecursiveIso[P, PF] composePrism O.oneOf[P]
-
   def thenn: Prism[P, (P, P)] =
     birecursiveIso[P, PF] composePrism O.thenn[P]
 
-  // Operations
+  object implicits {
+    implicit final class ProvOps(p: P) {
+      def ∧(q: P)(implicit D: Equal[D], I: Equal[I]): P =
+        provConjunctionSemiLattice.append(Conjunction(p), Conjunction(q)).unwrap
+
+      def ≺:(q: P): P =
+        thenn(q, p)
+
+      def conjunction: P @@ Conjunction = Conjunction(p)
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.Equals", "org.wartremover.warts.Recursion"))
+    implicit def provEqual(implicit D: Equal[D], I: Equal[I]): Equal[P] =
+      Equal.equal((x, y) => (x.project, y.project) match {
+        case (a@Fresh(), b@Fresh()) => a eq b
+        case (Value(l), Value(r)) => l ≟ r
+        case (PrjPath(l), PrjPath(r)) => l ≟ r
+        case (PrjValue(l), PrjValue(r)) => l ≟ r
+        case (InjValue(l), InjValue(r)) => l ≟ r
+        case (Both(_, _), _) => AsSet(flattenBoth(x)) ≟ AsSet(flattenBoth(y))
+        case (_, Both(_, _)) => AsSet(flattenBoth(x)) ≟ AsSet(flattenBoth(y))
+        case (Then(_, _), _) => flattenThen(x) ≟ flattenThen(y)
+        case (_, Then(_, _)) => flattenThen(x) ≟ flattenThen(y)
+        case _ => false
+      })
+
+    implicit def provConjunctionSemiLattice(implicit D: Equal[D], I: Equal[I]): SemiLattice[P @@ Conjunction] =
+      new SemiLattice[P @@ Conjunction] {
+        def append(a: P @@ Conjunction, b: => P @@ Conjunction) =
+          Conjunction(distinctConjunctions(both(a.unwrap, b.unwrap)))
+      }
+
+    implicit def provSequenceSemigroup: Semigroup[P] =
+      Semigroup.instance(thenn(_, _))
+  }
+
+  import implicits._
 
   /** Returns whether the provenance autojoin, collecting join keys using the
     * specified monad.
@@ -89,7 +120,7 @@ trait Prov[D, I, P] {
 
     def joinBoths(l0: P, r0: P): F[Boolean] = {
       val crossed =
-        flattenBoth(l0).join tuple flattenBoth(r0).join
+        flattenBoth(l0) tuple flattenBoth(r0)
 
       val joined =
         Disjunction.unsubst(crossed foldMapM {
@@ -97,35 +128,29 @@ trait Prov[D, I, P] {
         })
 
       joined.run match {
-        case (jks, b) => F.writer(JoinKeys(jks.keys.foldMap1Opt(ι).toIList), b)
-      }
-    }
+        case (jks, b) =>
+          val intersected = jks.keys.foldMap1Opt(Foldable1[NonEmptyList].fold1(_)) match {
+            case Some(isect) => JoinKeys(IList(NonEmptyList(isect)))
+            case None => JoinKeys.empty[I]
+          }
 
-    def joinOneOfs(l0: P, r0: P): F[Boolean] = {
-      val crossed =
-        flattenOneOf(l0) tuple flattenOneOf(r0)
-
-      val joined =
-        Disjunction.unsubst(crossed foldMapM {
-          case (l, r) => Disjunction.subst(autojoined[Writer[JoinKeys[I], ?]](l, r))
-        })
-
-      joined.run match {
-        case (jks, b) => F.writer(JoinKeys(jks.keys.foldMap1Opt(ι).toIList), b)
+          F.writer(intersected, b)
       }
     }
 
     def joinThens(l0: P, r0: P): F[Boolean] = {
-      val crossed =
-        flattenThen(l0) tuple flattenThen(r0)
+      val ls = flattenThen(l0).reverse
+      val rs = flattenThen(r0).reverse
 
-      Disjunction.unsubst(crossed foldMapM {
-        case (ls, rs) =>
-          Disjunction.subst(ls.reverse.alignBoth(rs.reverse).foldLeftM(true) {
-            case (true, Some((l, r))) => autojoined[F](l, r)
-            case _ => false.point[F]
-          })
-      })
+      val joined =
+        ls.alignBoth(rs).foldLeftM(true) {
+          case (true, Some((l, r))) => autojoined[Writer[JoinKeys[I], ?]](l, r)
+          case _ => false.point[Writer[JoinKeys[I], ?]]
+        }
+
+      joined.run match {
+        case (jks, b) => F.writer(JoinKeys(jks.keys.foldMap1Opt(ι).toIList), b)
+      }
     }
 
     (left.project, right.project) match {
@@ -134,149 +159,93 @@ trait Prov[D, I, P] {
       case (_, Both(_, _)) => joinBoths(left, right)
       case (Then(_, _), _) => joinThens(left, right)
       case (_, Then(_, _)) => joinThens(left, right)
-      case (OneOf(_, _), _) => joinOneOfs(left, right)
-      case (_, OneOf(_, _)) => joinOneOfs(left, right)
       case _ => (left ≟ right).point[F]
     }
   }
 
-  /** Reduce to normal form. */
-  def normalize(p: P)(implicit eqD: Equal[D], eqI: Equal[I]): P =
-    applyProjection(removeDuplicates(p)).cata(collapseNadaƒ)
+  /** Remove duplicate values from conjunctions. */
+  def distinctConjunctions(p: P)(implicit D: Equal[D], I: Equal[I]): P = {
+    def distinctConjunction(conj: NonEmptyList[P]): P =
+      conj.distinctE1.foldRight1(both(_, _))
 
+    val distinctConjunctionsƒ: ElgotAlgebra[(P, ?), PF, NonEmptyList[P]] = {
+      case (_, Both(l, r)) => l append r
+      case (_, Then(f, s)) => NonEmptyList(thenn(distinctConjunction(f), distinctConjunction(s)))
+      case (other, _) => NonEmptyList(other)
+    }
 
-  // Instances
+    distinctConjunction(p.elgotPara(distinctConjunctionsƒ))
+  }
 
-  @SuppressWarnings(Array("org.wartremover.warts.Recursion", "org.wartremover.warts.Equals"))
-  implicit def provenanceEqual(implicit eqD: Equal[D], eqI: Equal[I]): Equal[P] = {
-    implicit def listSetPEqual: Equal[IList[P] @@ AsSet] =
-      asSetEqual[IList, P](Foldable[IList], provenanceEqual(eqD, eqI))
+  /** Attempt to reduce a sequence ending in a value projection.
+    *
+    * A success indicates there was no projection or it was applied successfully,
+    * possibly eliminating provenance entirely.
+    *
+    * A failure indicates the projection is statically known to result in undefined.
+    */
+  def applyProjection(p: P)(implicit eqD: Equal[D], eqI: Equal[I]): Validation[Unit, Option[P]] = {
+    def applyProjection0(key: D, from: P): Option[(Boolean, IList[P])] = {
+      val (foundKey, join) = flattenBoth(from) foldMap {
+        case Embed(InjValue(k)) =>
+          ((k ≟ key).disjunction, IList[NonEmptyList[P] \/ (Boolean, P)]())
 
-    def thenEq(l: P, r: P): Boolean =
-      AsSet(flattenThen(l)) ≟ AsSet(flattenThen(r))
+        case Embed(Then(Embed(InjValue(k)), s)) =>
+          ((k ≟ key).disjunction, IList(((k ≟ key), s).right[NonEmptyList[P]]))
 
-    def bothEq(l: P, r: P): Boolean =
-      AsSet(flattenBoth(l) map (ls => AsSet(nubNada(ls)))) ≟
-        AsSet(flattenBoth(r) map (rs => AsSet(nubNada(rs))))
+        case other =>
+          (false.disjunction, IList(flattenThen(other).left[(Boolean, P)]))
+      }
 
-    def oneOfEq(l: P, r: P): Boolean =
-      AsSet(nubNada(flattenOneOf(l))) ≟ AsSet(nubNada(flattenOneOf(r)))
+      val joined =
+        if (foundKey.unwrap)
+          some(join.flatMap(
+            _.fold(_.tail, r => if (r._1) IList(r._2) else IList[P]())
+              .toNel
+              .map(_.foldMap1(ι))
+              .toIList))
+        else if (join.all(_.isRight))
+          none[IList[P]]
+        else
+          some(join.map(_.fold(_.foldMap1(ι), _._2)))
 
-    Equal.equal((x, y) => (x.project, y.project) match {
-      case (Nada(), Nada()) => true
-      case (a@Fresh(), b@Fresh()) => a eq b
-      case (Value(l), Value(r)) => l ≟ r
-      case (PrjPath(l), PrjPath(r)) => l ≟ r
-      case (PrjValue(l), PrjValue(r)) => l ≟ r
-      case (InjValue(l), InjValue(r)) => l ≟ r
-      case (Both(_, _), _) => bothEq(x, y)
-      case (_, Both(_, _)) => bothEq(x, y)
-      case (Then(_, _), _) => thenEq(x, y)
-      case (_, Then(_, _)) => thenEq(x, y)
-      case (OneOf(_, _), _) => oneOfEq(x, y)
-      case (_, OneOf(_, _)) => oneOfEq(x, y)
-      case _ => false
-    })
+      joined strengthL foundKey.unwrap
+    }
+
+    flattenThen(p) match {
+      case NonEmptyList(Embed(PrjValue(k)), ICons(r, rs)) =>
+        applyProjection0(k, r).toSuccess(()) map { ps0 =>
+          val ps = ps0.map(_.toNel) match {
+            case (true, Some(jn)) =>
+              some(NonEmptyList.nel(jn.foldMap1(_.conjunction).unwrap, rs))
+
+            case (false, Some(jn)) =>
+              some(NonEmptyList.nel(prjValue(k), jn.foldMap1(_.conjunction).unwrap :: rs))
+
+            case (_, None) =>
+              rs.toNel
+          }
+
+          ps.map(_.foldMap1(ι))
+        }
+
+      case _ => Success(some(p))
+    }
   }
 
   ////
 
-  private def removeDuplicates(p: P)(implicit eqD: Equal[D], eqI: Equal[I]): P = {
-    def removeDuplicates0(alternates: NEL[NEL[P]]): P =
-      alternates
-        .map(_.distinctE1.foldRight1(both(_, _)))
-        .distinctE1
-        .foldRight1(oneOf(_, _))
-
-    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    val removeDuplicatesƒ: Algebra[PF, NEL[NEL[P]]] = {
-      case Both(l, r) => (l |@| r)(_ append _)
-      case OneOf(l, r) => l append r
-      case Then(l, r) => NEL(NEL(thenn(removeDuplicates0(l), removeDuplicates0(r))))
-      case Value(i) => NEL(NEL(value(i)))
-      case InjValue(d) => NEL(NEL(injValue(d)))
-      case PrjValue(d) => NEL(NEL(prjValue(d)))
-      case PrjPath(d) => NEL(NEL(prjPath(d)))
-      case p@Fresh() => NEL(NEL(p.asInstanceOf[PF[P]].embed))
-      case Nada() => NEL(NEL(nada()))
+  private def flattenBoth(p: P): NonEmptyList[P] =
+    p.elgotPara[NonEmptyList[P]] {
+      case (_, Both(l, r)) => l append r
+      case (other, _) => NonEmptyList(other)
     }
 
-    removeDuplicates0(p.cata(removeDuplicatesƒ))
-  }
-
-  private def applyProjection(p: P)(implicit eqD: Equal[D], eqI: Equal[I]): P = {
-    def applyProjection0(thens: NEL[P]): P =
-      thens match {
-        case NEL(Embed(PrjValue(k)), ICons(Embed(InjValue(j)), ts)) =>
-          (k === j).option(ts)
-            .flatMap(_.foldRight1Opt(thenn(_, _)))
-            .getOrElse(nada())
-
-        case _ => thens.foldRight1(thenn(_, _))
-      }
-
-    // OneOf[Both[Then]]
-    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    val flattenƒ: Algebra[PF, NEL[NEL[NEL[P]]]] = {
-      case Then(l, r) => (l |@| r)((l1, r1) => (l1 |@| r1)(_ append _))
-      case Both(l, r) => (l |@| r)(_ append _)
-      case OneOf(l, r) => l append r
-      case Value(i) => NEL(NEL(NEL(value(i))))
-      case InjValue(d) => NEL(NEL(NEL(injValue(d))))
-      case PrjValue(d) => NEL(NEL(NEL(prjValue(d))))
-      case PrjPath(d) => NEL(NEL(NEL(prjPath(d))))
-      case p@Fresh() => NEL(NEL(NEL(p.asInstanceOf[PF[P]].embed)))
-      case Nada() => NEL(NEL(NEL(nada())))
+  private def flattenThen(p: P): NonEmptyList[P] =
+    p.elgotPara[NonEmptyList[P]] {
+      case (_, Then(h, t)) => h append t
+      case (other, _) => NonEmptyList(other)
     }
-
-    p.cata(flattenƒ)
-      .map(_.map(applyProjection0).foldRight1(both(_, _)))
-      .foldRight1(oneOf(_, _))
-  }
-
-  private val collapseNadaƒ: Algebra[PF, P] = {
-    case Both(l, Embed(Nada())) => l
-    case Both(Embed(Nada()), r) => r
-    case Then(Embed(Nada()), _) => nada()
-    case Then(_, Embed(Nada())) => nada()
-    case pf => pf.embed
-  }
-
-  /** The disjunction of sets arising from distributing `OneOf` over trees
-    * of `Both`.
-    */
-  private def flattenBoth(p: P): IList[IList[P]] =
-    p.elgotPara[IList[IList[P]]](flattenBothƒ)
-
-  private val flattenBothƒ: ElgotAlgebra[(P, ?), PF, IList[IList[P]]] = {
-    case (_, Both(l, r)) => (l |@| r)(_ ++ _)
-    case (_, OneOf(l, r)) => l ++ r
-    case (other, _) => IList(IList(other))
-  }
-
-  /** The disjunction described by a tree of `OneOf`. */
-  private def flattenOneOf(p: P): IList[P] =
-    p.elgotPara[IList[P]](flattenOneOfƒ)
-
-  private val flattenOneOfƒ: ElgotAlgebra[(P, ?), PF, IList[P]] = {
-    case (_, OneOf(l, r)) => l ++ r
-    case (other, _) => IList(other)
-  }
-
-  /** The disjunction of sequences arising from distributing `OneOf` over trees
-    * of `Then`.
-    */
-  private def flattenThen(p: P): IList[IList[P]] =
-    p.elgotPara[IList[IList[P]]](flattenThenƒ)
-
-  private val flattenThenƒ: ElgotAlgebra[(P, ?), PF, IList[IList[P]]] = {
-    case (_, Then(l, r)) => (l |@| r)(_ ++ _)
-    case (_, OneOf(l, r)) => l ++ r
-    case (other, _) => IList(IList(other))
-  }
-
-  private def nubNada(ps: IList[P]): IList[P] =
-    ps.filter(nada.isEmpty)
 }
 
 object Prov {

--- a/qscript/src/main/scala/quasar/qscript/provenance/ProvF.scala
+++ b/qscript/src/main/scala/quasar/qscript/provenance/ProvF.scala
@@ -31,22 +31,15 @@ import scalaz._, Scalaz._
 sealed abstract class ProvF[D, I, A]
 
 object ProvF extends ProvFInstances {
-  final case class Nada[D, I, A]() extends ProvF[D, I, A]
   final case class Fresh[D, I, A]() extends ProvF[D, I, A]
   final case class PrjPath[D, I, A](segment: D) extends ProvF[D, I, A]
   final case class PrjValue[D, I, A](field: D) extends ProvF[D, I, A]
   final case class InjValue[D, I, A](field: D) extends ProvF[D, I, A]
   final case class Value[D, I, A](id: I) extends ProvF[D, I, A]
   final case class Both[D, I, A](left: A, right: A) extends ProvF[D, I, A]
-  final case class OneOf[D, I, A](left: A, right: A) extends ProvF[D, I, A]
-  final case class Then[D, I, A](left: A, right: A) extends ProvF[D, I, A]
+  final case class Then[D, I, A](fst: A, snd: A) extends ProvF[D, I, A]
 
   final class Optics[D, I] {
-    def nada[A]: Prism[ProvF[D, I, A], Unit] =
-      Prism.partial[ProvF[D, I, A], Unit] {
-        case Nada() => ()
-      } (κ(Nada()))
-
     def fresh[A]: Prism[ProvF[D, I, A], Unit] =
       Prism.partial[ProvF[D, I, A], Unit] {
         case Fresh() => ()
@@ -79,19 +72,12 @@ object ProvF extends ProvFInstances {
         case (l, r) => Both(l, r)
       }
 
-    def oneOf[A]: Prism[ProvF[D, I, A], (A, A)] =
-      Prism.partial[ProvF[D, I, A], (A, A)] {
-        case OneOf(l, r) => (l, r)
-      } {
-        case (l, r) => OneOf(l, r)
-      }
-
     // NB: 'then' is now a reserved identifier in Scala
     def thenn[A]: Prism[ProvF[D, I, A], (A, A)] =
       Prism.partial[ProvF[D, I, A], (A, A)] {
-        case Then(l, r) => (l, r)
+        case Then(f, s) => (f, s)
       } {
-        case (l, r) => Then(l, r)
+        case (f, s) => Then(f, s)
       }
   }
 
@@ -107,17 +93,15 @@ sealed abstract class ProvFInstances {
     new Traverse[ProvF[D, I, ?]] {
       val O = Optics[D, I]
 
-      def traverseImpl[F[_]: Applicative, A, B](p: ProvF[D, I, A])(f: A => F[B]) =
+      def traverseImpl[F[_]: Applicative, A, B](p: ProvF[D, I, A])(g: A => F[B]) =
         p match {
-          case Nada() => O.nada[B]().point[F]
           case Fresh() => O.fresh[B]().point[F]
           case PrjPath(d) => O.prjPath[B](d).point[F]
           case PrjValue(d) => O.prjValue[B](d).point[F]
           case InjValue(d) => O.injValue[B](d).point[F]
           case Value(i) => O.value[B](i).point[F]
-          case Both(l, r) => f(l).tuple(f(r)).map(O.both(_))
-          case OneOf(l, r) => f(l).tuple(f(r)).map(O.oneOf(_))
-          case Then(l, r) => f(l).tuple(f(r)).map(O.thenn(_))
+          case Both(l, r) => g(l).tuple(g(r)).map(O.both(_))
+          case Then(f, s) => g(f).tuple(g(s)).map(O.thenn(_))
         }
     }
 
@@ -126,15 +110,13 @@ sealed abstract class ProvFInstances {
       def apply[A](show: Show[A]) = {
         implicit val showA = show
         Show.show {
-          case Nada() => Cord("∅")
           case Fresh() => Cord("∃")
-          case PrjPath(d) => d.show ++ Cord("/")
-          case PrjValue(d) => Cord("prj[") ++ d.show ++ Cord("]")
-          case InjValue(d) => Cord("inj[") ++ d.show ++ Cord("]")
+          case PrjPath(d) => Cord("\\") ++ d.show
+          case PrjValue(d) => Cord("prj{") ++ d.show ++ Cord("}")
+          case InjValue(d) => Cord("inj{") ++ d.show ++ Cord("}")
           case Value(i) => i.show
-          case Both(l, r) => Cord("(") ++ l.show ++ Cord(") /\\\\ (") ++ r.show ++ Cord(")")
-          case OneOf(l, r) => Cord("(") ++ l.show ++ Cord(") \\// (") ++ r.show ++ Cord(")")
-          case Then(l, r) => Cord("(") ++ l.show ++ Cord(") << (") ++ r.show ++ Cord(")")
+          case Both(l, r) => Cord("(") ++ l.show ++ Cord(" ∧ ") ++ r.show ++ Cord(")")
+          case Then(f, s) => f.show ++ Cord(" ≺ ") ++ s.show
         }
       }
     }

--- a/qscript/src/main/scala/quasar/qscript/provenance/package.scala
+++ b/qscript/src/main/scala/quasar/qscript/provenance/package.scala
@@ -18,11 +18,9 @@ package quasar.qscript
 
 import quasar.contrib.scalaz.foldable._
 
-import scalaz.{Equal, Foldable, IList, Tag, @@}
+import scalaz.{Equal, Foldable, Tag, @@}
 
 package object provenance {
-  type Dimensions[P] = IList[P]
-
   sealed trait AsSet
   val AsSet = Tag.of[AsSet]
 

--- a/qscript/src/test/scala/quasar/qscript/provenance/DimensionSpec.scala
+++ b/qscript/src/test/scala/quasar/qscript/provenance/DimensionSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript.provenance
+
+import slamdata.Predef.{Char, Int}
+import quasar.Qspec
+
+import matryoshka.data.Fix
+import scalaz.{IList, NonEmptyList}
+import scalaz.std.anyVal._
+
+object DimensionSpec extends Qspec {
+  val P = Prov[Char, Int, Fix[ProvF[Char, Int, ?]]]
+  val D = Dimension(P)
+
+  "autojoin keys" >> {
+    "builds join keys from zipped dimensions" >> {
+      val x = D.lshift(1, D.lshift(2, D.projectPath('a', D.empty)))
+      val y = D.lshift(3, D.lshift(4, D.projectPath('a', D.empty)))
+
+      val jks = JoinKeys(IList(NonEmptyList(JoinKey(1, 3)), NonEmptyList(JoinKey(2, 4))))
+
+      D.autojoinKeys(x, y) must_= jks
+    }
+
+    "does not include keys for dimensions after a partial join" >> {
+      val x = D.lshift(3, D.flatten(2, D.lshift(1, D.projectPath('a', D.empty))))
+      val y = D.lshift(9, D.lshift(8, D.lshift(7, D.projectPath('a', D.empty))))
+
+      val jks = JoinKeys(IList(NonEmptyList(JoinKey(1, 7))))
+
+      D.autojoinKeys(x, y) must_= jks
+    }
+
+    "does not include keys for dimensions after mismatched projection" >> {
+      val x = D.lshift(3, D.projectStatic('k', D.lshift(1, D.projectPath('a', D.empty))))
+      val y = D.lshift(9, D.lshift(7, D.projectPath('a', D.empty)))
+
+      val jks = JoinKeys(IList(NonEmptyList(JoinKey(1, 7))))
+
+      D.autojoinKeys(x, y) must_= jks
+    }
+
+    "does not include keys after a mismatch" >> {
+      val x = D.lshift(2, D.flatten(1, D.projectPath('b', D.projectPath('a', D.empty))))
+      val y = D.lshift(8, D.flatten(7, D.projectPath('c', D.projectPath('a', D.empty))))
+
+      D.autojoinKeys(x, y) must_= JoinKeys.empty
+    }
+  }
+}

--- a/qscript/src/test/scala/quasar/qscript/provenance/DimensionsGenerator.scala
+++ b/qscript/src/test/scala/quasar/qscript/provenance/DimensionsGenerator.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript.provenance
+
+import quasar.pkg.tests._
+
+import scalaz.{Equal, IList, NonEmptyList}
+
+trait DimensionsGenerator {
+  implicit def arbitraryDimensions[A: Arbitrary: Equal]: Arbitrary[Dimensions[A]] =
+    Arbitrary(for {
+      unionSize <- Gen.choose(0, 10)
+      union <- Gen.listOfN(unionSize, genJoin[A])
+    } yield Dimensions.normalize(Dimensions(IList.fromList(union))))
+
+  private def genJoin[A: Arbitrary]: Gen[NonEmptyList[A]] =
+    for {
+      size <- Gen.choose(0, 9)
+      h <- arbitrary[A]
+      t <- Gen.listOfN(size, arbitrary[A])
+    } yield NonEmptyList.nel(h, IList.fromList(t))
+}
+
+object DimensionsGenerator extends DimensionsGenerator

--- a/qscript/src/test/scala/quasar/qscript/provenance/DimensionsSpec.scala
+++ b/qscript/src/test/scala/quasar/qscript/provenance/DimensionsSpec.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript.provenance
+
+import slamdata.Predef.Boolean
+import quasar.Qspec
+import DimensionsGenerator._
+
+import scala.Predef.implicitly
+
+import org.scalacheck.{Arbitrary, Properties}
+import scalaz.{@@, Equal, SemiLattice, Show}
+import scalaz.Tags.{Conjunction, Disjunction}
+import scalaz.scalacheck.ScalazProperties.{equal => eql, monoid, traverse}
+import scalaz.std.anyVal._
+import scalaz.syntax.tag._
+import scalaz.syntax.std.boolean._
+
+final class DimensionsSpec extends Qspec {
+  import DimensionsSpec._
+
+  "union is idempotent" >> prop { d: Dimensions[Boolean] =>
+    (d ∨ d) must_= d
+  }
+
+  "union is commutative" >> prop { (l: Dimensions[Boolean], r: Dimensions[Boolean]) =>
+    (l ∨ r) must_= (r ∨ l)
+  }
+
+  "join is commutative" >> prop { (l: Dimensions[Boolean @@ Conjunction], r: Dimensions[Boolean @@ Conjunction]) =>
+    (l ∧ r) must_= (r ∧ l)
+  }
+
+  "laws" >> addFragments(properties {
+    val p = new Properties("scalaz")
+
+    p.include(eql.laws[Dimensions[Boolean]])
+
+    p.include(
+      monoid.laws[Dimensions[Boolean] @@ Disjunction](
+        Dimensions.disjMonoid[Boolean], implicitly, implicitly),
+      "union.")
+
+    p.include(
+      monoid.laws[Dimensions[Boolean @@ Conjunction] @@ Conjunction](
+        Dimensions.conjMonoid[Boolean @@ Conjunction], implicitly, implicitly),
+      "join.")
+
+    p.include(traverse.laws[Dimensions])
+
+    p
+  })
+}
+
+object DimensionsSpec {
+  implicit val andSemiLattice: SemiLattice[Boolean @@ Conjunction] =
+    new SemiLattice[Boolean @@ Conjunction] {
+      def append(l: Boolean @@ Conjunction, r: => Boolean @@ Conjunction) =
+        (l.unwrap && r.unwrap).conjunction
+    }
+
+  implicit val boolConjEqual: Equal[Boolean @@ Conjunction] =
+    Conjunction.subst(Equal[Boolean])
+
+  implicit val boolConjShow: Show[Boolean @@ Conjunction] =
+    Conjunction.subst(Show[Boolean])
+
+  implicit val boolConjArbitrary: Arbitrary[Boolean @@ Conjunction] =
+    Conjunction.subst(implicitly[Arbitrary[Boolean]])
+
+  implicit def dimsConjEqual[A: Equal]: Equal[Dimensions[A] @@ Conjunction] =
+    Conjunction.subst(Equal[Dimensions[A]])
+
+  implicit def dimsConjShow[A: Show]: Show[Dimensions[A] @@ Conjunction] =
+    Conjunction.subst(Show[Dimensions[A]])
+
+  implicit def dimsConjArbitrary[A: Arbitrary: Equal]: Arbitrary[Dimensions[A] @@ Conjunction] =
+    Conjunction.subst(implicitly[Arbitrary[Dimensions[A]]])
+
+  implicit def dimsDisjEqual[A: Equal]: Equal[Dimensions[A] @@ Disjunction] =
+    Disjunction.subst(Equal[Dimensions[A]])
+
+  implicit def dimsDisjShow[A: Show]: Show[Dimensions[A] @@ Disjunction] =
+    Disjunction.subst(Show[Dimensions[A]])
+
+  implicit def dimsDisjArbitrary[A: Arbitrary: Equal]: Arbitrary[Dimensions[A] @@ Disjunction] =
+    Disjunction.subst(implicitly[Arbitrary[Dimensions[A]]])
+}

--- a/qscript/src/test/scala/quasar/qscript/provenance/ProvFGenerator.scala
+++ b/qscript/src/test/scala/quasar/qscript/provenance/ProvFGenerator.scala
@@ -32,7 +32,6 @@ trait ProvFGenerator {
 
       def leafGenerators[A] =
         NonEmptyList(
-          1 -> Gen.const(O.nada[A]()),
           2 -> Gen.delay(Gen.const(O.fresh[A]())),
           10 -> (arbitrary[D] ^^ (O.prjPath[A](_))),
           10 -> (arbitrary[D] ^^ (O.prjValue[A](_))),
@@ -42,7 +41,6 @@ trait ProvFGenerator {
       def branchGenerators[A: Arbitrary] =
         uniformly(
           arbitrary[(A, A)] ^^ (O.both[A](_)),
-          arbitrary[(A, A)] ^^ (O.oneOf[A](_)),
           arbitrary[(A, A)] ^^ (O.thenn[A](_)))
     }
 }

--- a/qscript/src/test/scala/quasar/qscript/provenance/ProvFGenerator.scala
+++ b/qscript/src/test/scala/quasar/qscript/provenance/ProvFGenerator.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript.provenance
+
+import slamdata.Predef._
+import quasar.contrib.matryoshka.PatternArbitrary
+import quasar.pkg.tests._
+
+import matryoshka.Delay
+import scalaz._
+
+trait ProvFGenerator {
+  import ProvF._
+
+  implicit def arbitraryProvF[D: Arbitrary, I: Arbitrary]: Delay[Arbitrary, ProvF[D, I, ?]] =
+    new PatternArbitrary[ProvF[D, I, ?]] {
+      val O = new Optics[D, I]
+
+      def leafGenerators[A] =
+        NonEmptyList(
+          1 -> Gen.const(O.nada[A]()),
+          2 -> Gen.delay(Gen.const(O.fresh[A]())),
+          10 -> (arbitrary[D] ^^ (O.prjPath[A](_))),
+          10 -> (arbitrary[D] ^^ (O.prjValue[A](_))),
+          10 -> (arbitrary[D] ^^ (O.injValue[A](_))),
+          10 -> (arbitrary[I] ^^ (O.value[A](_))))
+
+      def branchGenerators[A: Arbitrary] =
+        uniformly(
+          arbitrary[(A, A)] ^^ (O.both[A](_)),
+          arbitrary[(A, A)] ^^ (O.oneOf[A](_)),
+          arbitrary[(A, A)] ^^ (O.thenn[A](_)))
+    }
+}
+
+object ProvFGenerator extends ProvFGenerator

--- a/qscript/src/test/scala/quasar/qscript/provenance/ProvSpec.scala
+++ b/qscript/src/test/scala/quasar/qscript/provenance/ProvSpec.scala
@@ -16,22 +16,33 @@
 
 package quasar.qscript.provenance
 
-import slamdata.Predef.{Char, Int}
+import slamdata.Predef.{Boolean, Char, Int}
+import quasar.contrib.matryoshka.arbitrary._
 import quasar.Qspec
 
 import matryoshka.data.Fix
-import scalaz.{IList, NonEmptyList}
+import org.specs2.scalacheck._
+import scalaz.{IList, NonEmptyList, Writer}
 import scalaz.std.anyVal._
+import scalaz.std.tuple._
+import scalaz.syntax.equal._
 
-object ProvSpec extends Qspec {
+object ProvSpec extends Qspec with ProvFGenerator {
+
+  implicit val params = Parameters(maxSize = 10)
 
   val P = Prov[Char, Int, Fix[ProvF[Char, Int, ?]]]
 
-  val p1 = P.proj('x')
-  val p1i = 'x'.toInt
+  import P.provenanceEqual
 
-  val p2 = P.proj('y')
-  val p2i = 'y'.toInt
+  val p1 = P.prjPath('x')
+  val p2 = P.prjPath('y')
+
+  val pk1 = P.prjValue('a')
+  val pk2 = P.prjValue('b')
+
+  val ik1 = P.injValue('a')
+  val ik2 = P.injValue('b')
 
   val v1i = 1
   val v1 = P.value(v1i)
@@ -42,103 +53,196 @@ object ProvSpec extends Qspec {
   val v4i = 4
   val v4 = P.value(v4i)
 
-  "provenance" should {
-    "join keys" >> {
-      "p1 θ p2" >> {
-        P.joinKeys(p1, p2) must_= JoinKeys.empty
-      }
+  def autojoined(a: Fix[P.PF], b: Fix[P.PF]): (JoinKeys[Int], Boolean) =
+    P.autojoined[Writer[JoinKeys[Int], ?]](a, b).run
 
-      "value θ proj" >> {
-        P.joinKeys(v1, p1) must_= JoinKeys.empty
-      }
+  "normalization" >> {
+    "right assoc boths" >> {
+      val tree = P.both(P.both(p1, pk1), P.both(p2, pk2))
+      val exp = P.both(p1, P.both(pk1, P.both(p2, pk2)))
 
-      "value θ value" >> {
-        P.joinKeys(v1, v2) must_=
-          JoinKeys.singleton(v1i, v2i)
-      }
+      P.normalize(tree) must_= exp
+    }
 
-      "(v1 /\\\\ v2) θ v3" >> {
-        P.joinKeys(P.both(v1, v2), v3) must_=
-          JoinKeys(IList(NonEmptyList(
-            JoinKey(v1i, v3i)
-          , JoinKey(v2i, v3i))))
-      }
+    "distinct both" >> {
+      val dupes = P.both(P.both(p1, pk2), P.both(P.both(pk2, p2), p1))
+      val exp = P.both(p1, P.both(pk2, p2))
 
-      "(v1 /\\\\ v2) θ (v3 /\\\\ v4)" >> {
-        P.joinKeys(P.both(v1, v2), P.both(v3, v4)) must_=
-          JoinKeys(IList(NonEmptyList(
-            JoinKey(v1i, v3i)
-          , JoinKey(v1i, v4i)
-          , JoinKey(v2i, v3i)
-          , JoinKey(v2i, v4i))))
-      }
+      P.normalize(dupes) must_= exp
+    }
 
-      "(v1 /\\\\ v2) θ (v3 \\// v4)" >> {
-        P.joinKeys(P.both(v1, v2), P.oneOf(v3, v4)) must_=
-          JoinKeys(IList(NonEmptyList(
-            JoinKey(v1i, v3i)
-          , JoinKey(v1i, v4i)
-          , JoinKey(v2i, v3i)
-          , JoinKey(v2i, v4i))))
-      }
+    "right assoc oneofs" >> {
+      val tree = P.oneOf(P.oneOf(p1, pk1), P.oneOf(p2, pk2))
+      val exp = P.oneOf(p1, P.oneOf(pk1, P.oneOf(p2, pk2)))
 
-      "(v1 /\\\\ v2) θ (v3 << v4)" >> {
-        P.joinKeys(P.both(v1, v2), P.thenn(v3, v4)) must_=
-          JoinKeys(IList(NonEmptyList(
-            JoinKey(v1i, v4i)
-          , JoinKey(v2i, v4i))))
-      }
+      P.normalize(tree) must_= exp
+    }
 
-      "(v2 << v1) θ v3" >> {
-        P.joinKeys(P.thenn(v2, v1), v3) must_=
-          JoinKeys.singleton(v1i, v3i)
-      }
+    "distinct oneOf" >> {
+      val dupes = P.oneOf(P.oneOf(p1, pk2), P.oneOf(P.oneOf(pk2, p2), p1))
+      val exp = P.oneOf(p1, P.oneOf(pk2, p2))
 
-      "(v2 << v1) θ (v4 << v3)" >> {
-        P.joinKeys(P.thenn(v2, v1), P.thenn(v4, v3)) must_=
-          JoinKeys(IList(
-            NonEmptyList(JoinKey(v1i, v3i))
-          , NonEmptyList(JoinKey(v2i, v4i))))
-      }
+      P.normalize(dupes) must_= exp
+    }
 
-      "(∅ \\// v2) θ v3" >> {
-        P.joinKeys(P.oneOf(P.nada(), v2), v3) must_=
-          JoinKeys.singleton(v2i, v3i)
-      }
+    "prj(k) << inj(k) << p == p" >> {
+      P.normalize(P.thenn(pk1, P.thenn(ik1, p1))) must_= p1
+    }
 
-      "(∅ \\// v2) θ (v3 \\// ∅)" >> {
-        P.joinKeys(P.oneOf(P.nada(), v2), P.oneOf(v3, P.nada())) must_=
-          JoinKeys.singleton(v2i, v3i)
-      }
+    "prj(k) << inj(k) /\\\\ p << q == (q /\\\\ (prj(k) << p << q))" >> {
+      val tree = P.thenn(pk1, P.thenn(P.both(ik1, p2), p1))
+      val exp = P.both(p1, P.thenn(pk1, P.thenn(p2, p1)))
 
-      "(v1 \\// v2) θ (v3 \\// v4)" >> {
-        P.joinKeys(P.oneOf(v1, v2), P.oneOf(v3, v4)) must_=
-          JoinKeys(IList(NonEmptyList(
-            JoinKey(v1i, v3i)
-          , JoinKey(v1i, v4i)
-          , JoinKey(v2i, v3i)
-          , JoinKey(v2i, v4i))))
-      }
+      P.normalize(tree) must_= exp
+    }
 
-      "(v1 \\// ∅) θ (v4 << v3)" >> {
-        P.joinKeys(P.oneOf(v1, P.nada()), P.thenn(v4, v3)) must_=
-          JoinKeys.singleton(v1i, v3i)
-      }
+    "prj(k) << inj(k) \\// p << q == (q \\// (prj(k) << p << q))" >> {
+      val tree = P.thenn(pk1, P.thenn(P.oneOf(ik1, p2), p1))
+      val exp = P.oneOf(p1, P.thenn(pk1, P.thenn(p2, p1)))
 
-      "((v1 /\\\\ v2) \\// v3) θ v4" >> {
-        P.joinKeys(P.oneOf(P.both(v1, v2), v3), v4) must_=
-          JoinKeys(IList(NonEmptyList(
-            JoinKey(v1i, v4i)
-          , JoinKey(v2i, v4i)
-          , JoinKey(v3i, v4i))))
-      }
+      P.normalize(tree) must_= exp
+    }
 
-      "((∅ \\// v2) /\\\\ v3) θ v4" >> {
-        P.joinKeys(P.both(P.oneOf(P.nada(), v2), v3), v4) must_=
-          JoinKeys(IList(NonEmptyList(
-            JoinKey(v2i, v4i)
-          , JoinKey(v3i, v4i))))
-      }
+    "prj(k) << inj(j) << q == ∅" >> prop { (k: Char, j: Char, p: Fix[P.PF]) => (k =/= j) ==> {
+      val tree = P.thenn(P.prjValue(k), P.thenn(P.injValue(j), p))
+      P.normalize(tree) must_= P.nada()
+    }}
+  }
+
+  "autojoined" >> {
+    "p1 θ p1" >> {
+      autojoined(p1, p1) must_= ((JoinKeys.empty, true))
+    }
+
+    "p1 θ p2" >> {
+      autojoined(p1, p2) must_= ((JoinKeys.empty, false))
+    }
+
+    "pk1 θ pk1" >> {
+      autojoined(pk1, pk1) must_= ((JoinKeys.empty, true))
+    }
+
+    "pk1 θ pk2" >> {
+      autojoined(pk1, pk2) must_= ((JoinKeys.empty, false))
+    }
+
+    "prjPath θ prjValue" >> {
+      autojoined(p1, pk1) must_= ((JoinKeys.empty, false))
+    }
+
+    "value θ prjPath" >> {
+      autojoined(v1, p1) must_= ((JoinKeys.empty, false))
+    }
+
+    "value θ prjValue" >> {
+      autojoined(v1, pk1) must_= ((JoinKeys.empty, false))
+    }
+
+    "value θ value" >> {
+      autojoined(v1, v2) must_= ((JoinKeys.singleton(v1i, v2i), true))
+    }
+
+    "(v1 /\\\\ v2) θ v3" >> {
+      val keys =
+        JoinKeys(IList(NonEmptyList(
+          JoinKey(v1i, v3i),
+          JoinKey(v2i, v3i))))
+
+      autojoined(P.both(v1, v2), v3) must_= ((keys, true))
+    }
+
+    "(v1 /\\\\ v2) θ (v3 /\\\\ v4)" >> {
+      val keys =
+        JoinKeys(IList(NonEmptyList(
+          JoinKey(v1i, v3i),
+          JoinKey(v1i, v4i),
+          JoinKey(v2i, v3i),
+          JoinKey(v2i, v4i))))
+
+      autojoined(P.both(v1, v2), P.both(v3, v4)) must_= ((keys, true))
+    }
+
+    "(v1 /\\\\ v2) θ (v3 \\// v4)" >> {
+      val keys =
+        JoinKeys(IList(NonEmptyList(
+          JoinKey(v1i, v3i),
+          JoinKey(v1i, v4i),
+          JoinKey(v2i, v3i),
+          JoinKey(v2i, v4i))))
+
+      autojoined(P.both(v1, v2), P.oneOf(v3, v4)) must_= ((keys, true))
+    }
+
+    "(v1 /\\\\ v2) θ (v3 << v4)" >> {
+      val keys =
+        JoinKeys(IList(NonEmptyList(
+          JoinKey(v1i, v4i),
+          JoinKey(v2i, v4i))))
+
+      autojoined(P.both(v1, v2), P.thenn(v3, v4)) must_= ((keys, false))
+    }
+
+    "(v2 << v1) θ v3" >> {
+      autojoined(P.thenn(v2, v1), v3) must_= ((JoinKeys.singleton(v1i, v3i), false))
+    }
+
+    "(v2 << v1) θ (v4 << v3)" >> {
+      val keys =
+        JoinKeys(IList(
+          NonEmptyList(JoinKey(v1i, v3i)),
+          NonEmptyList(JoinKey(v2i, v4i))))
+
+      autojoined(P.thenn(v2, v1), P.thenn(v4, v3)) must_= ((keys, true))
+    }
+
+    "(pk1 << v1) θ (pk1 << v3)" >> {
+      autojoined(P.thenn(pk1, v1), P.thenn(pk1, v3)) must_= ((JoinKeys.singleton(v1i, v3i), true))
+    }
+
+    "(pk1 << v1) θ (pk2 << v3)" >> {
+      autojoined(P.thenn(pk1, v1), P.thenn(pk2, v3)) must_= ((JoinKeys.singleton(v1i, v3i), false))
+    }
+
+    "(∅ \\// v2) θ v3" >> {
+      autojoined(P.oneOf(P.nada(), v2), v3) must_= ((JoinKeys.singleton(v2i, v3i), true))
+    }
+
+    "(∅ \\// v2) θ (v3 \\// ∅)" >> {
+      autojoined(P.oneOf(P.nada(), v2), P.oneOf(v3, P.nada())) must_= ((JoinKeys.singleton(v2i, v3i), true))
+    }
+
+    "(v1 \\// v2) θ (v3 \\// v4)" >> {
+      val keys =
+        JoinKeys(IList(NonEmptyList(
+          JoinKey(v1i, v3i),
+          JoinKey(v1i, v4i),
+          JoinKey(v2i, v3i),
+          JoinKey(v2i, v4i))))
+
+      autojoined(P.oneOf(v1, v2), P.oneOf(v3, v4)) must_= ((keys, true))
+    }
+
+    "(v1 \\// ∅) θ (v4 << v3)" >> {
+      autojoined(P.oneOf(v1, P.nada()), P.thenn(v4, v3)) must_= ((JoinKeys.singleton(v1i, v3i), false))
+    }
+
+    "((v1 /\\\\ v2) \\// v3) θ v4" >> {
+      val keys =
+        JoinKeys(IList(NonEmptyList(
+          JoinKey(v1i, v4i),
+          JoinKey(v2i, v4i),
+          JoinKey(v3i, v4i))))
+
+      autojoined(P.oneOf(P.both(v1, v2), v3), v4) must_= ((keys, true))
+    }
+
+    "((∅ \\// v2) /\\\\ v3) θ v4" >> {
+      val keys =
+        JoinKeys(IList(NonEmptyList(
+          JoinKey(v2i, v4i),
+          JoinKey(v3i, v4i))))
+
+      autojoined(P.both(P.oneOf(P.nada(), v2), v3), v4) must_= ((keys, true))
     }
   }
 }

--- a/qscript/src/test/scala/quasar/qscript/provenance/ProvSpec.scala
+++ b/qscript/src/test/scala/quasar/qscript/provenance/ProvSpec.scala
@@ -25,7 +25,7 @@ import scalaz.std.anyVal._
 
 object ProvSpec extends Qspec {
 
-  val P = Prov[Char, Int, Fix[ProvF[Char, Int, ?]]](_.toInt)
+  val P = Prov[Char, Int, Fix[ProvF[Char, Int, ?]]]
 
   val p1 = P.proj('x')
   val p1i = 'x'.toInt
@@ -49,8 +49,7 @@ object ProvSpec extends Qspec {
       }
 
       "value θ proj" >> {
-        P.joinKeys(v1, p1) must_=
-          JoinKeys.singleton(v1i, p1i)
+        P.joinKeys(v1, p1) must_= JoinKeys.empty
       }
 
       "value θ value" >> {

--- a/qsu/src/main/scala/quasar/qsu/ApplyProvenance.scala
+++ b/qsu/src/main/scala/quasar/qsu/ApplyProvenance.scala
@@ -276,7 +276,7 @@ object ApplyProvenance {
         Cord("AuthenticatedQSU {\n") ++
         g.show ++
         Cord("\n\n") ++
-        d.show ++
+        d.filterVertices(g.foldMapDown(sg => Set(sg.root))).show ++
         Cord("\n}")
       }
   }

--- a/qsu/src/main/scala/quasar/qsu/ApplyProvenance.scala
+++ b/qsu/src/main/scala/quasar/qsu/ApplyProvenance.scala
@@ -18,28 +18,41 @@ package quasar.qsu
 
 import slamdata.Predef._
 
+import quasar.contrib.matryoshka.ginterpret
 import quasar.contrib.scalaz.MonadState_
 import quasar.ejson
 import quasar.ejson.EJson
 import quasar.ejson.implicits._
 import quasar.fp._
 import quasar.contrib.iota._
-import quasar.fp.ski.ι
+import quasar.fp.ski.{ι, κ}
 import quasar.qscript.{
   construction,
   ExcludeId,
+  ExtractFunc,
   IdOnly,
   IdStatus,
-  OnUndefined,
+  IncludeId,
+  LeftSide,
+  RightSide,
+  LeftSide3,
+  Center,
+  RightSide3,
+  MapFuncsCore,
+  MapFuncsDerived,
+  MFC,
+  MFD,
   MonadPlannerErr,
+  OnUndefined,
   PlannerError
 }
 
 import matryoshka._
+import matryoshka.data.free._
 import matryoshka.implicits._
 import monocle.macros.Lenses
 import pathy.Path
-import scalaz.{Applicative, Cord, Functor, IList, Monad, Show, StateT, ValidationNel}
+import scalaz.{-\/, \/-, Applicative, Cord, Functor, IList, Monad, Show, StateT, ValidationNel}
 import scalaz.Scalaz._
 
 final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT: ShowT] private () extends QSUTTypes[T] {
@@ -92,16 +105,30 @@ final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT: ShowT] private () ext
         PlannerError.InternalError(s"Encountered unexpected $flattened.", None))
 
     g.unfold match {
-      case AutoJoin2(left, right, _) =>
-        compute2[F](g, left, right)(dims.join(_, _))
-
-      case AutoJoin3(left, center, right, _) =>
-        compute3[F](g, left, center, right) { (l, c, r) =>
-          dims.join(dims.join(l, c), r)
+      case AutoJoin2(left, right, combine) =>
+        compute2[F](g, left, right) { (l, r) =>
+          computeFuncProvenance(combine) {
+            case LeftSide => l
+            case RightSide => r
+          } getOrElse dims.join(l, r)
         }
 
-      case QSAutoJoin(left, right, _, _) =>
-        compute2[F](g, left, right)(dims.join(_, _))
+      case AutoJoin3(left, center, right, combine) =>
+        compute3[F](g, left, center, right) { (l, c, r) =>
+          computeFuncProvenance(combine) {
+            case LeftSide3 => l
+            case Center => c
+            case RightSide3 => r
+          } getOrElse dims.join(l, dims.join(c, r))
+        }
+
+      case QSAutoJoin(left, right, _, combine) =>
+        compute2[F](g, left, right) { (l, r) =>
+          computeFuncProvenance(combine) {
+            case LeftSide => l
+            case RightSide => r
+          } getOrElse dims.join(l, r)
+        }
 
       case DimEdit(src, DTrans.Squash()) =>
         compute1[F](g, src)(dims.squash)
@@ -131,25 +158,53 @@ final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT: ShowT] private () ext
 
       case JoinSideRef(_) => unexpectedError
 
-      case LeftShift(src, _, _, _, _, rot) =>
+      case LeftShift(src, struct, idStatus, _, repair, rot) =>
         val tid = IdAccess.identity(g.root)
         compute1[F](g, src) { sdims =>
-          rot match {
-            case Rotation.ShiftMap   | Rotation.ShiftArray   => dims.lshift(tid, sdims)
-            case Rotation.FlattenMap | Rotation.FlattenArray => dims.flatten(tid, sdims)
-          }
+          val structDims =
+            computeFuncProvenance(struct.linearize)(κ(sdims)).getOrElse(sdims)
+
+          val lsDims = applyIdStatus(idStatus, rot match {
+            case Rotation.ShiftMap | Rotation.ShiftArray =>
+              dims.lshift(tid, structDims)
+
+            case Rotation.FlattenMap | Rotation.FlattenArray =>
+              dims.flatten(tid, structDims)
+          })
+
+          computeFuncProvenance(repair) {
+            case ShiftTarget.LeftTarget => sdims
+            case ShiftTarget.RightTarget => lsDims
+            case ShiftTarget.AccessLeftTarget(_) => dims.empty
+          } getOrElse lsDims
         }
 
-        case MultiLeftShift(src, shifts, _, _) =>
-          val tid = IdAccess.identity(g.root)
-          compute1[F](g, src) { sdims =>
-            IList.fromList(shifts).sortBy(_._3).foldRight(sdims) {
-              case (shift, prv) => shift._3 match {
-                case Rotation.ShiftMap   | Rotation.ShiftArray   => dims.lshift(tid, prv)
-                case Rotation.FlattenMap | Rotation.FlattenArray => dims.flatten(tid, prv)
-              }
-            }
+      case MultiLeftShift(src, shifts, _, repair) =>
+        val tid = IdAccess.identity(g.root)
+        compute1[F](g, src) { sdims =>
+          val shiftDims = shifts map {
+            case (struct, idStatus, rot) =>
+              val structDims =
+                computeFuncProvenance(struct)(κ(sdims)) getOrElse sdims
+
+              applyIdStatus(idStatus, rot match {
+                case Rotation.ShiftMap | Rotation.ShiftArray =>
+                  dims.lshift(tid, structDims)
+
+                case Rotation.FlattenMap | Rotation.FlattenArray =>
+                  dims.flatten(tid, structDims)
+              })
           }
+
+          val repairDims =
+            computeFuncProvenance(repair) {
+              case -\/(Access.Value(_)) => sdims
+              case \/-(i) => shiftDims(i)
+              case _ => dims.empty
+            }
+
+          repairDims orElse shiftDims.foldRight1Opt(dims.join(_, _)) getOrElse sdims
+        }
 
       case LPFilter(_, _) => unexpectedError
 
@@ -165,9 +220,10 @@ final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT: ShowT] private () ext
       case QSFilter(src, _) =>
         compute1[F](g, src)(ι)
 
-      case QSReduce(src, _, _, _) =>
+      case QSReduce(src, _, _, repair) =>
         compute1[F](g, src) { sdims =>
-          dims.bucketAccess(g.root, dims.reduce(sdims))
+          val rdims = dims.bucketAccess(g.root, dims.reduce(sdims))
+          computeFuncProvenance(repair)(κ(rdims)) getOrElse rdims
         }
 
       case QSSort(src, _, _) =>
@@ -175,25 +231,35 @@ final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT: ShowT] private () ext
 
       case Unary(_, _) => unexpectedError
 
-      case Map(src, _) =>
-        compute1[F](g, src)(ι)
+      case Map(src, fm) =>
+        compute1[F](g, src) { sdims =>
+          computeFuncProvenance(fm.linearize)(κ(sdims)) getOrElse sdims
+        }
 
       case Read(file) =>
-        val rdims = dims.squash(segments(file).map(projStr).reverse)
+        val rdims = dims.squash(segments(file).map(projPathSegment).reverse)
         QAuthS[F].modify(_.addDims(g.root, rdims)) as rdims
 
       case Subset(from, _, count) =>
         compute2[F](g, from, count)(dims.join(_, _))
 
-      case ThetaJoin(left, right, _, _, _) =>
-        compute2[F](g, left, right)(dims.join(_, _))
+      case ThetaJoin(left, right, _, _, combine) =>
+        compute2[F](g, left, right) { (l, r) =>
+          computeFuncProvenance(combine) {
+            case LeftSide => l
+            case RightSide => r
+          } getOrElse dims.join(l, r)
+        }
 
       case Transpose(src, _, rot) =>
         val tid = IdAccess.identity(g.root)
         compute1[F](g, src) { sdims =>
           rot match {
-            case Rotation.ShiftMap   | Rotation.ShiftArray   => dims.lshift(tid, sdims)
-            case Rotation.FlattenMap | Rotation.FlattenArray => dims.flatten(tid, sdims)
+            case Rotation.ShiftMap | Rotation.ShiftArray =>
+              dims.lshift(tid, sdims)
+
+            case Rotation.FlattenMap | Rotation.FlattenArray =>
+              dims.flatten(tid, sdims)
           }
         }
 
@@ -203,6 +269,68 @@ final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT: ShowT] private () ext
       case Unreferenced() =>
         QAuthS[F].modify(_.addDims(g.root, dims.empty)) as dims.empty
     }
+  }
+
+  def computeFuncProvenance[A](fm: FreeMapA[A])(f: A => QDims): Option[QDims] =
+    some(fm.para(ginterpret(f, computeFuncProvenanceƒ[A]))).filter(_.nonEmpty)
+
+  def computeFuncProvenanceƒ[A]: GAlgebra[(FreeMapA[A], ?), MapFunc, QDims] = {
+    case MFC(MapFuncsCore.ConcatArrays((_, l), (_, r))) =>
+      // FIXME: Shift rhs indices by max on lhs
+      dims.join(l, r)
+
+    case MFC(MapFuncsCore.ConcatMaps((_, l), (_, r))) =>
+      dims.join(l, r)
+
+    case MFC(MapFuncsCore.Cond(_, (_, d), (ExtractFunc(MapFuncsCore.Undefined()), _))) =>
+      d
+
+    case MFC(MapFuncsCore.Cond(_, (ExtractFunc(MapFuncsCore.Undefined()), _), (_, d))) =>
+      d
+
+    case MFC(MapFuncsCore.Cond(_, (_, t), (_, f))) =>
+      dims.union(t, f)
+
+    case MFC(MapFuncsCore.DeleteKey((_, d), _)) =>
+      d
+
+    case MFC(MapFuncsCore.Guard(_, _, (_, d), (ExtractFunc(MapFuncsCore.Undefined()), _))) =>
+      d
+
+    case MFC(MapFuncsCore.Guard(_, _, (ExtractFunc(MapFuncsCore.Undefined()), _), (_, d))) =>
+      d
+
+    case MFC(MapFuncsCore.Guard(_, _, (_, a), (_, b))) =>
+      dims.union(a, b)
+
+    case MFC(MapFuncsCore.IfUndefined((_, d), _)) =>
+      d
+
+    case MFC(MapFuncsCore.MakeArray((_, d))) =>
+      dims.injectStatic(EJson.int[T[EJson]](0), d)
+
+    case MFC(MapFuncsCore.MakeMap((ExtractFunc(MapFuncsCore.Constant(k)), _), (_, v))) =>
+      dims.injectStatic(k, v)
+
+    case MFC(MapFuncsCore.MakeMap(_, (_, v))) =>
+      dims.injectDynamic(v)
+
+    case MFC(MapFuncsCore.ProjectIndex((_, a), (ExtractFunc(MapFuncsCore.Constant(i)), _))) =>
+      dims.projectStatic(i, a)
+
+    case MFC(MapFuncsCore.ProjectIndex((_, a), _)) =>
+      dims.projectDynamic(a)
+
+    case MFC(MapFuncsCore.ProjectKey((_, m), (ExtractFunc(MapFuncsCore.Constant(k)), _))) =>
+      dims.projectStatic(k, m)
+
+    case MFC(MapFuncsCore.ProjectKey((_, m), _)) =>
+      dims.projectDynamic(m)
+
+    case MFD(MapFuncsDerived.Typecheck((_, d), _)) =>
+      d
+
+    case _ => dims.empty
   }
 
   ////
@@ -243,8 +371,8 @@ final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT: ShowT] private () ext
       }
     }
 
-  private def projStr(s: String): QProv.P[T] =
-    dims.prov.proj(ejson.CommonEJson(ejson.Str[T[EJson]](s)).embed)
+  private def projPathSegment(s: String): QProv.P[T] =
+    dims.prov.prjPath(ejson.CommonEJson(ejson.Str[T[EJson]](s)).embed)
 
   private def segments(p: Path[_, _, _]): IList[String] = {
     val segs = Path.flatten[IList[String]](IList(), IList(), IList(), IList(_), IList(_), p)

--- a/qsu/src/main/scala/quasar/qsu/ApplyProvenance.scala
+++ b/qsu/src/main/scala/quasar/qsu/ApplyProvenance.scala
@@ -114,7 +114,7 @@ final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT: ShowT] private () ext
           })
 
           val nextIdx = dims.nextGroupKeyIndex(g.root, updated)
-          val idAccess = IdAccess.groupKey[dims.D](g.root, nextIdx)
+          val idAccess = IdAccess.groupKey(g.root, nextIdx)
           val nextDims = dims.swap(0, 1, dims.lshift(idAccess, updated))
 
           QAuthS[F].modify(
@@ -132,7 +132,7 @@ final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT: ShowT] private () ext
       case JoinSideRef(_) => unexpectedError
 
       case LeftShift(src, _, _, _, _, rot) =>
-        val tid = IdAccess.identity[dims.D](g.root)
+        val tid = IdAccess.identity(g.root)
         compute1[F](g, src) { sdims =>
           rot match {
             case Rotation.ShiftMap   | Rotation.ShiftArray   => dims.lshift(tid, sdims)
@@ -141,7 +141,7 @@ final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT: ShowT] private () ext
         }
 
         case MultiLeftShift(src, shifts, _, _) =>
-          val tid = IdAccess.identity[dims.D](g.root)
+          val tid = IdAccess.identity(g.root)
           compute1[F](g, src) { sdims =>
             IList.fromList(shifts).sortBy(_._3).foldRight(sdims) {
               case (shift, prv) => shift._3 match {
@@ -189,7 +189,7 @@ final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT: ShowT] private () ext
         compute2[F](g, left, right)(dims.join(_, _))
 
       case Transpose(src, _, rot) =>
-        val tid = IdAccess.identity[dims.D](g.root)
+        val tid = IdAccess.identity(g.root)
         compute1[F](g, src) { sdims =>
           rot match {
             case Rotation.ShiftMap   | Rotation.ShiftArray   => dims.lshift(tid, sdims)

--- a/qsu/src/main/scala/quasar/qsu/ApplyProvenance.scala
+++ b/qsu/src/main/scala/quasar/qsu/ApplyProvenance.scala
@@ -278,7 +278,7 @@ final class ApplyProvenance[T[_[_]]: BirecursiveT: EqualT: ShowT] private () ext
 
   def computeFuncProvenanceƒ[A]: GAlgebra[(FreeMapA[A], ?), MapFunc, QDims] = {
     case MFC(MapFuncsCore.ConcatArrays((_, l), (_, r))) =>
-      // FIXME: Shift rhs indices by max on lhs
+      // FIXME{ch1487}: Adjust rhs based on knowledge of lhs.
       dims.join(l, r)
 
     case MFC(MapFuncsCore.ConcatMaps((_, l), (_, r))) =>

--- a/qsu/src/main/scala/quasar/qsu/ExpandShifts.scala
+++ b/qsu/src/main/scala/quasar/qsu/ExpandShifts.scala
@@ -83,9 +83,9 @@ final class ExpandShifts[T[_[_]]: BirecursiveT: EqualT: ShowT] extends QSUTTypes
       val sortedShifts = IList.fromList(shifts).sortBy(_._3).toList
       val shiftedG = sortedShifts match {
         case (struct, idStatus, rotation) :: ss =>
-          val firstRepair: FreeMapA[QScriptUniform.ShiftTarget[T]] =
+          val firstRepair: FreeMapA[QScriptUniform.ShiftTarget] =
             func.StaticMapS(
-              "original" -> AccessLeftTarget[T](Access.valueHole(_)),
+              "original" -> AccessLeftTarget(Access.value(_)),
               "0" -> RightTarget
             )
           val firstShiftPat: QScriptUniform[Symbol] =
@@ -97,7 +97,7 @@ final class ExpandShifts[T[_[_]]: BirecursiveT: EqualT: ShowT] extends QSUTTypes
             shiftAndRotation <- ss.zipWithIndex.foldLeftM[G, (QSUGraph, Rotation)]((firstShift :++ mls, rotation)) {
               case ((shiftAbove, rotationAbove), ((newStruct, newIdStatus, newRotation), idx)) =>
                 val keysAbove = ("original" :: (0 to idx).map(_.toString).toList)
-                val staticAbove = func.StaticMapFS(keysAbove: _*)(func.ProjectKeyS(AccessLeftTarget[T](Access.valueHole(_)), _), s => s)
+                val staticAbove = func.StaticMapFS(keysAbove: _*)(func.ProjectKeyS(AccessLeftTarget[T](Access.value(_)), _), s => s)
 
                 val repair = func.ConcatMaps(staticAbove, func.MakeMapS((idx + 1).toString, RightTarget))
                 val struct = newStruct >> func.ProjectKeyS(func.Hole, originalKey)
@@ -111,10 +111,10 @@ final class ExpandShifts[T[_[_]]: BirecursiveT: EqualT: ShowT] extends QSUTTypes
                     func.Cond(
                       func.Or(
                         func.Eq(
-                          AccessLeftTarget[T](Access.id(IdAccess.identity[T[EJson]](shiftAbove.root), _)),
-                          AccessLeftTarget[T](Access.id(IdAccess.identity[T[EJson]](newShift.root), _))),
+                          AccessLeftTarget[T](Access.id(IdAccess.identity(shiftAbove.root), _)),
+                          AccessLeftTarget[T](Access.id(IdAccess.identity(newShift.root), _))),
                         func.IfUndefined(
-                          AccessLeftTarget[T](Access.id(IdAccess.identity[T[EJson]](newShift.root), _)),
+                          AccessLeftTarget[T](Access.id(IdAccess.identity(newShift.root), _)),
                           func.Constant(json.bool(true)))),
                       repair,
                       func.Undefined)

--- a/qsu/src/main/scala/quasar/qsu/ExpandShifts.scala
+++ b/qsu/src/main/scala/quasar/qsu/ExpandShifts.scala
@@ -133,7 +133,7 @@ final class ExpandShifts[T[_[_]]: BirecursiveT: EqualT: ShowT] extends QSUTTypes
       commonSrcDims <- dimsOf(commonRoot)
 
       structDim =
-        ApplyProvenance.computeFuncProvenance(struct)(κ(commonSrcDims))
+        ApplyProvenance.computeFuncDims(struct)(κ(commonSrcDims))
           .getOrElse(commonSrcDims)
 
       compatInfo <- MonadState_[G, CompatInfo].get
@@ -165,7 +165,7 @@ final class ExpandShifts[T[_[_]]: BirecursiveT: EqualT: ShowT] extends QSUTTypes
       // provenance for this shift on the common source.
       newDims <- sameFocus match {
         case Some((sym, _, _)) => dimsOf(sym)
-        case None => ApplyProvenance.computeProvenance[T, G](commonShift)
+        case None => ApplyProvenance.computeDims[T, G](commonShift)
       }
 
       joinDims =

--- a/qsu/src/main/scala/quasar/qsu/Graduate.scala
+++ b/qsu/src/main/scala/quasar/qsu/Graduate.scala
@@ -23,7 +23,6 @@ import quasar.common.JoinType
 import quasar.contrib.pathy.AFile
 import quasar.contrib.scalaz.MonadReader_
 import quasar.ejson.EJson
-import quasar.ejson.implicits._
 import quasar.fp._
 import quasar.contrib.iota._
 import quasar.fp.ski.κ
@@ -165,10 +164,10 @@ final class Graduate[T[_[_]]: BirecursiveT: ShowT] private () extends QSUTTypes[
       def holeAs(sym: Symbol): Hole => Symbol =
         κ(sym)
 
-      def resolveAccess[A, B](fa: FreeMapA[A])(ex: A => QAccess[B] \/ B)(f: B => Symbol): F[FreeMapA[B]] =
+      def resolveAccess[A, B](fa: FreeMapA[A])(ex: A => Access[B] \/ B)(f: B => Symbol): F[FreeMapA[B]] =
         MR.asks(_.resolveAccess[A, B](name, fa)(f)(ex))
 
-      def eqCond(lroot: Symbol, rroot: Symbol): JoinKey[QIdAccess] => F[JoinFunc] = {
+      def eqCond(lroot: Symbol, rroot: Symbol): JoinKey[IdAccess] => F[JoinFunc] = {
         case JoinKey(l, r) =>
           for {
             lside <- resolveAccess(func.Hole as Access.id(l, lroot))(_.left)(κ(lroot))
@@ -198,8 +197,8 @@ final class Graduate[T[_[_]]: BirecursiveT: ShowT] private () extends QSUTTypes[
             resolvedRepair <-
               resolveAccess(repair) {
                 case QSU.ShiftTarget.AccessLeftTarget(access) => access.map[JoinSide](_ => LeftSide).left
-                case QSU.ShiftTarget.LeftTarget() => (LeftSide: JoinSide).right
-                case QSU.ShiftTarget.RightTarget() => (RightSide: JoinSide).right
+                case QSU.ShiftTarget.LeftTarget => (LeftSide: JoinSide).right
+                case QSU.ShiftTarget.RightTarget => (RightSide: JoinSide).right
               }(κ(source.root))
 
             shiftType = rot match {
@@ -230,7 +229,7 @@ final class Graduate[T[_[_]]: BirecursiveT: ShowT] private () extends QSUTTypes[
 
         // TODO distinct should be its own node in qscript proper
         case QSU.Distinct(source) =>
-          resolveAccess(HoleF map (Access.value[T[EJson], Hole](_)))(_.left)(holeAs(source.root)) map { fm =>
+          resolveAccess(HoleF map (Access.value(_)))(_.left)(holeAs(source.root)) map { fm =>
             QCE(Reduce[T, QSUGraph](
               source,
               // Bucket by the value
@@ -247,7 +246,7 @@ final class Graduate[T[_[_]]: BirecursiveT: ShowT] private () extends QSUTTypes[
           val condition = joinKeys.keys.toNel.fold(func.Constant[JoinSide](EJson.bool(true)).point[F]) { jks =>
             val mkEq = eqCond(left.root, right.root)
 
-            val mkDisj = (_: NonEmptyList[JoinKey[QIdAccess]]).foldMapLeft1(mkEq) { (disj, k) =>
+            val mkDisj = (_: NonEmptyList[JoinKey[IdAccess]]).foldMapLeft1(mkEq) { (disj, k) =>
               (mkEq(k) |@| disj)(func.Or(_, _))
             }
 

--- a/qsu/src/main/scala/quasar/qsu/MinimizeAutoJoins.scala
+++ b/qsu/src/main/scala/quasar/qsu/MinimizeAutoJoins.scala
@@ -39,13 +39,13 @@ import quasar.qscript.{
   SrcHole
 }
 import quasar.qscript.RecFreeS._
+import quasar.qscript.provenance.Dimensions
 import quasar.qscript.rewrites.NormalizableT
 import quasar.qsu.{QScriptUniform => QSU}
 import quasar.qsu.ApplyProvenance.AuthenticatedQSU
 
 import matryoshka.{delayEqual, BirecursiveT, EqualT, ShowT}
 import monocle.Traversal
-import monocle.function.Each
 import monocle.std.option.{some => someP}
 import monocle.syntax.fields._1
 import scalaz.{Bind, Monad, OptionT, Scalaz, StateT}, Scalaz._   // sigh, monad/traverse conflict
@@ -104,10 +104,10 @@ final class MinimizeAutoJoins[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT]
       combiner: FreeMapA[Int]): G[Option[QSUGraph]] = {
 
     val groupKeyOf: Traversal[Option[QDims], Symbol] =
-      someP[QDims]           composeTraversal
-      Each.each[QDims, QP.P] composePrism
-      QP.prov.value          composePrism
-      IdAccess.groupKey      composeLens
+      someP[QDims] composeTraversal
+      Dimensions.dimension[QP.P] composePrism
+      QP.prov.value composePrism
+      IdAccess.groupKey composeLens
       _1
 
     for {

--- a/qsu/src/main/scala/quasar/qsu/QAuth.scala
+++ b/qsu/src/main/scala/quasar/qsu/QAuth.scala
@@ -109,7 +109,7 @@ sealed abstract class QAuthInstances {
     Monoid.instance(_ ++ _, QAuth.empty[T])
 
   implicit def equal[T[_[_]]: BirecursiveT: EqualT]: Equal[QAuth[T]] = {
-    implicit val eqP: Equal[QProv.P[T]] = QProv[T].prov.provenanceEqual
+    implicit val eqP: Equal[QProv.P[T]] = QProv[T].prov.implicits.provEqual
     Equal.equalBy(qa => (qa.dims, qa.groupKeys))
   }
 

--- a/qsu/src/main/scala/quasar/qsu/QAuth.scala
+++ b/qsu/src/main/scala/quasar/qsu/QAuth.scala
@@ -53,6 +53,9 @@ final case class QAuth[T[_[_]]](
     copy(groupKeys = groupKeys ++ tgtKeys)
   }
 
+  def filterVertices(p: Symbol => Boolean): QAuth[T] =
+    QAuth(dims.filterKeys(p), groupKeys.filterKeys { case (s, _) => p(s) })
+
   def lookupDims(vertex: Symbol): Option[QDims[T]] =
     dims get vertex
 

--- a/qsu/src/main/scala/quasar/qsu/QProv.scala
+++ b/qsu/src/main/scala/quasar/qsu/QProv.scala
@@ -29,18 +29,17 @@ import matryoshka.data._
 import scalaz.{Lens => _, _}, Scalaz._, Tags.MaxVal
 
 final class QProv[T[_[_]]: BirecursiveT: EqualT]
-    extends Dimension[T[EJson], IdAccess[T[EJson]], QProv.P[T]]
+    extends Dimension[T[EJson], IdAccess, QProv.P[T]]
     with QSUTTypes[T] {
 
   import QProv.BucketsState
 
   type D     = T[EJson]
-  type I     = IdAccess[D]
+  type I     = IdAccess
   type PF[A] = QProv.PF[T, A]
   type P     = QProv.P[T]
 
-  val prov: Prov[D, I, P] =
-    Prov[D, I, P](IdAccess.static(_))
+  val prov: Prov[D, I, P] = Prov[D, I, P]
 
   type BucketsM[F[_]] = MonadState_[F, BucketsState[I]]
   def BucketsM[F[_]](implicit ev: BucketsM[F]): BucketsM[F] = ev
@@ -63,7 +62,7 @@ final class QProv[T[_[_]]: BirecursiveT: EqualT]
           )) as s.nextIdx
         }
 
-        b = IdAccess.bucket[D](src, idx)
+        b = IdAccess.bucket(src, idx)
       } yield prov.value(b)
 
     case other =>
@@ -104,13 +103,13 @@ final class QProv[T[_[_]]: BirecursiveT: EqualT]
     def rename0(sym: Symbol): Symbol =
       (sym === from) ? to | sym
 
-    modifyIdentities(dims)(IdAccess.symbols[D].modify(rename0))
+    modifyIdentities(dims)(IdAccess.symbols.modify(rename0))
   }
 
   ////
 
   private val pfo = ProvF.Optics[D, I]
-  private val groupKey = prov.value composePrism IdAccess.groupKey[D]
+  private val groupKey = prov.value composePrism IdAccess.groupKey
 
   private def bucketedDims(src: Symbol, dims: Dimensions[P]): (I ==>> SInt, Dimensions[P]) =
     dims.reverse
@@ -121,7 +120,7 @@ final class QProv[T[_[_]]: BirecursiveT: EqualT]
 }
 
 object QProv {
-  type PF[T[_[_]], A] = ProvF[T[EJson], IdAccess[T[EJson]], A]
+  type PF[T[_[_]], A] = ProvF[T[EJson], IdAccess, A]
   type P[T[_[_]]]     = T[PF[T, ?]]
 
   final case class BucketsState[I](nextIdx: SInt, buckets: I ==>> SInt)

--- a/qsu/src/main/scala/quasar/qsu/QSUGraph.scala
+++ b/qsu/src/main/scala/quasar/qsu/QSUGraph.scala
@@ -480,14 +480,14 @@ object QSUGraph extends QSUGraphInstances {
     }
 
     object LeftShift {
-      def unapply[T[_[_]]](g: QSUGraph[T]): Option[(QSUGraph[T], RecFreeMap[T], IdStatus, OnUndefined, FreeMapA[T, QSU.ShiftTarget[T]], QSU.Rotation)] = g.unfold match {
+      def unapply[T[_[_]]](g: QSUGraph[T]): Option[(QSUGraph[T], RecFreeMap[T], IdStatus, OnUndefined, FreeMapA[T, QSU.ShiftTarget], QSU.Rotation)] = g.unfold match {
         case g: QSU.LeftShift[T, QSUGraph[T]] => QSU.LeftShift.unapply(g)
         case _ => None
       }
     }
 
     object MultiLeftShift {
-      def unapply[T[_[_]]](g: QSUGraph[T]): Option[(QSUGraph[T], List[(FreeMap[T], IdStatus, QSU.Rotation)], OnUndefined, FreeMapA[T, QAccess[T, Hole] \/ Int])] = g.unfold match {
+      def unapply[T[_[_]]](g: QSUGraph[T]): Option[(QSUGraph[T], List[(FreeMap[T], IdStatus, QSU.Rotation)], OnUndefined, FreeMapA[T, Access[Hole] \/ Int])] = g.unfold match {
         case g: QSU.MultiLeftShift[T, QSUGraph[T]] => QSU.MultiLeftShift.unapply(g)
         case _ => None
       }

--- a/qsu/src/main/scala/quasar/qsu/QSUTTypes.scala
+++ b/qsu/src/main/scala/quasar/qsu/QSUTTypes.scala
@@ -16,19 +16,16 @@
 
 package quasar.qsu
 
-import quasar.ejson.EJson
 import quasar.qscript.TTypes
 
 trait QSUTTypes[T[_[_]]] extends TTypes[T] {
   type QAuth = quasar.qsu.QAuth[T]
   type QDims = quasar.qsu.QDims[T]
-  type QIdAccess = quasar.qsu.QIdAccess[T]
-  type QAccess[A] = quasar.qsu.QAccess[T, A]
   type FreeAccess[A] = quasar.qsu.FreeAccess[T, A]
   type QSUGraph = quasar.qsu.QSUGraph[T]
   type RevIdx = quasar.qsu.QSUGraph.RevIdx[T]
   type RevIdxM[F[_]] = quasar.qsu.RevIdxM[T, F]
-  type References = quasar.qsu.References[T, T[EJson]]
+  type References = quasar.qsu.References[T]
   type QScriptUniform[A] = quasar.qsu.QScriptUniform[T, A]
   type QScriptEducated[A] = quasar.qscript.QScriptEducated[T, A]
 }

--- a/qsu/src/main/scala/quasar/qsu/QScriptUniform.scala
+++ b/qsu/src/main/scala/quasar/qsu/QScriptUniform.scala
@@ -425,6 +425,7 @@ object QScriptUniform {
   // horizontal composition of LeftShifts
   final case class MultiLeftShift[T[_[_]], A](
       source: A,
+      // TODO: NEL
       shifts: List[(FreeMap[T], IdStatus, Rotation)],
       onUndefined: OnUndefined,
       repair: FreeMapA[T, Access[Hole] \/ Int]) extends QScriptUniform[T, A]
@@ -438,6 +439,7 @@ object QScriptUniform {
   final case class QSReduce[T[_[_]], A](
       source: A,
       buckets: List[FreeMapA[T, Access[Hole]]],
+      // TODO: NEL
       reducers: List[ReduceFunc[FreeMap[T]]],
       repair: FreeMapA[T, ReduceIndex]) extends QScriptUniform[T, A]
 

--- a/qsu/src/main/scala/quasar/qsu/ReadLP.scala
+++ b/qsu/src/main/scala/quasar/qsu/ReadLP.scala
@@ -18,7 +18,6 @@ package quasar.qsu
 
 import slamdata.Predef.{Map => SMap, _}
 import quasar.{
-  ejson,
   BinaryFunc,
   Mapping,
   NullaryFunc,
@@ -254,17 +253,6 @@ final class ReadLP[T[_[_]]: BirecursiveT] private () extends QSUTTypes[T] {
       source <- withName[G](QSU.Unreferenced[T, Symbol]())
       back <- extend1[G](source)(QSU.Unary[T, Symbol](_, func))
     } yield back
-
-  private def projectConstIdx[G[_]: Monad: NameGenerator: MonadState_[?[_], RevIdx]](
-      idx: Int)(
-      parent: QSUGraph): G[QSUGraph] = {
-    val const: T[EJson] = ejson.ExtEJson(ejson.Int[T[EJson]](idx)).embed
-
-    for {
-      idxG <- nullary[G](IC(MapFuncsCore.Constant(const)))
-      back <- autoJoin2[G](parent, idxG)((p, i) => IC(MapFuncsCore.ProjectIndex[T, JoinSide](p, i)))
-    } yield back
-  }
 
   private def autoJoin2[G[_]: Monad: NameGenerator: MonadState_[?[_], RevIdx]](
       e1: QSUGraph, e2: QSUGraph)(

--- a/qsu/src/main/scala/quasar/qsu/References.scala
+++ b/qsu/src/main/scala/quasar/qsu/References.scala
@@ -25,7 +25,6 @@ import quasar.qscript.{FreeMap, FreeMapA}
 
 import matryoshka.{delayShow, delayEqual, equalTEqual, showTShow, BirecursiveT, ShowT, EqualT}
 import matryoshka.data._
-// import matryoshka.data.free._
 import scalaz.{\/, Cord, Equal, IMap, ISet, Monoid, Show}
 import scalaz.std.list._
 import scalaz.std.option._

--- a/qsu/src/main/scala/quasar/qsu/References.scala
+++ b/qsu/src/main/scala/quasar/qsu/References.scala
@@ -26,7 +26,7 @@ import quasar.qscript.{FreeMap, FreeMapA}
 import matryoshka.{delayShow, delayEqual, equalTEqual, showTShow, BirecursiveT, ShowT, EqualT}
 import matryoshka.data._
 // import matryoshka.data.free._
-import scalaz.{\/, Cord, Equal, IMap, ISet, Monoid, Order, Show}
+import scalaz.{\/, Cord, Equal, IMap, ISet, Monoid, Show}
 import scalaz.std.list._
 import scalaz.std.option._
 import scalaz.std.tuple._
@@ -36,19 +36,19 @@ import scalaz.syntax.std.option._
 import matryoshka.{Hole => _, _}
 import matryoshka.data._
 
-final case class References[T[_[_]], D](
-    accessing: References.Accessing[T, D],
-    accessed: References.Accessed[D]) {
+final case class References[T[_[_]]](
+    accessing: References.Accessing[T],
+    accessed: References.Accessed) {
 
-  def modifyAccess(of: Access[D, Symbol])(f: FreeMap[T] => FreeMap[T])(implicit D: Order[D]): References[T, D] =
+  def modifyAccess(of: Access[Symbol])(f: FreeMap[T] => FreeMap[T]): References[T] =
     modifySomeAccess(of, ISet.empty)(f)
 
-  def modifySomeAccess(of: Access[D, Symbol], except: ISet[Symbol])(f: FreeMap[T] => FreeMap[T])(implicit D: Order[D]): References[T, D] =
+  def modifySomeAccess(of: Access[Symbol], except: ISet[Symbol])(f: FreeMap[T] => FreeMap[T]): References[T] =
     accessed.lookup(of).fold(this) { syms =>
       copy(accessing = (syms \\ except).foldLeft(accessing)(_.adjust(_, _.adjust(of, f))))
     }
 
-  def recordAccess(by: Symbol, of: Access[D, Symbol], as: FreeMap[T])(implicit D: Order[D]): References[T, D] = {
+  def recordAccess(by: Symbol, of: Access[Symbol], as: FreeMap[T]): References[T] = {
     val accesses = IMap.singleton(of, as)
     val accessing1 = accessing.alter(by, _ map (_ union accesses) orElse some(accesses))
     val accessed1 = accessed |+| IMap.singleton(of, ISet singleton by)
@@ -56,7 +56,7 @@ final case class References[T[_[_]], D](
   }
 
   // Replace all accesses by `prev` with `next`.
-  def replaceAccess(prev: Symbol, next: Symbol)(implicit D: Order[D]): References[T, D] =
+  def replaceAccess(prev: Symbol, next: Symbol): References[T] =
     accessing.lookup(prev).fold(this) { accesses =>
       val nextAccessed = accesses.keySet.foldLeft(accessed) { (m, a) =>
         m.adjust(a, _.delete(prev).insert(next))
@@ -70,8 +70,7 @@ final case class References[T[_[_]], D](
   def resolveAccess[A, B]
     (by: Symbol, in: FreeMapA[T, A])
     (f: B => Symbol)
-    (ex: A => Access[D, B] \/ B)
-    (implicit D: Order[D])
+    (ex: A => Access[B] \/ B)
     : FreeMapA[T, B] =
       accessing.lookup(by).fold(in.map(a => ex(a).fold(Access.src.get(_), b => b))) { accesses =>
         in flatMap { a =>
@@ -87,27 +86,27 @@ final case class References[T[_[_]], D](
 
 object References {
   // How to access a given identity or value.
-  type Accesses[T[_[_]], D] = IMap[Access[D, Symbol], FreeMap[T]]
+  type Accesses[T[_[_]]] = IMap[Access[Symbol], FreeMap[T]]
   // Accesses by vertex.
-  type Accessing[T[_[_]], D] = IMap[Symbol, Accesses[T, D]]
+  type Accessing[T[_[_]]] = IMap[Symbol, Accesses[T]]
   // Vertices by access.
-  type Accessed[D] = IMap[Access[D, Symbol], ISet[Symbol]]
+  type Accessed = IMap[Access[Symbol], ISet[Symbol]]
 
-  def noRefs[T[_[_]], D]: References[T, D] =
+  def noRefs[T[_[_]]]: References[T] =
     References(IMap.empty, IMap.empty)
 
-  implicit def monoid[T[_[_]], D: Order]: Monoid[References[T, D]] =
+  implicit def monoid[T[_[_]]]: Monoid[References[T]] =
     Monoid.instance(
       (x, y) => References(
         x.accessing.unionWith(y.accessing)(_ union _),
         x.accessed |+| y.accessed),
       noRefs)
 
-  implicit def equal[T[_[_]]: BirecursiveT: EqualT, D: Equal]: Equal[References[T, D]] = {
+  implicit def equal[T[_[_]]: BirecursiveT: EqualT]: Equal[References[T]] = {
     Equal.equalBy(r => (r.accessing, r.accessed))
   }
 
-  implicit def show[T[_[_]]: ShowT, D: Show]: Show[References[T, D]] =
+  implicit def show[T[_[_]]: ShowT]: Show[References[T]] =
     Show.show {
       case References(accessing, accessed) =>
         Cord("References {\n\n") ++

--- a/qsu/src/main/scala/quasar/qsu/ReifyAutoJoins.scala
+++ b/qsu/src/main/scala/quasar/qsu/ReifyAutoJoins.scala
@@ -65,7 +65,7 @@ final class ReifyAutoJoins[T[_[_]]: BirecursiveT: EqualT] private () extends QSU
     case g @ AutoJoin2(left, right, combiner) =>
       val (l, r) = (left.root, right.root)
 
-      val keys: F[JoinKeys[QIdAccess]] =
+      val keys: F[JoinKeys[IdAccess]] =
         (auth.lookupDimsE[F](l) |@| auth.lookupDimsE[F](r))(prov.autojoinKeys(_, _))
 
       keys.map(ks =>
@@ -86,7 +86,7 @@ final class ReifyAutoJoins[T[_[_]]: BirecursiveT: EqualT] private () extends QSU
 
         case (joinName, lName, cName, ldims, cdims, rdims) =>
 
-          val lcKeys: JoinKeys[QIdAccess] =
+          val lcKeys: JoinKeys[IdAccess] =
             prov.autojoinKeys(ldims, cdims)
 
           def lcCombiner: JoinFunc =
@@ -112,7 +112,7 @@ final class ReifyAutoJoins[T[_[_]]: BirecursiveT: EqualT] private () extends QSU
           val lcDims: QDims =
             prov.join(ldims, cdims)
 
-          val keys: JoinKeys[QIdAccess] =
+          val keys: JoinKeys[IdAccess] =
             prov.autojoinKeys(lcDims, rdims)
 
           val lcName = Symbol(joinName)

--- a/qsu/src/main/scala/quasar/qsu/ReifyBuckets.scala
+++ b/qsu/src/main/scala/quasar/qsu/ReifyBuckets.scala
@@ -53,7 +53,7 @@ final class ReifyBuckets[T[_[_]]: BirecursiveT: EqualT: ShowT] private () extend
                 case (newSrc, original, reduceExpr) =>
                   val buckets =
                     buckets0.map(_ flatMap { access =>
-                      if (Access.valueHole.isEmpty(access))
+                      if (Access.value[Hole].isEmpty(access))
                         func.Hole as access
                       else
                         original as access
@@ -98,10 +98,10 @@ final class ReifyBuckets[T[_[_]]: BirecursiveT: EqualT: ShowT] private () extend
       res <- ids traverse {
         case id @ IdAccess.GroupKey(s, i) =>
           qauth.lookupGroupKeyE[F](s, i)
-            .map(fm => (ISet.singleton(s), fm as Access.value[prov.D, Hole](SrcHole)))
+            .map(fm => (ISet.singleton(s), fm as Access.value[Hole](SrcHole)))
 
         case other =>
-          (ISet.empty[Symbol], HoleF[T] as Access.id[prov.D, Hole](other, SrcHole)).point[F]
+          (ISet.empty[Symbol], HoleF[T] as Access.id[Hole](other, SrcHole)).point[F]
       }
     } yield res.unfzip leftMap (_.foldMap(ι))
 

--- a/qsu/src/main/scala/quasar/qsu/ReifyBuckets.scala
+++ b/qsu/src/main/scala/quasar/qsu/ReifyBuckets.scala
@@ -110,7 +110,7 @@ final class ReifyBuckets[T[_[_]]: BirecursiveT: EqualT: ShowT] private () extend
       : F[QSUGraph] =
     for {
       newGraph <- QSUGraph.withName[T, F]("rbu")(node)
-      _        <- ApplyProvenance.computeProvenance[T, F](newGraph)
+      _        <- ApplyProvenance.computeDims[T, F](newGraph)
     } yield newGraph
 
   private def mkReduce[A](

--- a/qsu/src/main/scala/quasar/qsu/ReifyIdentities.scala
+++ b/qsu/src/main/scala/quasar/qsu/ReifyIdentities.scala
@@ -88,34 +88,33 @@ final class ReifyIdentities[T[_[_]]: BirecursiveT: ShowT] private () extends QSU
   private def lookupIdentity(src: Symbol): FreeMap =
     func.ProjectKeyS(lookupIdentities, src.name)
 
-  private val defaultAccess: QAccess[Symbol] => FreeMap = {
+  private val defaultAccess: Access[Symbol] => FreeMap = {
     case Access.Id(idAccess, _) => idAccess match {
       case IdAccess.Bucket(src, idx) => lookupIdentity(bucketSymbol(src, idx))
       case IdAccess.GroupKey(src, idx) => lookupIdentity(groupKeySymbol(src, idx))
       case IdAccess.Identity(src) => lookupIdentity(src)
-      case IdAccess.Static(ejs) => func.Constant(ejs)
     }
     case Access.Value(_) => func.Hole
   }
 
-  private def bucketIdAccess(src: Symbol, buckets: List[FreeAccess[Hole]]): ISet[QAccess[Symbol]] =
+  private def bucketIdAccess(src: Symbol, buckets: List[FreeAccess[Hole]]): ISet[Access[Symbol]] =
     Foldable[List].compose[FreeMapA].foldMap(buckets) { access =>
       ISet.singleton(access.symbolic(κ(src)))
     }
 
-  private def shiftTargetAccess(src: Symbol, bucket: FreeMapA[ShiftTarget[T]]): ISet[QAccess[Symbol]] =
+  private def shiftTargetAccess(src: Symbol, bucket: FreeMapA[ShiftTarget]): ISet[Access[Symbol]] =
     Foldable[FreeMapA].foldMap(bucket) {
       case ShiftTarget.AccessLeftTarget(access) => ISet.singleton(access.symbolic(κ(src)))
       case _ => ISet.empty
     }
 
-  private def joinKeyAccess(src: Symbol, jk: JoinKey[QIdAccess]): IList[QAccess[Symbol]] =
+  private def joinKeyAccess(src: Symbol, jk: JoinKey[IdAccess]): IList[Access[Symbol]] =
     IList(jk.left, jk.right) map { idA =>
       Access.id(idA, IdAccess.symbols.headOption(idA) getOrElse src)
     }
 
-  private def recordAccesses[F[_]: Foldable](by: Symbol, fa: F[QAccess[Symbol]]): References =
-    fa.foldLeft(References.noRefs[T, T[EJson]])((r, a) => r.recordAccess(by, a, defaultAccess(a)))
+  private def recordAccesses[F[_]: Foldable](by: Symbol, fa: F[Access[Symbol]]): References =
+    fa.foldLeft(References.noRefs[T])((r, a) => r.recordAccess(by, a, defaultAccess(a)))
 
   // We can't use final here due to SI-4440 - it results in warning
   private case class ReifyState(status: ReifiedStatus, refs: References) {
@@ -166,13 +165,13 @@ final class ReifyIdentities[T[_[_]]: BirecursiveT: ShowT] private () extends QSU
     def freshName: F[Symbol] =
       freshSymbol("rid")
 
-    def isReferenced(access: QAccess[Symbol]): G[Boolean] =
+    def isReferenced(access: Access[Symbol]): G[Boolean] =
       G.gets(_.refs.accessed.member(access))
 
-    def includeIdRepair(oldRepair: FreeMapA[ShiftTarget[T]], oldIdStatus: IdStatus): FreeMapA[ShiftTarget[T]] =
+    def includeIdRepair(oldRepair: FreeMapA[ShiftTarget], oldIdStatus: IdStatus): FreeMapA[ShiftTarget] =
       if (oldIdStatus === ExcludeId)
         oldRepair >>= {
-          case ShiftTarget.RightTarget() => func.ProjectIndexI(RightTarget[T], 1)
+          case ShiftTarget.RightTarget => func.ProjectIndexI(RightTarget, 1)
           case tgt => tgt.pure[FreeMapA]
         }
       else oldRepair
@@ -188,7 +187,7 @@ final class ReifyIdentities[T[_[_]]: BirecursiveT: ShowT] private () extends QSU
         IdentitiesK -> initialI,
         ValueK -> initialV)
 
-    def modifyAccess(of: QAccess[Symbol])(f: FreeMap => FreeMap): G[Unit] =
+    def modifyAccess(of: Access[Symbol])(f: FreeMap => FreeMap): G[Unit] =
       G.modify(reifyRefs.modify(_.modifyAccess(of)(f)))
 
     /** Returns a new graph that applies `func` to the result of `g`. */
@@ -205,7 +204,7 @@ final class ReifyIdentities[T[_[_]]: BirecursiveT: ShowT] private () extends QSU
         newBranch = QSUGraph(origRoot, nestedVerts.updated(origRoot, newVert))
 
         replaceOldAccess = reifyRefs.modify(_.replaceAccess(origRoot, nestedRoot))
-        nestedAccess = Access.value[T[EJson], Symbol](nestedRoot)
+        nestedAccess = Access.value(nestedRoot)
         recordNewAccess = reifyRefs.modify(_.recordAccess(origRoot, nestedAccess, defaultAccess(nestedAccess)))
 
         _ <- G.modify(replaceOldAccess >>> recordNewAccess)
@@ -232,7 +231,7 @@ final class ReifyIdentities[T[_[_]]: BirecursiveT: ShowT] private () extends QSU
 
     /** Handle bookkeeping required when a vertex transitions to emitting IV. */
     def onNeedsIV(g: QSUGraph): G[Unit] =
-      setStatus(g.root, true) >> modifyAccess(Access.valueSymbol(g.root))(rebaseV)
+      setStatus(g.root, true) >> modifyAccess(Access.value(g.root))(rebaseV)
 
     /** Preserves any IV emitted by `src` in the output of `through`, returning
       * whether IV was emitted.
@@ -241,7 +240,7 @@ final class ReifyIdentities[T[_[_]]: BirecursiveT: ShowT] private () extends QSU
       for {
         srcStatus <- emitsIVMap(src)
         _         <- setStatus(through.root, srcStatus)
-        _         <- srcStatus.whenM(modifyAccess(Access.valueSymbol(through.root))(rebaseV))
+        _         <- srcStatus.whenM(modifyAccess(Access.value(through.root))(rebaseV))
       } yield srcStatus
 
     /** Rebase the given `FreeMap` to access the value side of an IV map. */
@@ -265,7 +264,7 @@ final class ReifyIdentities[T[_[_]]: BirecursiveT: ShowT] private () extends QSU
         preserveIV(source, g) as g
 
       case g @ E.LeftShift(source, struct, idStatus, onUndefined, repair, rot) =>
-        val idA = Access.id(IdAccess.identity[T[EJson]](g.root), g.root)
+        val idA = Access.id(IdAccess.identity(g.root), g.root)
 
         (emitsIVMap(source) |@| isReferenced(idA)).tupled flatMap {
           case (true, true) =>
@@ -379,7 +378,7 @@ final class ReifyIdentities[T[_[_]]: BirecursiveT: ShowT] private () extends QSU
 
       case g @ E.QSReduce(source, buckets, reducers, repair) =>
         val referencedBuckets = buckets.indices.toList.traverse { i =>
-          val baccess = IdAccess.Bucket[T[EJson]](g.root, i)
+          val baccess = IdAccess.Bucket(g.root, i)
           isReferenced(Access.id(baccess, g.root)) map (_ option baccess)
         } map (_.unite.toNel)
 
@@ -504,8 +503,8 @@ final class ReifyIdentities[T[_[_]]: BirecursiveT: ShowT] private () extends QSU
         setStatus(g.root, false) as g
     }
 
-    val groupKeyA: Optional[QAccess[Symbol], (Symbol, Int)] =
-      Access.id[T[EJson], Symbol] composePrism IdAccess.groupKey.first composeLens _1
+    val groupKeyA: Optional[Access[Symbol], (Symbol, Int)] =
+      Access.id[Symbol] composePrism IdAccess.groupKey.first composeLens _1
 
     // Reifies group key access.
     def reifyGroupKeys(auth: QAuth, g: QSUGraph): G[QSUGraph] = {
@@ -583,7 +582,7 @@ final class ReifyIdentities[T[_[_]]: BirecursiveT: ShowT] private () extends QSU
 }
 
 object ReifyIdentities {
-  final case class ResearchedQSU[T[_[_]]](refs: References[T, T[EJson]], graph: QSUGraph[T])
+  final case class ResearchedQSU[T[_[_]]](refs: References[T], graph: QSUGraph[T])
 
   object ResearchedQSU {
     implicit def show[T[_[_]]: ShowT]: Show[ResearchedQSU[T]] =

--- a/qsu/src/main/scala/quasar/qsu/ReifyIdentities.scala
+++ b/qsu/src/main/scala/quasar/qsu/ReifyIdentities.scala
@@ -142,7 +142,13 @@ final class ReifyIdentities[T[_[_]]: BirecursiveT: ShowT] private () extends QSU
         recordAccesses(g.root, bucketIdAccess(source, buckets))
 
       case QSU.QSAutoJoin(left, right, joinKeys, combiner) =>
-        val keysAccess = joinKeys.keys >>= (_.list) >>= (joinKeyAccess(g.root, _))
+        val keysAccess = for {
+          conj <- joinKeys.keys
+          isect <- conj.list
+          key <- isect.list
+          keyAccess <- joinKeyAccess(g.root, key)
+        } yield keyAccess
+
         recordAccesses(g.root, keysAccess)
 
       case other => References.noRefs

--- a/qsu/src/main/scala/quasar/qsu/ResolveOwnIdentities.scala
+++ b/qsu/src/main/scala/quasar/qsu/ResolveOwnIdentities.scala
@@ -19,7 +19,6 @@ package quasar.qsu
 import slamdata.Predef.{Boolean, Option, Symbol}
 
 import quasar.contrib.matryoshka._
-import quasar.ejson.EJson
 import quasar.fp._
 import quasar.contrib.iota._
 import quasar.qscript.{construction, Hole, IdOnly, IdStatus, IncludeId}
@@ -37,14 +36,14 @@ final class ResolveOwnIdentities[T[_[_]]: BirecursiveT: EqualT] private () exten
   val func = construction.Func[T]
 
   object ShiftId {
-    def unapply(qa: QAccess[Hole]): Option[Symbol] =
-      Access.identityHole[T[EJson]]
+    def unapply(qa: Access[Hole]): Option[Symbol] =
+      Access.id[Hole]
         .composeLens(_1)
-        .composePrism(IdAccess.identity[T[EJson]])
+        .composePrism(IdAccess.identity)
         .getOption(qa)
   }
 
-  def accessesShiftIdOf(node: Symbol): ShiftTarget[T] => Boolean = {
+  def accessesShiftIdOf(node: Symbol): ShiftTarget => Boolean = {
     case ShiftTarget.AccessLeftTarget(ShiftId(sym)) => sym === node
     case _ => false
   }
@@ -56,15 +55,15 @@ final class ResolveOwnIdentities[T[_[_]]: BirecursiveT: EqualT] private () exten
         val newRepair = repair flatMap {
           case ShiftTarget.AccessLeftTarget(ShiftId(sym)) if sym === qg.root =>
             if (idStatus === IdOnly)
-              RightTarget[T]
+              RightTarget
             else
-              func.ProjectIndexI(RightTarget[T], 0)
+              func.ProjectIndexI(RightTarget, 0)
 
-          case ShiftTarget.RightTarget() =>
+          case ShiftTarget.RightTarget =>
             if (idStatus === IdOnly)
-              RightTarget[T]
+              RightTarget
             else
-              func.ProjectIndexI(RightTarget[T], 1)
+              func.ProjectIndexI(RightTarget, 1)
 
           case other => func.Hole as other
         }

--- a/qsu/src/main/scala/quasar/qsu/minimizers/MergeReductions.scala
+++ b/qsu/src/main/scala/quasar/qsu/minimizers/MergeReductions.scala
@@ -57,9 +57,9 @@ final class MergeReductions[T[_[_]]: BirecursiveT: EqualT: ShowT] private () ext
 
     case qgraph @ QSReduce(src, buckets, reducers, repair) =>
       def rebuild(src: QSUGraph, fm: FreeMap): G[QSUGraph] = {
-        def rewriteBucket(bucket: QAccess[Hole]): FreeMapA[QAccess[Hole]] = bucket match {
+        def rewriteBucket(bucket: Access[Hole]): FreeMapA[Access[Hole]] = bucket match {
           case v @ Access.Value(_) => fm.map(κ(v))
-          case other => Free.pure[MapFunc, QAccess[Hole]](other)
+          case other => Free.pure[MapFunc, Access[Hole]](other)
         }
 
         val buckets2 = buckets.map(_.flatMap(rewriteBucket))

--- a/qsu/src/main/scala/quasar/qsu/package.scala
+++ b/qsu/src/main/scala/quasar/qsu/package.scala
@@ -19,7 +19,6 @@ package quasar
 import slamdata.Predef.{Map => SMap, _}
 import quasar.common.effect.NameGenerator
 import quasar.contrib.scalaz.MonadState_
-import quasar.ejson.EJson
 import quasar.fp._
 import quasar.qscript._, PlannerError.InternalError
 import quasar.qscript.provenance.Dimensions
@@ -32,29 +31,27 @@ import scalaz.syntax.traverse._
 import scalaz.syntax.show._
 
 package object qsu {
-  type QIdAccess[T[_[_]]] = IdAccess[T[EJson]]
-  type QAccess[T[_[_]], A] = Access[T[EJson], A]
-  type FreeAccess[T[_[_]], A] = FreeMapA[T, QAccess[T, A]]
+  type FreeAccess[T[_[_]], A] = FreeMapA[T, Access[A]]
   type QDims[T[_[_]]] = Dimensions[QProv.P[T]]
   type QSUVerts[T[_[_]]] = SMap[Symbol, QScriptUniform[T, Symbol]]
 
   type RevIdxM[T[_[_]], F[_]] = MonadState_[F, QSUGraph.RevIdx[T]]
   def RevIdxM[T[_[_]], F[_]](implicit ev: RevIdxM[T, F]): RevIdxM[T, F] = ev
 
-  def AccessHole[T[_[_]]]: FreeMapA[T, QAccess[T, Hole]] =
-    Free.pure(Access.valueHole(SrcHole))
+  def AccessHole[T[_[_]]]: FreeMapA[T, Access[Hole]] =
+    Free.pure(Access.value(SrcHole))
 
-  def LeftTarget[T[_[_]]]: FreeMapA[T, ShiftTarget[T]] =
-    Free.pure(ShiftTarget.LeftTarget[T]())
+  def LeftTarget[T[_[_]]]: FreeMapA[T, ShiftTarget] =
+    Free.pure(ShiftTarget.LeftTarget)
 
-  def RightTarget[T[_[_]]]: FreeMapA[T, ShiftTarget[T]] =
-    Free.pure(ShiftTarget.RightTarget[T]())
+  def RightTarget[T[_[_]]]: FreeMapA[T, ShiftTarget] =
+    Free.pure(ShiftTarget.RightTarget)
 
-  def AccessLeftTarget[T[_[_]]](f: Hole => QAccess[T, Hole]): FreeMapA[T, ShiftTarget[T]] =
+  def AccessLeftTarget[T[_[_]]](f: Hole => Access[Hole]): FreeMapA[T, ShiftTarget] =
     Free.pure(ShiftTarget.AccessLeftTarget(f(SrcHole)))
 
   def AccessValueF[T[_[_]], A](a: A): FreeAccess[T, A] =
-    Free.pure[MapFunc[T, ?], QAccess[T, A]](Access.Value(a))
+    Free.pure[MapFunc[T, ?], Access[A]](Access.Value(a))
 
   def AccessValueHoleF[T[_[_]]]: FreeAccess[T, Hole] =
     AccessValueF[T, Hole](SrcHole)

--- a/qsu/src/test/scala/quasar/qsu/ApplyProvenanceSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/ApplyProvenanceSpec.scala
@@ -72,8 +72,8 @@ object ApplyProvenanceSpec extends Qspec with QSUTTypes[Fix] {
           (qsu.read('name1, afile), fm))
 
       val dims: SMap[Symbol, QDims] = SMap(
-        'name0 -> IList(qprov.prov.proj(J.str("foobar"))),
-        'name1 -> IList(qprov.prov.proj(J.str("foobar"))))
+        'name0 -> IList(qprov.prov.prjPath(J.str("foobar"))),
+        'name1 -> IList(qprov.prov.prjPath(J.str("foobar"))))
 
       tree must haveDimensions(dims)
     }
@@ -95,11 +95,11 @@ object ApplyProvenanceSpec extends Qspec with QSUTTypes[Fix] {
           qprov.prov.value(IdAccess.bucket('n4, 1))
         , qprov.prov.value(IdAccess.bucket('n4, 0)))
       , 'n3 -> IList(
-          qprov.prov.proj(J.str("foobar"))
+          qprov.prov.prjPath(J.str("foobar"))
         , qprov.prov.value(IdAccess.groupKey('n2, 1))
         , qprov.prov.value(IdAccess.groupKey('n2, 0)))
       , 'n2 -> IList(
-          qprov.prov.proj(J.str("foobar"))
+          qprov.prov.prjPath(J.str("foobar"))
         , qprov.prov.value(IdAccess.groupKey('n2, 1))
         , qprov.prov.value(IdAccess.groupKey('n2, 0)))
       ))
@@ -122,12 +122,12 @@ object ApplyProvenanceSpec extends Qspec with QSUTTypes[Fix] {
         'n0 -> IList(
           qprov.prov.thenn(
             qprov.prov.value(IdAccess.identity('n2))
-          , qprov.prov.proj(J.str("foobar"))))
+          , qprov.prov.prjPath(J.str("foobar"))))
       , 'n2 -> IList(
           qprov.prov.value(IdAccess.identity('n2))
-        , qprov.prov.proj(J.str("foobar")))
+        , qprov.prov.prjPath(J.str("foobar")))
       , 'n3 -> IList(
-          qprov.prov.proj(J.str("foobar")))
+          qprov.prov.prjPath(J.str("foobar")))
       ))
     }
   }

--- a/qsu/src/test/scala/quasar/qsu/ApplyProvenanceSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/ApplyProvenanceSpec.scala
@@ -59,7 +59,7 @@ object ApplyProvenanceSpec extends Qspec with QSUTTypes[Fix] {
 
   // FIXME: Figure out how to get this to resolve normally.
   implicit val eqP: Equal[qprov.P] =
-    qprov.prov.provenanceEqual(Equal[qprov.D], Equal[QIdAccess])
+    qprov.prov.provenanceEqual(Equal[qprov.D], Equal[IdAccess])
 
   "provenance application" should {
 

--- a/qsu/src/test/scala/quasar/qsu/ExpandShiftsSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/ExpandShiftsSpec.scala
@@ -51,8 +51,8 @@ object ExpandShiftsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
 
   val hole: Hole = SrcHole
 
-  def index(i: Int): FreeMapA[QAccess[Hole] \/ Int] =
-    i.right[QAccess[Hole]].pure[FreeMapA]
+  def index(i: Int): FreeMapA[Access[Hole] \/ Int] =
+    i.right[Access[Hole]].pure[FreeMapA]
 
   "convert singly nested LeftShift/ThetaJoin" in {
     val dataset = qsu.leftShift(
@@ -118,23 +118,23 @@ object ExpandShiftsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
         )
         innerRepair must beTreeEqual(
           func.StaticMapS(
-            "original" -> AccessLeftTarget[Fix](Access.valueHole(_)),
+            "original" -> AccessLeftTarget[Fix](Access.value(_)),
             "0" -> RightTarget[Fix])
         )
         outerRepair must beTreeEqual(
           func.Cond(
             func.Or(
               func.Eq(
-                AccessLeftTarget[Fix](Access.id(IdAccess.identity[Fix[EJson]]('esh0), _)),
-                AccessLeftTarget[Fix](Access.id(IdAccess.identity[Fix[EJson]]('esh1), _))),
+                AccessLeftTarget[Fix](Access.id(IdAccess.identity('esh0), _)),
+                AccessLeftTarget[Fix](Access.id(IdAccess.identity('esh1), _))),
               func.IfUndefined(
-                AccessLeftTarget[Fix](Access.id(IdAccess.identity[Fix[EJson]]('esh1), _)),
+                AccessLeftTarget[Fix](Access.id(IdAccess.identity('esh1), _)),
                 func.Constant(json.bool(true)))),
             func.StaticMapS(
                 "original" ->
-                  func.ProjectKeyS(AccessLeftTarget[Fix](Access.valueHole(_)), "original"),
+                  func.ProjectKeyS(AccessLeftTarget[Fix](Access.value(_)), "original"),
                 "0" ->
-                  func.ProjectKeyS(AccessLeftTarget[Fix](Access.valueHole(_)), "0"),
+                  func.ProjectKeyS(AccessLeftTarget[Fix](Access.value(_)), "0"),
                 "1" -> RightTarget[Fix]),
             func.Undefined
           )
@@ -273,41 +273,41 @@ object ExpandShiftsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
         )
         innermostRepair must beTreeEqual(
           func.StaticMapS(
-            "original" -> AccessLeftTarget[Fix](Access.valueHole(_)),
+            "original" -> AccessLeftTarget[Fix](Access.value(_)),
             "0" -> RightTarget[Fix])
         )
         innerRepair must beTreeEqual(
           func.Cond(
             func.Or(
               func.Eq(
-                AccessLeftTarget[Fix](Access.id(IdAccess.identity[Fix[EJson]]('esh0), _)),
-                AccessLeftTarget[Fix](Access.id(IdAccess.identity[Fix[EJson]]('esh1), _))),
+                AccessLeftTarget[Fix](Access.id(IdAccess.identity('esh0), _)),
+                AccessLeftTarget[Fix](Access.id(IdAccess.identity('esh1), _))),
               func.IfUndefined(
-                AccessLeftTarget[Fix](Access.id(IdAccess.identity[Fix[EJson]]('esh1), _)),
+                AccessLeftTarget[Fix](Access.id(IdAccess.identity('esh1), _)),
                 func.Constant(json.bool(true)))),
             func.StaticMapS(
               "original" ->
-                func.ProjectKeyS(AccessLeftTarget[Fix](Access.valueHole(_)), "original"),
+                func.ProjectKeyS(AccessLeftTarget[Fix](Access.value(_)), "original"),
               "0" ->
-                func.ProjectKeyS(AccessLeftTarget[Fix](Access.valueHole(_)), "0"),
+                func.ProjectKeyS(AccessLeftTarget[Fix](Access.value(_)), "0"),
               "1" -> RightTarget[Fix]),
             func.Undefined))
         outerRepair must beTreeEqual(
           func.Cond(
             func.Or(
               func.Eq(
-                AccessLeftTarget[Fix](Access.id(IdAccess.identity[Fix[EJson]]('esh1), _)),
-                AccessLeftTarget[Fix](Access.id(IdAccess.identity[Fix[EJson]]('esh2), _))),
+                AccessLeftTarget[Fix](Access.id(IdAccess.identity('esh1), _)),
+                AccessLeftTarget[Fix](Access.id(IdAccess.identity('esh2), _))),
               func.IfUndefined(
-                AccessLeftTarget[Fix](Access.id(IdAccess.identity[Fix[EJson]]('esh2), _)),
+                AccessLeftTarget[Fix](Access.id(IdAccess.identity('esh2), _)),
                 func.Constant(json.bool(true)))),
             func.StaticMapS(
               "original" ->
-                func.ProjectKeyS(AccessLeftTarget[Fix](Access.valueHole(_)), "original"),
+                func.ProjectKeyS(AccessLeftTarget[Fix](Access.value(_)), "original"),
               "0" ->
-                func.ProjectKeyS(AccessLeftTarget[Fix](Access.valueHole(_)), "0"),
+                func.ProjectKeyS(AccessLeftTarget[Fix](Access.value(_)), "0"),
               "1" ->
-                func.ProjectKeyS(AccessLeftTarget[Fix](Access.valueHole(_)), "1"),
+                func.ProjectKeyS(AccessLeftTarget[Fix](Access.value(_)), "1"),
               "2" -> RightTarget[Fix]),
             func.Undefined
         ))

--- a/qsu/src/test/scala/quasar/qsu/GraduateSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/GraduateSpec.scala
@@ -105,7 +105,7 @@ object GraduateSpec extends Qspec with QSUTTypes[Fix] {
 
       "convert QSReduce" in {
         val buckets: List[FreeMap] = List(func.Add(HoleF, IntLit(17)))
-        val abuckets: List[FreeAccess[Hole]] = buckets.map(_.map(Access.value[Fix[EJson], Hole](_)))
+        val abuckets: List[FreeAccess[Hole]] = buckets.map(_.map(Access.value[Hole](_)))
         val reducers: List[ReduceFunc[FreeMap]] = List(ReduceFuncs.Count(HoleF))
         val repair: FreeMapA[ReduceIndex] = ReduceIndexF(\/-(0))
 
@@ -118,8 +118,8 @@ object GraduateSpec extends Qspec with QSUTTypes[Fix] {
       "convert LeftShift" in {
         val struct: RecFreeMap = recFunc.Add(recFunc.Hole, recFunc.Constant(Fixed[Fix[EJson]].int(17)))
 
-        val arepair: FreeMapA[QScriptUniform.ShiftTarget[Fix]] = func.ConcatArrays(
-          func.MakeArray(AccessLeftTarget[Fix](Access.valueHole(_))),
+        val arepair: FreeMapA[QScriptUniform.ShiftTarget] = func.ConcatArrays(
+          func.MakeArray(AccessLeftTarget[Fix](Access.value(_))),
           func.ConcatArrays(
             LeftTarget[Fix],
             func.MakeArray(RightTarget[Fix])))
@@ -137,7 +137,7 @@ object GraduateSpec extends Qspec with QSUTTypes[Fix] {
 
       "convert QSSort" in {
         val buckets: List[FreeMap] = List(func.Add(HoleF, IntLit(17)))
-        val abuckets: List[FreeAccess[Hole]] = buckets.map(_.map(Access.value[Fix[EJson], Hole](_)))
+        val abuckets: List[FreeAccess[Hole]] = buckets.map(_.map(Access.value[Hole](_)))
         val order: NEL[(FreeMap, SortDir)] = NEL(HoleF -> SortDir.Descending)
 
         val qgraph: Fix[QSU] = qsu.qsSort(qsu.read(afile), abuckets, order)
@@ -178,7 +178,7 @@ object GraduateSpec extends Qspec with QSUTTypes[Fix] {
     "graduate naive `select * from zips`" in {
       val aconcatArr =
         func.ConcatArrays(
-          func.MakeArray(AccessLeftTarget[Fix](Access.valueHole(_))),
+          func.MakeArray(AccessLeftTarget[Fix](Access.value(_))),
           func.MakeArray(RightTarget[Fix]))
       val concatArr =
         func.ConcatArrays(

--- a/qsu/src/test/scala/quasar/qsu/MinimizeAutoJoinsSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/MinimizeAutoJoinsSpec.scala
@@ -836,10 +836,9 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
             func.ProjectKeyS(func.Hole, "results"))
 
           repairInner must beTreeEqual(
-            func.StaticMapS(
-              "original" ->
-                func.ProjectKeyS(AccessLeftTarget[Fix](Access.value(_)), "original"),
-              "results" -> RightTarget[Fix]))
+            func.ConcatMaps(
+              AccessLeftTarget[Fix](Access.value(_)),
+              func.MakeMapS("results", RightTarget[Fix])))
 
           structOuter.linearize must beTreeEqual(func.ProjectKeyS(func.Hole, "results"))
 
@@ -918,14 +917,11 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
           outerStruct must beTreeEqual(recFunc.ProjectKeyS(recFunc.Hole, "right"))
 
           outerRepair must beTreeEqual(
-            func.StaticMapS(
-              "0" ->
-                func.ProjectKeyS(
-                  func.ProjectKeyS(
-                    AccessLeftTarget[Fix](Access.value(_)),
-                    "left"),
-                  "0"),
-              "1" -> RightTarget[Fix]))
+            func.ConcatMaps(
+              func.ProjectKeyS(
+                AccessLeftTarget[Fix](Access.value(_)),
+                "left"),
+              func.MakeMapS("1", RightTarget[Fix])))
 
           fm must beTreeEqual(
             recFunc.Divide(
@@ -1043,53 +1039,45 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
         outerMultiRepair must beTreeEqual(
           func.StaticMapS(
             "left" ->
-              func.StaticMapS(
-                "left" ->
-                  func.StaticMapS(
-                    "original" ->
-                      func.ProjectKeyS(
-                        func.ProjectKeyS(
-                          func.ProjectKeyS(
-                            AccessHole[Fix].map(_.left[Int]),
-                            "left"),
-                          "left"),
-                        "original"),
-                    "results" ->
-                      Free.pure[MapFunc, Access[Hole] \/ Int](0.right)),
-                "right" ->
-                  func.ProjectKeyS(
+              func.ConcatMaps(
+                func.ProjectKeyS(
+                  AccessHole[Fix].map(_.left[Int]),
+                  "left"),
+                func.MakeMapS(
+                  "left",
+                  func.ConcatMaps(
                     func.ProjectKeyS(
-                      AccessHole[Fix].map(_.left[Int]),
+                      func.ProjectKeyS(
+                        AccessHole[Fix].map(_.left[Int]),
+                        "left"),
                       "left"),
-                    "right")),
+                    func.MakeMapS(
+                      "results",
+                      Free.pure[MapFunc, Access[Hole] \/ Int](0.right))))),
             "right" -> func.MakeMapS("3", Free.pure[MapFunc, Access[Hole] \/ Int](1.right))))
 
         singleRepair must beTreeEqual(
-          func.StaticMapS(
-            "0" ->
-              RightTarget[Fix],
-            "1" ->
-              func.ProjectKeyS(
-                func.ProjectKeyS(
+          func.ConcatMaps(
+            func.ConcatMaps(
+              func.StaticMapS(
+                "0" ->
+                  RightTarget[Fix],
+                "1" ->
                   func.ProjectKeyS(
-                    AccessLeftTarget[Fix](Access.value(_)),
-                    "left"),
-                  "left"),
-                "original"),
-            "2" ->
-              func.ProjectKeyS(
-                func.ProjectKeyS(
-                  func.ProjectKeyS(
-                    AccessLeftTarget[Fix](Access.value(_)),
-                    "left"),
-                  "right"),
-                "2"),
-            "3" ->
+                    func.ProjectKeyS(
+                      func.ProjectKeyS(
+                        AccessLeftTarget[Fix](Access.value(_)),
+                        "left"),
+                      "left"),
+                    "original")),
               func.ProjectKeyS(
                 func.ProjectKeyS(
                   AccessLeftTarget[Fix](Access.value(_)),
-                  "right"),
-                "3")))
+                  "left"),
+                "right")),
+            func.ProjectKeyS(
+              AccessLeftTarget[Fix](Access.value(_)),
+              "right")))
 
         singleStruct must beTreeEqual(
           recFunc.ProjectKeyS(
@@ -1420,14 +1408,11 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
             recFunc.ProjectKeyS(recFunc.ProjectKeyS(recFunc.Hole, "right"), "c"))
 
           outerRepair must beTreeEqual(
-            func.StaticMapS(
-              "0" ->
-                func.ProjectKeyS(
-                  func.ProjectKeyS(
-                    AccessLeftTarget[Fix](Access.value(_)),
-                    "left"),
-                  "0"),
-              "1" -> RightTarget[Fix]))
+            func.ConcatMaps(
+              func.ProjectKeyS(
+                AccessLeftTarget[Fix](Access.value(_)),
+                "left"),
+              func.MakeMapS("1", RightTarget[Fix])))
 
           fm must beTreeEqual(
             recFunc.Add(

--- a/qsu/src/test/scala/quasar/qsu/MinimizeAutoJoinsSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/MinimizeAutoJoinsSpec.scala
@@ -70,7 +70,7 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
     qsu.leftShift(qsu.read(afile), recFunc.Hole, ExcludeId, OnUndefined.Omit, RightTarget[Fix], Rotation.ShiftMap)
 
   implicit val eqP: Equal[qprov.P] =
-    qprov.prov.provenanceEqual(Equal[qprov.D], Equal[QIdAccess])
+    qprov.prov.provenanceEqual(Equal[qprov.D], Equal[IdAccess])
 
   "autojoin minimization" should {
     "linearize .foo + .bar" in {
@@ -545,7 +545,7 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
           repair must beTreeEqual(
             func.StaticMapS(
               "0" -> RightTarget[Fix],
-              "1" -> AccessLeftTarget[Fix](Access.valueHole(_))))
+              "1" -> AccessLeftTarget[Fix](Access.value(_))))
 
           fm.linearize must beTreeEqual(
             func.Add(
@@ -584,7 +584,7 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
           repair must beTreeEqual(
             func.StaticMapS(
               "1" -> RightTarget[Fix],
-              "0" -> AccessLeftTarget[Fix](Access.valueHole(_))))
+              "0" -> AccessLeftTarget[Fix](Access.value(_))))
 
           fm.linearize must beTreeEqual(
             func.Add(
@@ -635,7 +635,7 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
         repairInner must beTreeEqual(
           func.StaticMapS(
             "0" -> RightTarget[Fix],
-            "1" -> AccessLeftTarget[Fix](Access.valueHole(_))))
+            "1" -> AccessLeftTarget[Fix](Access.value(_))))
 
         h1 must beTreeEqual(func.ProjectKeyS(func.Hole, "0"))
         h2 must beTreeEqual(func.ProjectKeyS(func.Hole, "1"))
@@ -694,7 +694,7 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
         repairInner must beTreeEqual(
           func.StaticMapS(
             "0" -> RightTarget[Fix],
-            "1" -> AccessLeftTarget[Fix](Access.valueHole(_))))
+            "1" -> AccessLeftTarget[Fix](Access.value(_))))
 
         h1 must beTreeEqual(func.ProjectKeyS(func.Hole, "0"))
         h2 must beTreeEqual(func.ProjectKeyS(func.Hole, "1"))
@@ -753,7 +753,7 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
 
           repairInner must beTreeEqual(
             func.StaticMapS(
-              "original" -> AccessLeftTarget[Fix](Access.valueHole(_)),
+              "original" -> AccessLeftTarget[Fix](Access.value(_)),
               "results" -> RightTarget[Fix]))
 
           structOuter.linearize must beTreeEqual(
@@ -765,7 +765,7 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
                 RightTarget[Fix],
               "1" ->
                 func.ProjectKeyS(
-                  AccessLeftTarget[Fix](Access.valueHole(_)),
+                  AccessLeftTarget[Fix](Access.value(_)),
                   "original")))
 
           fm.linearize must beTreeEqual(
@@ -829,7 +829,7 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
 
           repairInnerInner must beTreeEqual(
             func.StaticMapS(
-              "original" -> AccessLeftTarget[Fix](Access.valueHole(_)),
+              "original" -> AccessLeftTarget[Fix](Access.value(_)),
               "results" -> RightTarget[Fix]))
 
           structInner.linearize must beTreeEqual(
@@ -838,7 +838,7 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
           repairInner must beTreeEqual(
             func.StaticMapS(
               "original" ->
-                func.ProjectKeyS(AccessLeftTarget[Fix](Access.valueHole(_)), "original"),
+                func.ProjectKeyS(AccessLeftTarget[Fix](Access.value(_)), "original"),
               "results" -> RightTarget[Fix]))
 
           structOuter.linearize must beTreeEqual(func.ProjectKeyS(func.Hole, "results"))
@@ -849,7 +849,7 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
                 RightTarget[Fix],
               "1" ->
                 func.ProjectKeyS(
-                  AccessLeftTarget[Fix](Access.valueHole(_)),
+                  AccessLeftTarget[Fix](Access.value(_)),
                   "original")))
 
           fm.linearize must beTreeEqual(
@@ -911,9 +911,9 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
           innerRepair must beTreeEqual(
             func.StaticMapS(
               "left" ->
-                func.MakeMapS("0", Free.pure[MapFunc, QAccess[Hole] \/ Int](0.right)),
+                func.MakeMapS("0", Free.pure[MapFunc, Access[Hole] \/ Int](0.right)),
               "right" ->
-                Free.pure[MapFunc, QAccess[Hole] \/ Int](1.right)))
+                Free.pure[MapFunc, Access[Hole] \/ Int](1.right)))
 
           outerStruct must beTreeEqual(recFunc.ProjectKeyS(recFunc.Hole, "right"))
 
@@ -1025,11 +1025,11 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
                 "original" ->
                   AccessHole[Fix].map(_.left[Int]),
                 "results" ->
-                  Free.pure[MapFunc, QAccess[Hole] \/ Int](0.right)),
+                  Free.pure[MapFunc, Access[Hole] \/ Int](0.right)),
               "right" ->
-                func.MakeMapS("2", Free.pure[MapFunc, QAccess[Hole] \/ Int](1.right))),
+                func.MakeMapS("2", Free.pure[MapFunc, Access[Hole] \/ Int](1.right))),
             "right" ->
-              Free.pure[MapFunc, QAccess[Hole] \/ Int](2.right)))
+              Free.pure[MapFunc, Access[Hole] \/ Int](2.right)))
 
         outerastruct must beTreeEqual(
           func.ProjectKeyS(
@@ -1055,14 +1055,14 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
                           "left"),
                         "original"),
                     "results" ->
-                      Free.pure[MapFunc, QAccess[Hole] \/ Int](0.right)),
+                      Free.pure[MapFunc, Access[Hole] \/ Int](0.right)),
                 "right" ->
                   func.ProjectKeyS(
                     func.ProjectKeyS(
                       AccessHole[Fix].map(_.left[Int]),
                       "left"),
                     "right")),
-            "right" -> func.MakeMapS("3", Free.pure[MapFunc, QAccess[Hole] \/ Int](1.right))))
+            "right" -> func.MakeMapS("3", Free.pure[MapFunc, Access[Hole] \/ Int](1.right))))
 
         singleRepair must beTreeEqual(
           func.StaticMapS(
@@ -1335,7 +1335,7 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
           innerRepair must beTreeEqual(
             func.StaticMapS(
               "original" ->
-                AccessLeftTarget[Fix](Access.valueHole(_)),
+                AccessLeftTarget[Fix](Access.value(_)),
               "results" ->
                 RightTarget[Fix]))
 
@@ -1347,7 +1347,7 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
               "1" ->
                 RightTarget[Fix],
               "0" ->
-                func.ProjectKeyS(AccessLeftTarget[Fix](Access.valueHole(_)), "original")))
+                func.ProjectKeyS(AccessLeftTarget[Fix](Access.value(_)), "original")))
 
           fm.linearize must beTreeEqual(
             func.Add(
@@ -1412,9 +1412,9 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
               "left" ->
                 func.StaticMapS(
                   "0" ->
-                    Free.pure[MapFunc, QAccess[Hole] \/ Int](0.right)),
+                    Free.pure[MapFunc, Access[Hole] \/ Int](0.right)),
               "right" ->
-                Free.pure[MapFunc, QAccess[Hole] \/ Int](1.right)))
+                Free.pure[MapFunc, Access[Hole] \/ Int](1.right)))
 
           outerStruct must beTreeEqual(
             recFunc.ProjectKeyS(recFunc.ProjectKeyS(recFunc.Hole, "right"), "c"))
@@ -1424,7 +1424,7 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
               "0" ->
                 func.ProjectKeyS(
                   func.ProjectKeyS(
-                    AccessLeftTarget[Fix](Access.valueHole(_)),
+                    AccessLeftTarget[Fix](Access.value(_)),
                     "left"),
                   "0"),
               "1" -> RightTarget[Fix]))

--- a/qsu/src/test/scala/quasar/qsu/ReifyBucketsSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/ReifyBucketsSpec.scala
@@ -21,7 +21,7 @@ import slamdata.Predef.{List, Long, Nil}
 import quasar.{Qspec, TreeMatchers}
 import quasar.ejson.{EJson, Fixed}
 import quasar.ejson.implicits._
-import quasar.contrib.iota.{copkEqual, copkTraverse, copkShow}
+import quasar.contrib.iota.{copkEqual, copkTraverse}
 import quasar.qscript.{construction, ExcludeId, Hole, MapFuncsCore, PlannerError, ReduceFuncs, SrcHole}
 
 import matryoshka.{delayEqual, delayShow, showTShow, Embed}
@@ -59,7 +59,7 @@ object ReifyBucketsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
           ReduceFuncs.Sum(()))
 
       val expBucket =
-        func.ProjectKeyS(func.Hole, "state") map (Access.value[Fix[EJson], Hole](_))
+        func.ProjectKeyS(func.Hole, "state") map (Access.value[Hole](_))
 
       val expReducer =
         func.ProjectKeyS(func.Hole, "pop")
@@ -88,7 +88,7 @@ object ReifyBucketsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
           ReduceFuncs.Sum(()))
 
       val expB =
-        func.Constant[Access[Fix[EJson], Hole]](J.int(7))
+        func.Constant[Access[Hole]](J.int(7))
 
       val expReducer =
         func.ProjectKeyS(func.Hole, "pop")
@@ -164,13 +164,13 @@ object ReifyBucketsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
           _(MapFuncsCore.ConcatMaps(_, _))))
 
       val expArbBucket =
-        func.ProjectKeyS(func.Hole, "city") map (Access.value[Fix[EJson], Hole](_))
+        func.ProjectKeyS(func.Hole, "city") map (Access.value[Hole](_))
 
       val expArbExpr =
         func.ProjectKeyS(func.Hole, "city")
 
       val expSumBucket =
-        func.ProjectKeyS(func.ProjectKeyS(func.Hole, "grouped"), "city") map (Access.value[Fix[EJson], Hole](_))
+        func.ProjectKeyS(func.ProjectKeyS(func.Hole, "grouped"), "city") map (Access.value[Hole](_))
 
       val expSumExpr =
         func.ProjectKeyS(func.Hole, "reduce_expr_0")
@@ -268,13 +268,13 @@ object ReifyBucketsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
           _(MapFuncsCore.ConcatMaps(_, _))))
 
       val expArbBucket =
-        func.ProjectKeyS(func.Hole, "city") map (Access.value[Fix[EJson], Hole](_))
+        func.ProjectKeyS(func.Hole, "city") map (Access.value[Hole](_))
 
       val expArbExpr =
         func.ProjectKeyS(func.Hole, "city")
 
       val expSumBucket =
-        func.ProjectKeyS(func.ProjectKeyS(func.Hole, "grouped"), "city") map (Access.value[Fix[EJson], Hole](_))
+        func.ProjectKeyS(func.ProjectKeyS(func.Hole, "grouped"), "city") map (Access.value[Hole](_))
 
       val expSumExpr =
         func.ProjectKeyS(func.ProjectKeyS(func.Hole, "reduce_expr_0"), "quux")

--- a/qsu/src/test/scala/quasar/qsu/ResolveOwnIdentitiesSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/ResolveOwnIdentitiesSpec.scala
@@ -26,6 +26,7 @@ import quasar.contrib.iota.{copkEqual, copkTraverse}
 import quasar.fp.ski.κ
 import quasar.qscript.{construction, ExcludeId, Hole, IdOnly, IncludeId, OnUndefined, SrcHole}
 
+import matryoshka._
 import matryoshka.data.Fix
 import matryoshka.data.free._
 import monocle.syntax.fields._1
@@ -51,12 +52,12 @@ object ResolveOwnIdentitiesSpec extends Qspec with QSUTTypes[Fix] with TreeMatch
         val renamedRep = rep map {
           case ShiftTarget.AccessLeftTarget(access) =>
             val renamedAccess =
-              Access.identityHole[J]
+              Access.id[Hole]
                 .composeLens(_1)
-                .composePrism(IdAccess.identity[J])
+                .composePrism(IdAccess.identity)
                 .modify(rns)
 
-            ShiftTarget.AccessLeftTarget[Fix](renamedAccess(access))
+            ShiftTarget.AccessLeftTarget(renamedAccess(access))
 
           case other => other
         }
@@ -65,8 +66,8 @@ object ResolveOwnIdentitiesSpec extends Qspec with QSUTTypes[Fix] with TreeMatch
     }
 
   "resolving own left shift identity" should {
-    val ownAccess: QAccess[Hole] =
-      Access.identityHole[J](IdAccess.identity[J]('ls), SrcHole)
+    val ownAccess: Access[Hole] =
+      Access.id[Hole](IdAccess.identity('ls), SrcHole)
 
     val initialRepair =
       func.ConcatArrays(

--- a/repl/src/main/resources/log4j.properties
+++ b/repl/src/main/resources/log4j.properties
@@ -8,3 +8,5 @@ log4j.appender.FILE.layout.ConversionPattern=%d %5p [%t] (%F:%L) - %m%n
 log4j.logger.quasar=INFO
 # NIHDB is a bit chatty
 log4j.logger.quasar.niflheim=ERROR
+# Uncomment to log all compilation phases.
+#log4j.logger.quasar.qsu.LPtoQS=DEBUG


### PR DESCRIPTION
* Adds a new provenance + dimensions representation that allows us to track value-level projection and injection.
* Leverages new provenance to allow nested left shifts of different foci to properly cross, while accurately recognizing and joining multiple shifts of the same focus.

[ch1131]