### PR TITLE
Remove `$obj` from precise json.

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,19 +626,16 @@ Type      | Readable        | Precise  | Notes
 null      | `null`          | *same*   |
 boolean   | `true`, `false` | *same*   |
 string    | `"abc"`         | *same*   |
-int       | `1`             | *same*   |
-decimal   | `2.1`           | *same*   |
-object    | `{ "a": 1 }`    | *same*   |
-object    | `{ "$foo": 2 }` | `{ "$obj": { "$foo": 2 } }` | Requires a type-specifier if any key starts with `$`.
+number    | `1`, `2.1`      | *same*   |
+object    | `{ "a": 1 }`    | *same*   | Keys that coincidentally equal a precise temporal key (e.g. "$localtime") are not supported.
 array     | `[1, 2, 3]`     | *same*   |
-localdatetime  | `"2015-01-31T10:30:00"`    | `{ "$localdatetime": "2015-01-31T10:30" }` |
-localdate      | `"2015-01-31"`    | `{ "$localdate": "2015-01-31" }` |
-localtime      | `"10:30:00.000"`    | `{ "$localtime": "10:30" }` |
-offsetdatetime | `"2015-01-31T10:30:00Z"`    | `{ "$offsetdatetime": "2015-01-31T10:30Z" }` |
-offsetdate | `"2015-01-31Z"`    | `{ "$offsetdate": "2015-01-31Z" }` |
-offsettime | `"10:30:00.000Z"`    | `{ "$offsettime": "10:30Z" }` |
-interval  | `"PT12H34M"`    | `{ "$interval": "P7DT12H34M" }` | 
-binary    | `"TE1OTw=="`    | `{ "$binary": "TE1OTw==" }` | BASE64-encoded.
+localdatetime  | `"2015-01-31T10:30:00"`  | `{ "$localdatetime": "2015-01-31T10:30" }`   |
+localdate      | `"2015-01-31"`           | `{ "$localdate": "2015-01-31" }`             |
+localtime      | `"10:30:00.000"`         | `{ "$localtime": "10:30" }`                  |
+offsetdatetime | `"2015-01-31T10:30:00Z"` | `{ "$offsetdatetime": "2015-01-31T10:30Z" }` |
+offsetdate     | `"2015-01-31Z"`          | `{ "$offsetdate": "2015-01-31Z" }`           |
+offsettime     | `"10:30:00.000Z"`        | `{ "$offsettime": "10:30Z" }`                |
+interval       | `"PT12H34M"`             | `{ "$interval": "P7DT12H34M" }`              |
 
 
 ### CSV

--- a/frontend/src/test/scala/quasar/frontend/data/DataCodecSpec.scala
+++ b/frontend/src/test/scala/quasar/frontend/data/DataCodecSpec.scala
@@ -98,17 +98,11 @@ class DataCodecSpecs extends quasar.Qspec {
           """{ "a": 1, "b": 2, "c": 3, "d": 4, "e": 5 }""")
       }
 
-      "encode obj with leading '$'s" in {
+      "encode nonsense obj with leading '$'s (precise)" in {
         DataCodec.render(Data.Obj(ListMap(
           "$a" -> Data.Int(1),
           LocalDateKey -> Data.LocalDateTime(LocalDateTime.parse("2015-01-31T10:30"))))) must beSome(
-
-            s"""{ "$ObjKey": { "$$a": 1, "$LocalDateKey": { "$LocalDateTimeKey": "2015-01-31T10:30:00.000000000" } } }""")
-      }
-
-      "encode obj with $obj" in {
-        DataCodec.render(Data.Obj(ListMap(ObjKey -> Data.Obj(ListMap(ObjKey -> Data.Int(1)))))) must
-          beSome(s"""{ "$ObjKey": { "$ObjKey": { "$ObjKey": { "$ObjKey": 1 } } } }""")
+            s"""{ "$$a": 1, "$LocalDateKey": { "$LocalDateTimeKey": "2015-01-31T10:30:00.000000000" } }""")
       }
 
       "encode array" in {
@@ -190,13 +184,12 @@ class DataCodecSpecs extends quasar.Qspec {
         results must beSome(expected)
       }
 
+      "succeed with unescaped leading '$'" in {
+        DataCodec.parse("""{ "$a": 1 }""") must
+          be_\/-(Data.Obj(ListMap(("$a", Data.Int(1)))))
+      }
 
       // Some invalid inputs:
-
-      "fail with unescaped leading '$'" in {
-        DataCodec.parse("""{ "$a": 1 }""") must
-          be_-\/(UnescapedKeyError(jSingleObject("$a", jNumber(1))))
-      }
 
       "fail with invalid offset date time value" in {
         DataCodec.parse(s"""{ "$OffsetDateTimeKey": 123456 }""") must be_-\/
@@ -269,11 +262,11 @@ class DataCodecSpecs extends quasar.Qspec {
           beSome("""{ "a": 1, "b": 2, "c": 3, "d": 4, "e": 5 }""")
       }
 
-      "encode obj with leading '$'s" in {
+      "encode nonsense obj with precise key paired with non-precise key (readable)" in {
         DataCodec.render(Data.Obj(ListMap(
           "$a" -> Data.Int(1),
-          LocalDateTimeKey -> Data.LocalDateTime(LocalDateTime.parse("2015-01-31T10:30"))))) must
-          beSome(s"""{ "$$a": 1, "$LocalDateTimeKey": "2015-01-31T10:30" }""")
+          LocalDateKey -> Data.LocalDateTime(LocalDateTime.parse("2015-01-31T10:30"))))) must
+          beSome(s"""{ "$$a": 1, "$LocalDateKey": "2015-01-31T10:30" }""")
       }
 
       "encode array" in {

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/Slice.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/Slice.scala
@@ -1766,9 +1766,6 @@ abstract class Slice { source =>
     import DataCodec.PreciseKeys._
 
     def inner(node: SchemaNode): SchemaNode = node match {
-      case obj @ SchemaNode.Obj(nodes) if obj.keys.exists(_.contains("$")) =>
-        SchemaNode.Obj(Map(ObjKey -> SchemaNode.Obj(nodes.mapValues(inner))))
-
       case SchemaNode.Obj(nodes) =>
         SchemaNode.Obj(nodes.mapValues(inner))
 


### PR DESCRIPTION
We no longer support keys that coincidentally share a name with a precise key.