### PR TITLE
Coalesce mappable regions before ApplyProvenance 

### DIFF
--- a/qsu/src/main/scala/quasar/qsu/CoalesceUnaryMappable.scala
+++ b/qsu/src/main/scala/quasar/qsu/CoalesceUnaryMappable.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qsu
+
+import quasar.fp._
+import quasar.qscript.RecFreeS._
+
+import scalaz.syntax.equal._
+
+/** Coalesces adjacent mappable regions of a single root. */
+final class CoalesceUnaryMappable[T[_[_]]] private () extends QSUTTypes[T] {
+  def apply(graph: QSUGraph): QSUGraph =
+    graph rewrite {
+      case g @ MappableRegion.MaximalUnary(src, fm) if g.root =/= src.root =>
+        g.overwriteAtRoot(QScriptUniform.Map(src.root, fm.asRec))
+    }
+}
+
+object CoalesceUnaryMappable {
+  def apply[T[_[_]]](graph: QSUGraph[T]): QSUGraph[T] =
+    (new CoalesceUnaryMappable[T])(graph)
+}

--- a/qsu/src/main/scala/quasar/qsu/InlineNullary.scala
+++ b/qsu/src/main/scala/quasar/qsu/InlineNullary.scala
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qsu
+
+import slamdata.Predef.{None, Option, Some, String, Symbol}
+
+import quasar.common.effect.NameGenerator
+import quasar.qscript.{
+  Center,
+  HoleF,
+  LeftSide,
+  LeftSideF,
+  LeftSide3,
+  RecFreeS,
+  RightSide,
+  RightSideF,
+  RightSide3
+}
+
+import scalaz.{Monad, StateT}
+import scalaz.syntax.monad._
+
+/** Inlines nullary mappable expressions into AutoJoin combiners, reducing or
+  * eliminating the AutoJoin.
+  */
+final class InlineNullary[T[_[_]]] private () extends QSUTTypes[T] {
+  import QSUGraph.Extractors._
+  import RecFreeS._
+
+  private val namePrefix: String = "iln"
+
+  def apply[F[_]: Monad: NameGenerator: RevIdxM](graph: QSUGraph): F[QSUGraph] =
+    graph rewriteM[F] {
+      case g @ AutoJoin2(left, right, combine) =>
+        (nullary(left), nullary(right)) match {
+          case (Some(l), Some(r)) =>
+            val fm = combine flatMap {
+              case LeftSide => l
+              case RightSide => r
+            }
+
+            QSUGraph.withName[T, F](namePrefix)(QSU.Unreferenced[T, Symbol]()) map { u =>
+              g.overwriteAtRoot(QSU.Map(u.root, fm.asRec))
+            }
+
+          case (Some(l), None) =>
+            val fm = combine flatMap {
+              case LeftSide => l
+              case RightSide => HoleF[T]
+            }
+            g.overwriteAtRoot(QSU.Map(right.root, fm.asRec)).point[F]
+
+          case (None, Some(r)) =>
+            val fm = combine flatMap {
+              case LeftSide => HoleF[T]
+              case RightSide => r
+            }
+            g.overwriteAtRoot(QSU.Map(left.root, fm.asRec)).point[F]
+
+          case (None, None) => g.point[F]
+        }
+
+      case g @ AutoJoin3(left, center, right, combine) =>
+        (nullary(left), nullary(center), nullary(right)) match {
+          case (Some(l), Some(c), Some(r)) =>
+            val fm = combine flatMap {
+              case LeftSide3 => l
+              case Center => c
+              case RightSide3 => r
+            }
+
+            QSUGraph.withName[T, F](namePrefix)(QSU.Unreferenced[T, Symbol]()) map { u =>
+              g.overwriteAtRoot(QSU.Map(u.root, fm.asRec))
+            }
+
+          case (Some(l), Some(c), None) =>
+            val fm = combine flatMap {
+              case LeftSide3 => l
+              case Center => c
+              case RightSide3 => HoleF[T]
+            }
+            g.overwriteAtRoot(QSU.Map(right.root, fm.asRec)).point[F]
+
+          case (Some(l), None, Some(r)) =>
+            val fm = combine flatMap {
+              case LeftSide3 => l
+              case Center => HoleF[T]
+              case RightSide3 => r
+            }
+            g.overwriteAtRoot(QSU.Map(center.root, fm.asRec)).point[F]
+
+          case (Some(l), None, None) =>
+            val jf = combine flatMap {
+              case LeftSide3 => l >> LeftSideF[T]
+              case Center => LeftSideF[T]
+              case RightSide3 => RightSideF[T]
+            }
+            g.overwriteAtRoot(QSU.AutoJoin2(center.root, right.root, jf)).point[F]
+
+          case (None, Some(c), Some(r)) =>
+            val fm = combine flatMap {
+              case LeftSide3 => HoleF[T]
+              case Center => c
+              case RightSide3 => r
+            }
+            g.overwriteAtRoot(QSU.Map(left.root, fm.asRec)).point[F]
+
+          case (None, Some(c), None) =>
+            val jf = combine flatMap {
+              case LeftSide3 => LeftSideF[T]
+              case Center => c >> LeftSideF[T]
+              case RightSide3 => RightSideF[T]
+            }
+            g.overwriteAtRoot(QSU.AutoJoin2(left.root, right.root, jf)).point[F]
+
+          case (None, None, Some(r)) =>
+            val jf = combine flatMap {
+              case LeftSide3 => LeftSideF[T]
+              case Center => RightSideF[T]
+              case RightSide3 => r >> LeftSideF[T]
+            }
+            g.overwriteAtRoot(QSU.AutoJoin2(left.root, center.root, jf)).point[F]
+
+          case (None, None, None) => g.point[F]
+        }
+    }
+
+  private val QSU = QScriptUniform
+
+  private val nullary: QSUGraph => Option[FreeMap] =
+    MappableRegion.MaximalNullary.unapply[T] _
+}
+
+object InlineNullary {
+  def apply[T[_[_]], F[_]: Monad: NameGenerator](graph: QSUGraph[T]): F[QSUGraph[T]] = {
+    type G[A] = StateT[F, QSUGraph.RevIdx[T], A]
+    (new InlineNullary[T])[G](graph).eval(graph.generateRevIndex)
+  }
+}

