### PR TITLE
make ArrayColumn.update return this.type instead of Unit

### DIFF
--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/Column.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/Column.scala
@@ -601,7 +601,7 @@ object Column {
 }
 
 trait ArrayColumn[@specialized(Boolean, Long, Double) A] extends BitsetColumn with Column {
-  def update(row: Int, value: A): Unit
+  def update(row: Int, value: A): this.type
   def clear(row: Int): Unit
   def resize(size: Int): ArrayColumn[A]
 }
@@ -625,9 +625,10 @@ class ArrayHomogeneousArrayColumn[@specialized(Boolean, Long, Double) A](val def
 
   def apply(row: Int) = values(row)
 
-  def update(row: Int, value: Array[A]) {
+  def update(row: Int, value: Array[A]) = {
     defined.set(row)
     values(row) = value
+    this
   }
 
   def clear(row: Int): Unit = defined.clear(row)
@@ -662,6 +663,7 @@ class ArrayBoolColumn(val defined: BitSet, val values: BitSet) extends BitsetCol
   def update(row: Int, value: Boolean) = {
     defined.set(row)
     if (value) values.set(row) else values.clear(row)
+    this
   }
 
   def clear(row: Int): Unit = defined.clear(row)
@@ -695,6 +697,7 @@ class ArrayLongColumn(val defined: BitSet, val values: Array[Long]) extends Bits
   def update(row: Int, value: Long) = {
     defined.set(row)
     values(row) = value
+    this
   }
 
   def clear(row: Int): Unit = defined.clear(row)
@@ -722,6 +725,7 @@ class ArrayDoubleColumn(val defined: BitSet, val values: Array[Double]) extends 
   def update(row: Int, value: Double) = {
     defined.set(row)
     values(row) = value
+    this
   }
 
   def clear(row: Int): Unit = defined.clear(row)
@@ -749,6 +753,7 @@ class ArrayNumColumn(val defined: BitSet, val values: Array[BigDecimal]) extends
   def update(row: Int, value: BigDecimal) = {
     defined.set(row)
     values(row) = value
+    this
   }
 
   def clear(row: Int): Unit = defined.clear(row)
@@ -776,6 +781,7 @@ class ArrayStrColumn(val defined: BitSet, val values: Array[String]) extends Bit
   def update(row: Int, value: String) = {
     defined.set(row)
     values(row) = value
+    this
   }
 
   def clear(row: Int): Unit = defined.clear(row)
@@ -803,6 +809,7 @@ class ArrayOffsetDateTimeColumn(val defined: BitSet, val values: Array[OffsetDat
   def update(row: Int, value: OffsetDateTime) = {
     defined.set(row)
     values(row) = value
+    this
   }
 
   def clear(row: Int): Unit = defined.clear(row)
@@ -830,6 +837,7 @@ class ArrayOffsetTimeColumn(val defined: BitSet, val values: Array[OffsetTime]) 
   def update(row: Int, value: OffsetTime) = {
     defined.set(row)
     values(row) = value
+    this
   }
 
   def clear(row: Int): Unit = defined.clear(row)
@@ -857,6 +865,7 @@ class ArrayOffsetDateColumn(val defined: BitSet, val values: Array[OffsetDate]) 
   def update(row: Int, value: OffsetDate) = {
     defined.set(row)
     values(row) = value
+    this
   }
 
   def clear(row: Int): Unit = defined.clear(row)
@@ -884,6 +893,7 @@ class ArrayLocalDateTimeColumn(val defined: BitSet, val values: Array[LocalDateT
   def update(row: Int, value: LocalDateTime) = {
     defined.set(row)
     values(row) = value
+    this
   }
 
   def clear(row: Int): Unit = defined.clear(row)
@@ -911,6 +921,7 @@ class ArrayLocalTimeColumn(val defined: BitSet, val values: Array[LocalTime]) ex
   def update(row: Int, value: LocalTime) = {
     defined.set(row)
     values(row) = value
+    this
   }
 
   def clear(row: Int): Unit = defined.clear(row)
@@ -938,6 +949,7 @@ class ArrayLocalDateColumn(val defined: BitSet, val values: Array[LocalDate]) ex
   def update(row: Int, value: LocalDate) = {
     defined.set(row)
     values(row) = value
+    this
   }
 
   def clear(row: Int): Unit = defined.clear(row)
@@ -965,6 +977,7 @@ class ArrayIntervalColumn(val defined: BitSet, val values: Array[DateTimeInterva
   def update(row: Int, value: DateTimeInterval) = {
     defined.set(row)
     values(row) = value
+    this
   }
 
   def clear(row: Int): Unit = defined.clear(row)
@@ -989,6 +1002,7 @@ object ArrayIntervalColumn {
 class MutableEmptyArrayColumn(val defined: BitSet) extends BitsetColumn(defined) with ArrayColumn[Boolean] with EmptyArrayColumn {
   def update(row: Int, value: Boolean) = {
     if (value) defined.set(row) else defined.clear(row)
+    this
   }
 
   def clear(row: Int): Unit = defined.clear(row)
@@ -1006,6 +1020,7 @@ object MutableEmptyArrayColumn {
 class MutableEmptyObjectColumn(val defined: BitSet) extends BitsetColumn(defined) with ArrayColumn[Boolean] with EmptyObjectColumn {
   def update(row: Int, value: Boolean) = {
     if (value) defined.set(row) else defined.clear(row)
+    this
   }
 
   def clear(row: Int): Unit = defined.clear(row)
@@ -1023,6 +1038,7 @@ object MutableEmptyObjectColumn {
 class MutableNullColumn(val defined: BitSet) extends BitsetColumn(defined) with ArrayColumn[Boolean] with NullColumn {
   def update(row: Int, value: Boolean) = {
     if (value) defined.set(row) else defined.clear(row)
+    this
   }
 
   def clear(row: Int): Unit = defined.clear(row)

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/Slice.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/Slice.scala
@@ -1967,97 +1967,66 @@ object Slice {
               val c = acc.getOrElse(ref, ArrayBoolColumn.empty(sliceSize)).asInstanceOf[ArrayBoolColumn]
               c.update(sliceIndex, b)
 
-              c
-
             case CLong(d) =>
               val c = acc.getOrElse(ref, ArrayLongColumn.empty(sliceSize)).asInstanceOf[ArrayLongColumn]
               c.update(sliceIndex, d.toLong)
-
-              c
 
             case CDouble(d) =>
               val c = acc.getOrElse(ref, ArrayDoubleColumn.empty(sliceSize)).asInstanceOf[ArrayDoubleColumn]
               c.update(sliceIndex, d.toDouble)
 
-              c
-
             case CNum(d) =>
               val c = acc.getOrElse(ref, ArrayNumColumn.empty(sliceSize)).asInstanceOf[ArrayNumColumn]
               c.update(sliceIndex, d)
-
-              c
 
             case CString(s) =>
               val c = acc.getOrElse(ref, ArrayStrColumn.empty(sliceSize)).asInstanceOf[ArrayStrColumn]
               c.update(sliceIndex, s)
 
-              c
-
             case COffsetDateTime(d) =>
               val c = acc.getOrElse(ref, ArrayOffsetDateTimeColumn.empty(sliceSize)).asInstanceOf[ArrayOffsetDateTimeColumn]
               c.update(sliceIndex, d)
-
-              c
 
             case COffsetTime(d) =>
               val c = acc.getOrElse(ref, ArrayOffsetTimeColumn.empty(sliceSize)).asInstanceOf[ArrayOffsetTimeColumn]
               c.update(sliceIndex, d)
 
-              c
-
             case COffsetDate(d) =>
               val c = acc.getOrElse(ref, ArrayOffsetDateColumn.empty(sliceSize)).asInstanceOf[ArrayOffsetDateColumn]
               c.update(sliceIndex, d)
-
-              c
 
             case CLocalDateTime(d) =>
               val c = acc.getOrElse(ref, ArrayLocalDateTimeColumn.empty(sliceSize)).asInstanceOf[ArrayLocalDateTimeColumn]
               c.update(sliceIndex, d)
 
-              c
-
             case CLocalTime(d) =>
               val c = acc.getOrElse(ref, ArrayLocalTimeColumn.empty(sliceSize)).asInstanceOf[ArrayLocalTimeColumn]
               c.update(sliceIndex, d)
-
-              c
 
             case CLocalDate(d) =>
               val c = acc.getOrElse(ref, ArrayLocalDateColumn.empty(sliceSize)).asInstanceOf[ArrayLocalDateColumn]
               c.update(sliceIndex, d)
 
-              c
-
             case CInterval(p) =>
               val c = acc.getOrElse(ref, ArrayIntervalColumn.empty(sliceSize)).asInstanceOf[ArrayIntervalColumn]
               c.update(sliceIndex, p)
-
-              c
 
             case CArray(arr, cType) =>
               val c = acc.getOrElse(ref, ArrayHomogeneousArrayColumn.empty(sliceSize)(cType)).asInstanceOf[ArrayHomogeneousArrayColumn[cType.tpe]]
               c.update(sliceIndex, arr)
 
-              c
-
             case CEmptyArray =>
               val c = acc.getOrElse(ref, MutableEmptyArrayColumn.empty()).asInstanceOf[MutableEmptyArrayColumn]
               c.update(sliceIndex, true)
-
-              c
 
             case CEmptyObject =>
               val c = acc.getOrElse(ref, MutableEmptyObjectColumn.empty()).asInstanceOf[MutableEmptyObjectColumn]
               c.update(sliceIndex, true)
 
-              c
-
             case CNull =>
               val c = acc.getOrElse(ref, MutableNullColumn.empty()).asInstanceOf[MutableNullColumn]
               c.update(sliceIndex, true)
 
-              c
             case x =>
               sys.error(s"Unexpected arg $x")
           }


### PR DESCRIPTION
Just got reminded about this while refactoring the columns map, but like to create as a separate PR. 
We discussed this change earlier as part of another PR.