### PR TITLE
SST performance improvements

### DIFF
--- a/impl/src/main/scala/quasar/impl/schema/SstConfig.scala
+++ b/impl/src/main/scala/quasar/impl/schema/SstConfig.scala
@@ -16,6 +16,7 @@
 
 package quasar.impl.schema
 
+import slamdata.Predef.Boolean
 import quasar.api.SchemaConfig
 import quasar.fp.numeric.{Natural, Positive}
 
@@ -24,35 +25,39 @@ import eu.timepit.refined.auto._
 /** Configuration for SST-based schema, allowing for control over various aspects
   * of compression.
   *
-  * @param arrayMaxLength  arrays larger than this will be compressed
-  * @param mapMaxSize      maps larger than this will be compressed
-  * @param retainKeysSize  the number of map keys to retain, per type, during compression
-  * @param stringMaxLength all strings longer than this are compressed to char[]
-  * @param unionMaxSize    unions larger than this will be compressed
+  * @param arrayMaxLength arrays larger than this will be compressed
+  * @param mapMaxSize maps larger than this will be compressed
+  * @param retainKeysSize the number of map keys to retain, per type, during compression
+  * @param stringMaxLength all strings longer than this are compressed
+  * @param stringPreserveStructure whether to preserve structure when compressing strings
+  * @param unionMaxSize unions larger than this will be compressed
   */
 final case class SstConfig[J, A](
-    arrayMaxLength:  Natural,
-    mapMaxSize:      Natural,
-    retainKeysSize:  Natural,
+    arrayMaxLength: Natural,
+    mapMaxSize: Natural,
+    retainKeysSize: Natural,
     stringMaxLength: Natural,
-    unionMaxSize:    Positive)
+    stringPreserveStructure: Boolean,
+    unionMaxSize: Positive)
     extends SchemaConfig {
 
   type Schema = SstSchema[J, A]
 }
 
 object SstConfig {
-  val DefaultArrayMaxLength:  Natural  = 10L
-  val DefaultMapMaxSize:      Natural  = 32L
-  val DefaultRetainKeysSize:  Natural  =  0L
-  val DefaultStringMaxLength: Natural  =  0L
-  val DefaultUnionMaxSize:    Positive =  1L
+  val DefaultArrayMaxLength: Natural = 10L
+  val DefaultMapMaxSize: Natural = 32L
+  val DefaultRetainKeysSize: Natural = 0L
+  val DefaultStringMaxLength: Natural = 0L
+  val DefaultStringPreserveStructure: Boolean = false
+  val DefaultUnionMaxSize: Positive = 1L
 
   def Default[J, A]: SstConfig[J, A] =
     SstConfig[J, A](
-      arrayMaxLength  = DefaultArrayMaxLength,
-      mapMaxSize      = DefaultMapMaxSize,
-      retainKeysSize  = DefaultRetainKeysSize,
+      arrayMaxLength = DefaultArrayMaxLength,
+      mapMaxSize = DefaultMapMaxSize,
+      retainKeysSize = DefaultRetainKeysSize,
       stringMaxLength = DefaultStringMaxLength,
-      unionMaxSize    = DefaultUnionMaxSize)
+      stringPreserveStructure = DefaultStringPreserveStructure,
+      unionMaxSize = DefaultUnionMaxSize)
 }

--- a/impl/src/main/scala/quasar/impl/schema/SstEvalConfig.scala
+++ b/impl/src/main/scala/quasar/impl/schema/SstEvalConfig.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.impl.schema
+
+import quasar.fp.numeric.Positive
+
+import eu.timepit.refined.auto._
+
+/** Configuration parameters related to the computation of SSTs.
+  *
+  * @param sampleSize the number of records to sample when generating SST schemas
+  * @param parallelism the number of chunks to process in parallel when generating SST schemas
+  * @param chunkSize the size of each chunk when generating SST schemas
+  */
+final case class SstEvalConfig(
+    sampleSize: Positive,
+    parallelism: Positive,
+    chunkSize: Positive)
+
+object SstEvalConfig {
+  val single: SstEvalConfig = SstEvalConfig(1L, 1L, 1L)
+}