--- a/qsu/src/main/scala/quasar/qsu/LPtoQS.scala
+++ b/qsu/src/main/scala/quasar/qsu/LPtoQS.scala
@@ -45,7 +45,11 @@ final class LPtoQS[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT]
       RewriteGroupByArrays[T, F]             >-
       debug("RewriteGroupByArrays")          >-
       EliminateUnary[T]                      >-
-      debug("EliminateUnary")                >-
+      debug("EliminateUnary")                >==>
+      InlineNullary[T, F]                    >-
+      debug("InlineNullary")                 >-
+      CoalesceUnaryMappable[T]               >-
+      debug("CoalesceUnaryMappable")         >-
       RecognizeDistinct[T]                   >-
       debug("RecognizeDistinct")             >==>
       ExtractFreeMap[T, F]                   >-

--- a/qsu/src/test/scala/quasar/qsu/CoalesceUnaryMappableSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/CoalesceUnaryMappableSpec.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qsu
+
+import quasar.{Qspec, TreeMatchers}
+import quasar.contrib.iota._
+import quasar.contrib.matryoshka._
+import quasar.contrib.pathy.AFile
+import quasar.ejson.{EJson, Fixed}
+import quasar.ejson.implicits._
+import quasar.fp._
+import quasar.qscript.construction
+
+import matryoshka._
+import matryoshka.data._
+import pathy.Path._
+
+object CoalesceUnaryMappableSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
+  import QSUGraph.Extractors._
+
+  val qsu = QScriptUniform.DslT[Fix]
+  val rec = construction.RecFunc[Fix]
+  val mf = construction.Func[Fix]
+  val J = Fixed[Fix[EJson]]
+
+  val dataA: AFile = rootDir </> file("dataA")
+
+  val coalesce = CoalesceUnaryMappable[Fix] _
+
+  "coalescing mappable regions having a single root" should {
+    "be the identity for a Map applied to a non-mappable root" >> {
+      val g = QSUGraph.fromTree[Fix](
+        qsu.map(
+          qsu.read(dataA),
+          rec.ProjectKeyS(rec.Hole, "A")))
+
+      coalesce(g) must beLike {
+        case Map(Read(p), f) =>
+          val exp = mf.ProjectKeyS(mf.Hole, "A")
+          p must_= dataA
+          f.linearize must beTreeEqual(exp)
+      }
+    }
+
+    "compose the functions of adjacent Map nodes" >> {
+      val g = QSUGraph.fromTree[Fix](
+        qsu.map(
+          qsu.map(
+            qsu.map(
+              qsu.read(dataA),
+              rec.ProjectKeyS(rec.Hole, "X")),
+            rec.ProjectKeyS(rec.Hole, "Y")),
+          rec.ProjectKeyS(rec.Hole, "Z")))
+
+      coalesce(g) must beLike {
+        case Map(Read(p), f) =>
+          val exp =
+            mf.ProjectKeyS(mf.ProjectKeyS(mf.ProjectKeyS(mf.Hole, "X"), "Y"), "Z")
+
+          p must_= dataA
+          f.linearize must beTreeEqual(exp)
+      }
+    }
+  }
+}

