### PR TITLE
mark tests with ignoreFieldOrder

### DIFF
--- a/it/src/main/resources/tests/backendStatuses.test
+++ b/it/src/main/resources/tests/backendStatuses.test
@@ -1,6 +1,8 @@
 {
     "name": "select all backend failure statuses",
     "backends": {
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
     },
     "data": "newTests.data",
     "query": "select backends{_:} as backend, backends{:_} as status, name from `newTests.data`",

--- a/it/src/main/resources/tests/bigdecimal.test
+++ b/it/src/main/resources/tests/bigdecimal.test
@@ -1,6 +1,8 @@
 {
     "name": "bigdecimal",
     "backends": {
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
     },
     "data": "bigdecimal.data",
     "query": "select nr, val1 from `bigdecimal.data`",

--- a/it/src/main/resources/tests/boulderLikePop.test
+++ b/it/src/main/resources/tests/boulderLikePop.test
@@ -2,7 +2,8 @@
   "name": "population of Boulder-like towns",
 
   "backends": {
-        "mimir":"ignoreFieldOrder"
+    "lwc_local": "ignoreFieldOrder",
+    "mimir": "ignoreFieldOrder"
   },
 
   "data": "zips.data",

--- a/it/src/main/resources/tests/concatBetween.test
+++ b/it/src/main/resources/tests/concatBetween.test
@@ -1,7 +1,8 @@
 {
     "name": "concat BETWEEN with other fields",
     "backends": {
-        "mimir":          "ignoreFieldOrder"
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
     },
     "data": "smallZips.data",
     "query": "select city, pop, pop between 1000 and 10000 as midsized from `smallZips.data`",

--- a/it/src/main/resources/tests/constantAndGrouped.test
+++ b/it/src/main/resources/tests/constantAndGrouped.test
@@ -2,7 +2,8 @@
     "name": "constant and a grouped value",
 
     "backends": {
-        "mimir":          "ignoreFieldOrder"
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
     },
     "data": "zips.data",
 

--- a/it/src/main/resources/tests/convertFromString.test
+++ b/it/src/main/resources/tests/convertFromString.test
@@ -1,7 +1,8 @@
 {
     "name": "convert values from strings",
     "backends": {
-        "mimir":             "ignoreFieldOrder"
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
     },
     "data": "smallZips.data",
     "query": "select integer(`_id`) as intId, decimal(`_id`) as decId from `smallZips.data`",

--- a/it/src/main/resources/tests/countAndSumGroupedBySingleField.test
+++ b/it/src/main/resources/tests/countAndSumGroupedBySingleField.test
@@ -1,6 +1,11 @@
 {
     "name": "count and sum grouped by single field",
 
+    "backends": {
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
+    },
+
     "data": "zips.data",
 
     "query": "select count(*) as cnt, sum(pop) as sm from `zips.data` group by state",

--- a/it/src/main/resources/tests/demo/groupedSelectOfNestedReduction.test
+++ b/it/src/main/resources/tests/demo/groupedSelectOfNestedReduction.test
@@ -1,6 +1,8 @@
 {
     "name": "select unreduced grouped values from nested select with reduction",
     "backends": {
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
     },
     "data": "patients.data",
     "query": "select city, cnt as c from (select city, count(*) as cnt from `patients.data` where state = \"NY\"

--- a/it/src/main/resources/tests/derivedFunctionCeil.test
+++ b/it/src/main/resources/tests/derivedFunctionCeil.test
@@ -1,6 +1,8 @@
 {
     "name": "derived function ceil",
     "backends": {
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
     },
     "data": "divide.data",
     "query": "select nr, ceil(val3) as ceil1 from `divide.data`",

--- a/it/src/main/resources/tests/derivedFunctionFloor.test
+++ b/it/src/main/resources/tests/derivedFunctionFloor.test
@@ -1,6 +1,8 @@
 {
     "name": "derived function floor",
     "backends": {
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
     },
     "data": "divide.data",
     "query": "select nr, floor(val3) as floor1 from `divide.data`",

--- a/it/src/main/resources/tests/derivedFunctionRound.test
+++ b/it/src/main/resources/tests/derivedFunctionRound.test
@@ -1,6 +1,8 @@
 {
     "name": "derived function round",
     "backends": {
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
     },
     "data": "divide.data",
     "query": "select nr, round(val3) as round1 from `divide.data`",

--- a/it/src/main/resources/tests/derivedFunctionTrunc.test
+++ b/it/src/main/resources/tests/derivedFunctionTrunc.test
@@ -1,5 +1,9 @@
 {
     "name": "derived function trunc",
+    "backends": {
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
+    },
     "data": "divide.data",
     "query": "select nr, trunc(val3) as trunc1 from `divide.data`",
     "predicate": "exactly",

--- a/it/src/main/resources/tests/fieldOrder.test
+++ b/it/src/main/resources/tests/fieldOrder.test
@@ -2,6 +2,7 @@
     "name": "reduced expressions which trigger bad field ordering in MongoDB (#598)",
 
     "backends": {
+        "lwc_local": "ignoreFieldOrder",
         "mimir": "ignoreFieldOrder"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/fieldWithReduction.test
+++ b/it/src/main/resources/tests/fieldWithReduction.test
@@ -2,6 +2,8 @@
     "name": "select field with reduction",
 
     "backends": {
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
     },
     "data": "extraSmallZips.data",
 

--- a/it/src/main/resources/tests/flattenArrayLeftWithUnflattened.test
+++ b/it/src/main/resources/tests/flattenArrayLeftWithUnflattened.test
@@ -1,6 +1,7 @@
 {
     "name": "flatten array on the left with unflattened field",
     "backends": {
+        "lwc_local": "ignoreFieldOrder",
         "mimir": "ignoreFieldOrder"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/flattenArrayWithUnflattened.test
+++ b/it/src/main/resources/tests/flattenArrayWithUnflattened.test
@@ -1,6 +1,7 @@
 {
     "name": "flatten array with unflattened field",
     "backends": {
+        "lwc_local": "ignoreFieldOrder",
         "mimir": "ignoreFieldOrder"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/functions/simple_if_undefined.test
+++ b/it/src/main/resources/tests/functions/simple_if_undefined.test
@@ -2,6 +2,8 @@
   "name": "[qa_s02] simple check if a field is undefined",
 
   "backends": {
+    "lwc_local": "ignoreFieldOrder",
+    "mimir": "ignoreFieldOrder"
   },
 
   "data": "functions.data",

--- a/it/src/main/resources/tests/groupByExpression.test
+++ b/it/src/main/resources/tests/groupByExpression.test
@@ -2,7 +2,8 @@
     "name": "group by a computed value",
 
     "backends": {
-        "mimir":"ignoreFieldOrder"
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
     },
     "data": "zips.data",
 

--- a/it/src/main/resources/tests/groupBySimpleExpression.test
+++ b/it/src/main/resources/tests/groupBySimpleExpression.test
@@ -1,7 +1,8 @@
 {
     "name": "group by simple expression",
     "backends": {
-        "mimir":             "ignoreFieldOrder"
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
     },
     "data": "extraSmallZips.data",
     "query": "select city, sum(pop) from `extraSmallZips.data` group by lower(city)",

--- a/it/src/main/resources/tests/joins/groupedJoin.test
+++ b/it/src/main/resources/tests/joins/groupedJoin.test
@@ -2,6 +2,7 @@
     "name": "[qa_s07] count grouped joined tables",
 
     "backends": {
+        "lwc_local": "ignoreFieldOrder",
         "mimir": "ignoreFieldOrder"
     },
 

--- a/it/src/main/resources/tests/joins/joinDistinct.test
+++ b/it/src/main/resources/tests/joins/joinDistinct.test
@@ -2,6 +2,7 @@
     "name": "[qa_s07] join distinct",
 
     "backends": {
+        "lwc_local": "ignoreFieldOrder",
         "mimir": "ignoreFieldOrder"
     },
 

--- a/it/src/main/resources/tests/joins/joinSubSelects.test
+++ b/it/src/main/resources/tests/joins/joinSubSelects.test
@@ -2,9 +2,9 @@
     "name": "[qa_s07] join the results of a pair of sub-queries",
 
     "backends": {
-        "mimir":          "ignoreFieldOrder"
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
     },
-
 
     "data": ["../zips.data", "../largeZips.data"],
 

--- a/it/src/main/resources/tests/joins/joinWithComplexCondition.test
+++ b/it/src/main/resources/tests/joins/joinWithComplexCondition.test
@@ -2,9 +2,9 @@
     "name": "[qa_s07] join with complex conditions",
 
     "backends": {
+        "lwc_local": "ignoreFieldOrder",
         "mimir": "ignoreFieldOrder"
     },
-
 
     "data": ["../slamengine_commits.data", "../slamengine_commits_dup.data"],
 

--- a/it/src/main/resources/tests/joins/joinWithMultipleConditions.test
+++ b/it/src/main/resources/tests/joins/joinWithMultipleConditions.test
@@ -2,6 +2,7 @@
     "name": "[qa_s07] join with multiple conditions",
 
     "backends": {
+        "lwc_local": "ignoreFieldOrder",
         "mimir": "ignoreFieldOrder"
     },
 

--- a/it/src/main/resources/tests/joins/joinWithReversedCondition.test
+++ b/it/src/main/resources/tests/joins/joinWithReversedCondition.test
@@ -2,9 +2,9 @@
     "name": "[qa_s07] join with reversed condition and complex condition expression",
 
     "backends": {
+        "lwc_local": "ignoreFieldOrder",
         "mimir": "ignoreFieldOrder"
     },
-
 
     "data": ["../slamengine_commits.data", "../slamengine_commits_dup.data"],
 

--- a/it/src/main/resources/tests/joins/selfjoinWithComplexCondition.test
+++ b/it/src/main/resources/tests/joins/selfjoinWithComplexCondition.test
@@ -2,6 +2,7 @@
     "name": "[qa_s07] self-join with complex conditions",
 
     "backends": {
+        "lwc_local": "ignoreFieldOrder",
         "mimir": "ignoreFieldOrder"
     },
 

--- a/it/src/main/resources/tests/jsWithNonJsFilter.test
+++ b/it/src/main/resources/tests/jsWithNonJsFilter.test
@@ -1,7 +1,8 @@
 {
     "name": "filter on JS with non-JS",
     "backends": {
-        "mimir":"ignoreFieldOrder"
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
     },
     "data": "largeZips.data",
     "query": "select city, pop from `largeZips.data` where length(city) < 5 and pop < 30000",

--- a/it/src/main/resources/tests/letBinding.test
+++ b/it/src/main/resources/tests/letBinding.test
@@ -3,6 +3,11 @@
 
     "backends": {},
 
+    "backends": {
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
+    },
+
     "data": "zips.data",
 
     "query": "min_pop := 10000;

--- a/it/src/main/resources/tests/longCitiesWithLength.test
+++ b/it/src/main/resources/tests/longCitiesWithLength.test
@@ -1,7 +1,8 @@
 {
     "name": "long city names in Colorado",
     "backends": {
-        "mimir":"ignoreFieldOrder"
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
     },
     "data": "largeZips.data",
     "query": "select distinct city, length(city) as len from `largeZips.data` where state=\"CO\" and length(city) >= 10",

--- a/it/src/main/resources/tests/negatedRegex.test
+++ b/it/src/main/resources/tests/negatedRegex.test
@@ -1,7 +1,8 @@
 {
     "name": "negate matches in filter and projection",
     "backends": {
-        "mimir":"ignoreFieldOrder"
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
     },
     "data": "largeZips.data",
     "query": "select city, city !~ \"A\" as noA from `largeZips.data` where city !~ \"CHI\"",

--- a/it/src/main/resources/tests/null/toFromString.test
+++ b/it/src/main/resources/tests/null/toFromString.test
@@ -1,6 +1,7 @@
 {
     "name": "convert null to/from strings",
     "backends": {
+        "lwc_local": "ignoreFieldOrder",
         "mimir": "ignoreFieldOrder"
     },
     "data": "nulls.data",

--- a/it/src/main/resources/tests/numericFieldNames.test
+++ b/it/src/main/resources/tests/numericFieldNames.test
@@ -2,6 +2,8 @@
   "name": "numeric field names",
 
   "backends": {
+    "lwc_local": "ignoreFieldOrder",
+    "mimir": "ignoreFieldOrder"
   },
 
   "data": "smallZips.data",

--- a/it/src/main/resources/tests/projectIndexFromGroup.test
+++ b/it/src/main/resources/tests/projectIndexFromGroup.test
@@ -1,7 +1,8 @@
 {
     "name": "project index from group",
     "backends": {
-        "mimir":"ignoreFieldOrder"
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
     },
     "data": "slamengine_commits.data",
     "query": "select parents[0].sha, count(*) as count from `slamengine_commits.data` group by parents[0].sha",

--- a/it/src/main/resources/tests/projectIndexFromGroupWithFilter.test
+++ b/it/src/main/resources/tests/projectIndexFromGroupWithFilter.test
@@ -1,7 +1,8 @@
 {
     "name": "project index from group with filter",
     "backends": {
-        "mimir":"ignoreFieldOrder"
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
     },
     "data": "slamengine_commits.data",
     "query": "select parents[0].sha, count(*) as count from `slamengine_commits.data` where parents[0].sha like \"5%\" group by parents[0].sha",

--- a/it/src/main/resources/tests/regression/bug2226.test
+++ b/it/src/main/resources/tests/regression/bug2226.test
@@ -2,7 +2,8 @@
   "name": "[reg] bug2226",
   "data": "revenue.data",
   "backends": {
-    "mimir":             "ignoreFieldOrder"
+    "lwc_local": "ignoreFieldOrder",
+    "mimir": "ignoreFieldOrder"
   },
   "query": "SELECT DISTINCT Value AS value, Q AS dimension, Region AS series, null AS parallel FROM (SELECT quarter AS Q, value AS Value, region AS Region from `revenue.data`) as meh",
   "predicate": "exactly",

--- a/it/src/main/resources/tests/selectArrayElement.test
+++ b/it/src/main/resources/tests/selectArrayElement.test
@@ -1,6 +1,9 @@
 {
     "name": "select array element",
-    "backends": {},
+    "backends": {
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
+    },
     "data": "largeZips.data",
     "query": "select city, loc[0] as lat from `largeZips.data`",
     "predicate": "atLeast",

--- a/it/src/main/resources/tests/selectCount.test
+++ b/it/src/main/resources/tests/selectCount.test
@@ -1,6 +1,7 @@
 {
     "name": "select count and another field",
     "backends": {
+        "lwc_local": "ignoreFieldOrder",
         "mimir": "ignoreFieldOrder"
     },
     "data": "slamengine_commits.data",

--- a/it/src/main/resources/tests/simpleProjectWithOneRenamed.test
+++ b/it/src/main/resources/tests/simpleProjectWithOneRenamed.test
@@ -2,6 +2,8 @@
     "name": "simple $project with one renamed field and one unchanged (see #598)",
 
     "backends": {
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
     },
 
     "data": "zips.data",

--- a/it/src/main/resources/tests/sortByJS.test
+++ b/it/src/main/resources/tests/sortByJS.test
@@ -1,9 +1,10 @@
 {
   "name": "sort by JS expression with filter",
 
-  "backends": {
-        "mimir":"ignoreFieldOrder"
-  },
+    "backends": {
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
+    },
 
   "data": "zips.data",
 

--- a/it/src/main/resources/tests/sumDistinct.test
+++ b/it/src/main/resources/tests/sumDistinct.test
@@ -1,6 +1,8 @@
 {
     "name": "grouped sum of distinct values",
     "backends": {
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
     },
     "data": "zips.data",
     "query": "select state, sum(distinct(pop)) from `zips.data` group by state",

--- a/it/src/main/resources/tests/trivialGroup.test
+++ b/it/src/main/resources/tests/trivialGroup.test
@@ -1,7 +1,8 @@
 {
     "name": "trivial group by",
     "backends": {
-        "mimir":"ignoreFieldOrder"
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
     },
     "data": "largeZips.data",
     "query": "select city, sum(pop) as totalPop from `largeZips.data` group by city",

--- a/it/src/main/resources/tests/unifyFlattenedFieldsWithUnflattened.test
+++ b/it/src/main/resources/tests/unifyFlattenedFieldsWithUnflattened.test
@@ -1,6 +1,7 @@
 {
     "name": "unify flattened fields with unflattened field",
     "backends": {
+        "lwc_local": "ignoreFieldOrder",
         "mimir": "ignoreFieldOrder"
     },
     "data": "zips.data",

--- a/it/src/main/resources/tests/union/self_union.test
+++ b/it/src/main/resources/tests/union/self_union.test
@@ -9,6 +9,7 @@
   "query": "select * from (select * from `simple_union.data` union select * from `simple_union.data`) order by a",
 
   "predicate": "exactly",
+  "ignoreFieldOrder": true,
 
   "expected": [{"a": "1", "b": 1},
                {"a": "2", "b": 2}]

--- a/it/src/main/resources/tests/union/self_union_all.test
+++ b/it/src/main/resources/tests/union/self_union_all.test
@@ -10,6 +10,8 @@
 
   "predicate": "exactly",
 
+  "ignoreFieldOrder": true,
+
   "expected": [
     {"a": "1", "b": 1},
     {"a": "1", "b": 1},

--- a/it/src/main/resources/tests/union/simple_union.test
+++ b/it/src/main/resources/tests/union/simple_union.test
@@ -9,6 +9,7 @@
   "query": "select * from (select * from `simple_union.data` union select * from `simple_union2.data`) order by b",
 
   "predicate": "exactly",
+  "ignoreFieldOrder": true,
 
   "expected": [{"a": "1", "b": 1},
                {"a": "2", "b": 2},

--- a/it/src/main/resources/tests/union/simple_union_all.test
+++ b/it/src/main/resources/tests/union/simple_union_all.test
@@ -9,6 +9,7 @@
   "query": "select * from (select * from `simple_union.data` union all select * from `simple_union2.data`) order by b",
 
   "predicate": "exactly",
+  "ignoreFieldOrder": true,
 
   "expected": [
     {"a": "1", "b": 1},

--- a/it/src/main/resources/tests/usefulGroupBy.test
+++ b/it/src/main/resources/tests/usefulGroupBy.test
@@ -1,6 +1,8 @@
 {
     "name": "useful group by",
     "backends": {
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
     },
     "data": "extraSmallZips.data",
     "query": "select city || \", \" || state, sum(pop) from `extraSmallZips.data` group by city, state",

--- a/it/src/main/resources/tests/zipsByCityLength.test
+++ b/it/src/main/resources/tests/zipsByCityLength.test
@@ -1,7 +1,8 @@
 {
     "name": "count occurrences of each value of length(city), with filtering",
     "backends": {
-        "mimir":"ignoreFieldOrder"
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
     },
     "data": "largeZips.data",
     "query": "select length(city) as len, count(*) as cnt


### PR DESCRIPTION
Just marking more tests with `ignoreFieldOrder` as prep for ch1318. The radix trie impl changes the field order for other queries than the old impl. 