### PR TITLE
OffsetDateTime toEpochSeconds returns seconds, not milliseconds

### DIFF
--- a/impl/src/main/scala/quasar/impl/table/PreparationsManager.scala
+++ b/impl/src/main/scala/quasar/impl/table/PreparationsManager.scala
@@ -84,7 +84,7 @@ class PreparationsManager[F[_]: Effect, I, Q, R] private (
                     PreparationEvent.PreparationErrored(
                       tableId,
                       start,
-                      (end.toEpochSecond - start.toEpochSecond).millis,
+                      (end.toEpochSecond - start.toEpochSecond).seconds,
                       t)))
               } yield ()
 
@@ -104,7 +104,7 @@ class PreparationsManager[F[_]: Effect, I, Q, R] private (
                         PreparationEvent.PreparationSucceeded(
                           tableId,
                           start,
-                          (end.toEpochSecond - start.toEpochSecond).millis)))
+                          (end.toEpochSecond - start.toEpochSecond).seconds)))
                   } yield ()
                 }
               } yield ()

--- a/impl/src/test/scala/quasar/impl/table/PreparationsManagerSpec.scala
+++ b/impl/src/test/scala/quasar/impl/table/PreparationsManagerSpec.scala
@@ -35,6 +35,8 @@ import scalaz.syntax.monad._
 import shims._
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.SECONDS
+
 
 object PreparationsManagerSpec extends Specification {
   import PreparationsManager._
@@ -63,8 +65,8 @@ object PreparationsManagerSpec extends Specification {
 
         _ <- Stream.eval(IO {
           event must beLike {
-            case PreparationEvent.PreparationSucceeded(id, _, _) =>
-              // TODO assertions about time?
+            case PreparationEvent.PreparationSucceeded(id, _, duration) =>
+              duration.unit mustEqual SECONDS
               id mustEqual Id
           }
 
@@ -154,7 +156,8 @@ object PreparationsManagerSpec extends Specification {
       val event = results.compile.last.unsafeRunSync
 
       event must beLike {
-        case Some(PreparationEvent.PreparationErrored(_, _, _, TestException)) => ok
+        case Some(PreparationEvent.PreparationErrored(_, _, duration, TestException)) =>
+          duration.unit mustEqual SECONDS
       }
     }
 


### PR DESCRIPTION
We already record durations for [ch1749], but they're expressed in seconds, not milliseconds.