--- a/qsu/src/test/scala/quasar/qsu/InlineNullarySpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/InlineNullarySpec.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qsu
+
+import slamdata.Predef._
+import quasar.{Qspec, TreeMatchers}
+import quasar.contrib.iota._
+import quasar.contrib.matryoshka._
+import quasar.contrib.pathy.AFile
+import quasar.ejson.{EJson, Fixed}
+import quasar.ejson.implicits._
+import quasar.fp._
+import quasar.qscript.{construction, Hole, JoinSide}
+
+import matryoshka._
+import matryoshka.data._
+import pathy.Path._
+import scalaz.State
+
+object InlineNullarySpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
+  import QSUGraph.Extractors._
+
+  val qsu = QScriptUniform.DslT[Fix]
+  val rec = construction.RecFunc[Fix]
+  val mf = construction.Func[Fix]
+  val J = Fixed[Fix[EJson]]
+
+  val dataA: AFile = rootDir </> file("dataA")
+  val dataB: AFile = rootDir </> file("dataB")
+
+  def inlineNullary(g: QSUGraph): QSUGraph =
+    InlineNullary[Fix, State[Long, ?]](g).eval(1)
+
+  "inlining nullary nodes" should {
+    "be identity for nullary Map nodes" >> {
+      val fm =
+        rec.MakeMapS("now", rec.Now[Hole])
+
+      val g = QSUGraph.fromTree[Fix](
+        qsu.map(qsu.unreferenced(), fm))
+
+      inlineNullary(g) must beLike {
+        case Map(Unreferenced(), f) =>
+          f.linearize must beTreeEqual(fm.linearize)
+      }
+    }
+
+    "convert an AutoJoin2 with a nullary root into a Map" >> {
+      val key = rec.Constant[Hole](J.str("k1"))
+      val fm = mf.MakeMap(mf.LeftSide, mf.RightSide)
+
+      val g = QSUGraph.fromTree[Fix](
+        qsu._autojoin2(
+          qsu.map(
+            qsu.unreferenced(),
+            key),
+          qsu.read(dataA),
+          fm))
+
+      inlineNullary(g) must beLike {
+        case Map(Read(p), f) =>
+          val exp = mf.MakeMapS("k1", mf.Hole)
+          p must_= dataA
+          f.linearize must beTreeEqual(exp)
+      }
+    }
+
+    "convert an AutoJoin3 with one nullary root into an AutoJoin2" >> {
+      val g = QSUGraph.fromTree[Fix](
+        qsu._autojoin3(
+          qsu.map(
+            qsu.unreferenced(),
+            rec.Eq(rec.Now[Hole], rec.Constant(J.int(0)))),
+          qsu.read(dataA),
+          qsu.read(dataB),
+          mf.Cond(mf.LeftSide3, mf.Center, mf.RightSide3)))
+
+      inlineNullary(g) must beLike {
+        case AutoJoin2(Read(l), Read(r), f) =>
+          l must_= dataA
+          r must_= dataB
+
+          val exp = mf.Cond(
+            mf.Eq(mf.Now[JoinSide], mf.Constant(J.int(0))),
+            mf.LeftSide,
+            mf.RightSide)
+
+          f must beTreeEqual(exp)
+      }
+    }
+
+    "convert an AutoJoin3 with two nullary roots into a Map" >> {
+      val g = QSUGraph.fromTree[Fix](
+        qsu._autojoin3(
+          qsu.map(
+            qsu.unreferenced(),
+            rec.Eq(rec.Now[Hole], rec.Constant(J.int(0)))),
+          qsu.read(dataA),
+          qsu.map(
+            qsu.unreferenced(),
+            rec.Constant[Hole](J.str("row"))),
+          mf.Cond(mf.LeftSide3, mf.Center, mf.RightSide3)))
+
+      inlineNullary(g) must beLike {
+        case Map(Read(l), f) =>
+          l must_= dataA
+
+          val exp = mf.Cond(
+            mf.Eq(mf.Now[Hole], mf.Constant(J.int(0))),
+            mf.Hole,
+            mf.Constant(J.str("row")))
+
+          f.linearize must beTreeEqual(exp)
+      }
+    }
+  }
+}

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/Slice.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/Slice.scala
@@ -19,7 +19,6 @@ package quasar.yggdrasil.table
 import quasar.blueeyes._, json._
 import quasar.common.data.PreciseKeys
 import quasar.contrib.std.errorImpossible
-import quasar.frontend.data.DataCodec
 import quasar.precog._
 import quasar.precog.common._
 import quasar.precog.util._


### PR DESCRIPTION
Inlines nullary regions and coalesces unary ones prior to computing provenance to avoid having to create existentials due to "dynamic" project/injects.

Also appears to speed up compilation in general due to shrinking the size of the graph earlier on in the process.