### PR TITLE
upgrade scalaz to 7.2.26

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   private val scodecBitsVersion   = "1.1.2"
   private val scodecScalazVersion = "1.4.1a"
   private val scalacheckVersion   = "1.14.0"
-  private val scalazVersion       = "7.2.23"
+  private val scalazVersion       = "7.2.26"
   private val scalazStreamVersion = "0.8.6a"
   private val scoptVersion        = "3.5.0"
   private val shapelessVersion    = "2.3.3"


### PR DESCRIPTION
We were running into the `NoSuchMethodError` below because of https://github.com/scalaz/scalaz/pull/1790

```
java.lang.NoSuchMethodError: scalaz.NonEmptyList$.apply(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lscalaz/NonEmptyList;
        at quasar.frontend.logicalplan.Optimizer.<init>(Optimizer.scala:376)
        at quasar.frontend.logicalplan.package$.preparePlan(package.scala:95)
        at quasar.compile.package$.$anonfun$queryPlan$1(package.scala:150)
        at cats.data.WriterT.$anonfun$flatMap$1(WriterT.scala:44)
```

[ch1794]

