### PR TITLE
Introduce MalformedResource to ResourceError

### DIFF
--- a/api/src/main/scala/quasar/api/datasource/DatasourceError.scala
+++ b/api/src/main/scala/quasar/api/datasource/DatasourceError.scala
@@ -50,6 +50,9 @@ object DatasourceError extends DatasourceErrorInstances {
 
   sealed trait DiscoveryError[+I] extends DatasourceError[I, Nothing]
 
+  final case class MalformedResource(path: ResourcePath)
+    extends DiscoveryError[Nothing]
+
   final case class PathNotFound(path: ResourcePath)
     extends DiscoveryError[Nothing]
 
@@ -151,6 +154,9 @@ sealed abstract class DatasourceErrorInstances {
 
   implicit def showDiscoveryError[I: Show]: Show[DiscoveryError[I]] =
     Show.show {
+      case MalformedResource(p) =>
+        Cord("MalformedResource(") ++ p.show ++ Cord(")")
+
       case PathNotAResource(p) =>
         Cord("PathNotAResource(") ++ p.show ++ Cord(")")
 

--- a/api/src/main/scala/quasar/api/datasource/DatasourceError.scala
+++ b/api/src/main/scala/quasar/api/datasource/DatasourceError.scala
@@ -50,9 +50,6 @@ object DatasourceError extends DatasourceErrorInstances {
 
   sealed trait DiscoveryError[+I] extends DatasourceError[I, Nothing]
 
-  final case class MalformedResource(path: ResourcePath)
-    extends DiscoveryError[Nothing]
-
   final case class PathNotFound(path: ResourcePath)
     extends DiscoveryError[Nothing]
 
@@ -154,9 +151,6 @@ sealed abstract class DatasourceErrorInstances {
 
   implicit def showDiscoveryError[I: Show]: Show[DiscoveryError[I]] =
     Show.show {
-      case MalformedResource(p) =>
-        Cord("MalformedResource(") ++ p.show ++ Cord(")")
-
       case PathNotAResource(p) =>
         Cord("PathNotAResource(") ++ p.show ++ Cord(")")
 


### PR DESCRIPTION
`MalformedResource` intends to represent the case where a user tries to query something we can't parse into `Json`. This could be an image, some binary file or even a line-delimited JSON when we expected array JSON.

This is related ch#945. In order to implement what 945 specifies, I'll need to open two more PRs against `slamdata-backend` and `quasar-s3`.