--- a/impl/src/main/scala/quasar/impl/schema/package.scala
+++ b/impl/src/main/scala/quasar/impl/schema/package.scala
@@ -68,7 +68,7 @@ package object schema {
     val thresholding: ElgotCoalgebra[SST[J, A] \/ ?, SSTF[J, A, ?], SST[J, A]] = {
       val independent =
         orOriginal(applyTransforms(
-          compression.limitStrings[J, A](config.stringMaxLength)))
+          compression.limitStrings[J, A](config.stringMaxLength, config.stringPreserveStructure)))
 
       compression.limitArrays[J, A](config.arrayMaxLength)
         .andThen(_.bimap(_.transAna[SST[J, A]](independent), independent))
@@ -78,8 +78,8 @@ package object schema {
       applyTransforms(
         compression.coalesceWithUnknown[J, A](config.retainKeysSize),
         compression.coalesceKeys[J, A](config.mapMaxSize, config.retainKeysSize),
-        compression.coalescePrimary[J, A],
-        compression.narrowUnion[J, A](config.unionMaxSize))
+        compression.coalescePrimary[J, A](config.stringPreserveStructure),
+        compression.narrowUnion[J, A](config.unionMaxSize, config.stringPreserveStructure))
 
     @SuppressWarnings(Array("org.wartremover.warts.Var"))
     def iterate(sst: SST[J, A]): Option[SST[J, A]] = {

--- a/impl/src/test/scala/quasar/impl/datasources/DatasourceManagementSpec.scala
+++ b/impl/src/test/scala/quasar/impl/datasources/DatasourceManagementSpec.scala
@@ -29,7 +29,7 @@ import quasar.contrib.scalaz.MonadError_
 import quasar.ejson.EJson
 import quasar.ejson.implicits._
 import quasar.impl.DatasourceModule
-import quasar.impl.schema.{SstConfig, SstSchema}
+import quasar.impl.schema.{SstConfig, SstSchema, SstEvalConfig}
 import quasar.qscript.{MonadPlannerErr, PlannerError, QScriptEducated}
 import quasar.sst._, StructuralType.TypeST
 import quasar.tpe._
@@ -124,7 +124,8 @@ final class DatasourceManagementSpec extends quasar.Qspec with ConditionMatchers
   def withInitialMgmt[A](configured: IMap[Int, DatasourceRef[Json]])(f: (Mgmt, IO[Running]) => IO[A]): A =
     (for {
       s <- Scheduler.allocate[IO](1)
-      t <- DatasourceManagement[Fix, IO, Int, Double](modules, configured, 10L, s._1)
+      evalCfg = SstEvalConfig(10L, 1L, 100L)
+      t <- DatasourceManagement[Fix, IO, Int, Double](modules, configured, evalCfg, s._1)
       (mgmt, run) = t
       a <- f(mgmt, run.get)
       _ <- s._2

--- a/impl/src/test/scala/quasar/impl/schema/ExtractSstSpec.scala
+++ b/impl/src/test/scala/quasar/impl/schema/ExtractSstSpec.scala
@@ -49,6 +49,7 @@ final class ExtractSstSpec extends quasar.Qspec {
 
   def verify(cfg: SstConfig[J, Real], input: List[Data], expected: S) =
     Stream.emits(input)
+      .chunks
       .through(extractSst(cfg))
       .covary[cats.effect.IO]
       .compile.last.unsafeRunSync

--- a/impl/src/test/scala/quasar/impl/schema/ExtractSstSpec.scala
+++ b/impl/src/test/scala/quasar/impl/schema/ExtractSstSpec.scala
@@ -45,7 +45,7 @@ final class ExtractSstSpec extends quasar.Qspec {
     Show.showFromToString
 
   val J = Fixed[J]
-  val config = SstConfig[J, Real](1000L, 1000L, 1000L, 1000L, 1000L)
+  val config = SstConfig[J, Real](1000L, 1000L, 1000L, 1000L, true, 1000L)
 
   def verify(cfg: SstConfig[J, Real], input: List[Data], expected: S) =
     Stream.emits(input)
@@ -113,6 +113,27 @@ final class ExtractSstSpec extends quasar.Qspec {
       ), None))).embed
 
     verify(config.copy(stringMaxLength = 5L), input, expected)
+  }
+
+  "compress long strings without structure" >> {
+    val input = List(
+      _obj(ListMap("foo" -> _str("abcdef"))),
+      _obj(ListMap("bar" -> _str("abcde")))
+    )
+
+    val expected = envT(
+      TypeStat.coll(Real(2), Real(1).some, Real(1).some),
+      TypeST(TypeF.map[J, S](IMap(
+        J.str("foo") -> envT(
+          TypeStat.coll(Real(1), Real(6).some, Real(6).some),
+          TypeST(TypeF.simple[J, S](SimpleType.Str))).embed,
+
+        J.str("bar") -> envT(
+          TypeStat.coll(Real(1), Real(5).some, Real(5).some),
+          TypeST(TypeF.const[J, S](J.str("abcde")))).embed
+      ), None))).embed
+
+    verify(config.copy(stringMaxLength = 5L, stringPreserveStructure = false), input, expected)
   }
 
   "coalesce map keys until <= max size" >> {

--- a/it/src/test/scala/quasar/regression/Sql2QueryRegressionSpec.scala
+++ b/it/src/test/scala/quasar/regression/Sql2QueryRegressionSpec.scala
@@ -30,6 +30,7 @@ import quasar.fp._
 import quasar.frontend.data.DataCodec
 import quasar.impl.datasource.local.LocalType
 import quasar.impl.external.ExternalConfig
+import quasar.impl.schema.SstEvalConfig
 import quasar.mimir.Precog
 import quasar.run.{Quasar, QuasarError, SqlQuery}
 import quasar.run.implicits._
@@ -83,7 +84,9 @@ final class Sql2QueryRegressionSpec extends Qspec {
 
     precog <- Precog.stream(tmpPath.toFile)
 
-    q <- Quasar[IO](precog, ExternalConfig.Empty, 1L)
+    evalCfg = SstEvalConfig(1L, 1L, 1L)
+
+    q <- Quasar[IO](precog, ExternalConfig.Empty, SstEvalConfig.single)
 
     localCfg =
       ("rootDir" := testsDir.toString) ->:

--- a/repl/src/main/scala/quasar/repl/Main.scala
+++ b/repl/src/main/scala/quasar/repl/Main.scala
@@ -22,6 +22,7 @@ import quasar.impl.external.ExternalConfig
 import quasar.common.{PhaseResultCatsT, PhaseResultListen, PhaseResultTell}
 import quasar.contrib.cats.writerT.{catsWriterTMonadListen_, catsWriterTMonadTell_}
 import quasar.contrib.scalaz.MonadError_
+import quasar.impl.schema.SstEvalConfig
 import quasar.mimir.Precog
 import quasar.run.{MonadQuasarErr, Quasar, QuasarError}
 
@@ -59,7 +60,8 @@ object Main extends StreamApp[PhaseResultCatsT[IO, ?]] {
     for {
       (dataPath, pluginPath) <- paths[F]
       precog <- Precog.stream(dataPath.toFile).translate(λ[FunctionK[IO, F]](_.to[F]))
-      q <- Quasar[F](precog, ExternalConfig.PluginDirectory(pluginPath), 1000L)
+      evalCfg = SstEvalConfig(1000L, 2L, 250L)
+      q <- Quasar[F](precog, ExternalConfig.PluginDirectory(pluginPath), evalCfg)
     } yield q
 
   def repl[F[_]: ConcurrentEffect: MonadQuasarErr: PhaseResultListen: PhaseResultTell: Timer](

--- a/run/src/main/scala/quasar/run/Quasar.scala
+++ b/run/src/main/scala/quasar/run/Quasar.scala
@@ -25,7 +25,6 @@ import quasar.common.PhaseResultTell
 import quasar.contrib.pathy.ADir
 import quasar.contrib.std.uuid._
 import quasar.ejson.EJson
-import quasar.fp.numeric.Positive
 import quasar.impl.DatasourceModule
 import quasar.impl.datasource.local.LocalDatasourceModule
 import quasar.impl.datasources.{DatasourceManagement, DefaultDatasources}

--- a/sst/src/main/scala/quasar/sst/strings.scala
+++ b/sst/src/main/scala/quasar/sst/strings.scala
@@ -37,12 +37,12 @@ object strings {
 
   /** Compresses a string into a generic char[]. */
   def compress[T, J, A: ConvertableTo: Order](strStat: TypeStat[A], s: String)(
-    implicit
-    A: Field[A],
-    C: Corecursive.Aux[T, SSTF[J, A, ?]],
-    JC: Corecursive.Aux[J, EJson],
-    JR: Recursive.Aux[J, EJson]
-  ): SSTF[J, A, T] = {
+      implicit
+      A: Field[A],
+      C: Corecursive.Aux[T, SSTF[J, A, ?]],
+      JC: Corecursive.Aux[J, EJson],
+      JR: Recursive.Aux[J, EJson])
+      : SSTF[J, A, T] = {
     // NB: Imported here so as not to pollute outer scope given Iterable's
     //     pervasiveness.
     import scalaz.std.iterable._
@@ -58,15 +58,19 @@ object strings {
     stringTagged(strStat, C.embed(envT(strStat, TypeST(TypeF.arr(charArr)))))
   }
 
+  def simple[T, J, A](strStat: TypeStat[A]): SSTF[J, A, T] =
+    envT(strStat, TypeST[J, T](TypeF.Simple(SimpleType.Str)))
+
   /** Widens a string into an array of its characters.
     *
     * FIXME: Overly specific, define in terms of [Co]Recursive.
     */
   def widen[J: Order, A: ConvertableTo: Field: Order](count: A, s: String)(
-    implicit
-    JC: Corecursive.Aux[J, EJson],
-    JR: Recursive.Aux[J, EJson]
-  ): SSTF[J, A, SST[J, A]] = {
+      implicit
+      JC: Corecursive.Aux[J, EJson],
+      JR: Recursive.Aux[J, EJson])
+      : SSTF[J, A, SST[J, A]] = {
+
     val charArr =
       SST.fromEJson(count, EJson.arr(s.map(EJson.char[J](_)) : _*))
 

--- a/sst/src/test/scala/quasar/sst/StructuralTypeSpec.scala
+++ b/sst/src/test/scala/quasar/sst/StructuralTypeSpec.scala
@@ -65,6 +65,10 @@ final class StructuralTypeSpec extends Spec
   //checkAll(propz.comonad.laws[StructuralType[J, ?]])
 
   "structural semigroup" >> {
+    "is commutative" >> prop { (x: S, y: S) =>
+      (x |+| y) must equal(y |+| x)
+    }
+
     "accumulates measure for identical structure" >> prop { (ejs: J, k0: Int) =>
       val k = scala.math.abs(k0 % 100) + 1
       val st = mkST(ejs)


### PR DESCRIPTION
Some low-hanging fruit to improve SST generation performance

1. Make preservation of string structure during compression optional, defaulting to not preserving structure.
2. Optimize computing an SST from a `Chunk` of data.
3. Leverage the fact that SST merging forms a commutative semigroup to divide and conquer, computing multiple chunks in parallel.