### PR TITLE
fix round for doubles

### DIFF
--- a/frontend/src/test/scala/quasar/std/StdLibSpec.scala
+++ b/frontend/src/test/scala/quasar/std/StdLibSpec.scala
@@ -2174,6 +2174,15 @@ abstract class StdLibSpec extends Qspec {
           unary(Round(_).embed, Data.Int(x), Data.Int(x))
         }
 
+        "any Double" >> prop { (x: Double) =>
+          val bd = BigDecimal(x)
+          unary(Round(_).embed, Data.Dec(bd), Data.Dec(bd.setScale(0, RoundingMode.HALF_EVEN)))
+        }
+
+        "any Dec" >> prop { (x: BigDecimal) =>
+          unary(Round(_).embed, Data.Dec(x), Data.Dec(x.setScale(0, RoundingMode.HALF_EVEN)))
+        }
+
         "0.5 -> 0" >> {
           unary(Round(_).embed, Data.Dec(0.5), Data.Int(0))
         }

--- a/mimir/src/main/scala/quasar/mimir/MathLib.scala
+++ b/mimir/src/main/scala/quasar/mimir/MathLib.scala
@@ -70,11 +70,6 @@ trait MathLibModule extends ColumnarTableLibModule with InfixLibModule {
 
     object tanh extends Op1DD(doubleIsDefined, Math.tanh)
 
-    // Math.round returns Long, so we have to improvise.
-    // 4503599627370496.0 is the point where Double can't represent fractional
-    // values anymore, so beyond that we just pass the value through
-    object round extends Op1DD(doubleIsDefined, n => if (Math.abs(n) >= 4503599627370496.0) n else Math.round(n))
-
     object cosh extends Op1DD(doubleIsDefined, Math.cosh)
 
     object tan extends Op1DD(doubleIsDefined, Math.tan)

--- a/mimir/src/main/scala/quasar/mimir/UnaryLib.scala
+++ b/mimir/src/main/scala/quasar/mimir/UnaryLib.scala
@@ -105,19 +105,7 @@ trait UnaryLibModule extends ColumnarTableLibModule {
       object Round extends Op1F1 {
         val tpe = UnaryOperationType(JNumberT, JNumberT)
         def f1: CF1 = CF1P {
-          // encoding of half-even rounding
-          case c: DoubleColumn => new DoubleFrom.D(c, doubleIsDefined, { d =>
-            if (math.abs(d % 1) == 0.5) {
-              val candidate = math.ceil(d)
-
-              if (candidate % 2 == 0)
-                candidate
-              else
-                math.floor(d)
-            } else {
-              math.round(d)
-            }
-          })
+          case c: DoubleColumn => new DoubleFrom.D(c, doubleIsDefined, math.rint)
           case c: LongColumn   => new LongFrom.L(c, n => true, x => x)
           case c: NumColumn    => new NumFrom.N(c, n => true, _.setScale(0, RoundingMode.HALF_EVEN))
         }

--- a/mimir/src/test/scala/quasar/mimir/MathLibSpecs.scala
+++ b/mimir/src/test/scala/quasar/mimir/MathLibSpecs.scala
@@ -335,20 +335,6 @@ trait MathLibSpecs extends EvaluatorSpecification
 
       result2.toSet must_== Set(0.0, 0.7615941559557649, -0.7615941559557649, 1.0, -1.0)
     }
-    "compute round" in {
-      val input = dag.Operate(BuiltInFunction1Op(round),
-        dag.AbsoluteLoad(Const(CString("/hom/numbers4"))))
-
-      val result = testEval(input)
-
-      result must haveSize(6)
-
-      val result2 = result collect {
-        case (ids, JNum(d)) if ids.length == 1  => d
-      }
-
-      result2.toSet must_== Set(0, 1, -1, 42, -23)
-    }
     "compute cosh" in {
       val input = dag.Operate(BuiltInFunction1Op(cosh),
         dag.AbsoluteLoad(Const(CString("/hom/numbers4"))))
@@ -832,20 +818,6 @@ trait MathLibSpecs extends EvaluatorSpecification
       }
 
       result2.toSet must_== Set(0.0, 0.7615941559557649, -0.7615941559557649, 1.0, -1.0)
-    }
-    "compute round" in {
-      val input = dag.Operate(BuiltInFunction1Op(round),
-        dag.AbsoluteLoad(Const(CString("/het/numbers4"))))
-
-      val result = testEval(input)
-
-      result must haveSize(6)
-
-      val result2 = result collect {
-        case (ids, JNum(d)) if ids.length == 1  => d
-      }
-
-      result2.toSet must_== Set(0, 1, -1, 42, -23)
     }
     "compute cosh" in {
       val input = dag.Operate(BuiltInFunction1Op(cosh),
@@ -1348,20 +1320,6 @@ trait MathLibSpecs extends EvaluatorSpecification
 
       result2.toSet must_== Set(0.0, 0.9999999999998128, -0.9950547536867305, -0.9999999999244973, 0.9999877116507956, -0.9999092042625951, 0.9999999958776927, 0.9999999994421064, 0.9999999999986171, -0.9999999999986171, -0.999999969540041, -0.9999983369439447, 0.9999983369439447, -0.9999999999897818, 0.9999999999897818)
     }
-    "compute round" in {
-      val input = dag.Operate(BuiltInFunction1Op(round),
-        dag.AbsoluteLoad(Const(CString("/hom/numbersAcrossSlices"))))
-
-      val result = testEval(input)
-
-      result must haveSize(22)
-
-      val result2 = result collect {
-        case (ids, JNum(d)) if ids.length == 1 => d
-      }
-
-      result2.toSet must_== Set(0, 10, -7, 14, -3, -12, 6, 13, -5, 7, -14, 11, -9, -13, 15)
-    }
     "compute cosh" in {
       val input = dag.Operate(BuiltInFunction1Op(cosh),
         dag.AbsoluteLoad(Const(CString("/hom/numbersAcrossSlices"))))
@@ -1817,20 +1775,6 @@ trait MathLibSpecs extends EvaluatorSpecification
       }
 
       result2.toSet must_== Set(0.0, -0.9950547536867305, 0.9999999999244973, -0.7615941559557649, 0.7615941559557649, 0.9999092042625951, 0.9640275800758169)
-    }
-    "compute round" in {
-      val input = dag.Operate(BuiltInFunction1Op(round),
-        dag.AbsoluteLoad(Const(CString("/het/numbersAcrossSlices"))))
-
-      val result = testEval(input)
-
-      result must haveSize(9)
-
-      val result2 = result collect {
-        case (ids, JNum(d)) if ids.length == 1 => d
-      }
-
-      result2.toSet must_== Set(0, 5, -3, 1, 2, 12, -1)
     }
     "compute cosh" in {
       val input = dag.Operate(BuiltInFunction1Op(cosh),

--- a/mimir/src/test/scala/quasar/mimir/StringLibSpecs.scala
+++ b/mimir/src/test/scala/quasar/mimir/StringLibSpecs.scala
@@ -801,7 +801,7 @@ trait StringLibSpecs extends EvaluatorSpecification
 
     "trim the trailing '.0' in round double conversion" in {
       val input = dag.Operate(BuiltInFunction1Op(numToString),
-        dag.Operate(BuiltInFunction1Op(round),
+        dag.Operate(BuiltInFunction1Op(rint),
           Const(CDouble(3.14))))
 
       val resultE = testEval(input)


### PR DESCRIPTION
fix round for doubles

... removed round from MathLib because it's broken and we can use rint instead
(both Math.rint and round from sql2 use HALF_EVEN)

[ch1777]