### PR TITLE
Avoid simplifying constant comparisons in outer joins

### DIFF
--- a/it/src/main/resources/tests/joins/staticOuterJoin.test
+++ b/it/src/main/resources/tests/joins/staticOuterJoin.test
@@ -1,0 +1,21 @@
+{
+    "name": "[qa_s07] full outer join with static join condition",
+
+    "backends": {
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
+    },
+
+    "data": ["../extraSmallZips.data"],
+
+    "query": "select l.state as lstate, l.city as lcity, r.state as rstate, r.city as rcity from `../extraSmallZips.data` as l full outer join `../extraSmallZips.data` as r on 1 = 0",
+
+    "predicate": "atLeast",
+    "ignoreResultOrder": true,
+
+    "expected": [
+        {"rcity": "AGAWAM",  "rstate": "MA" },
+        {"rcity": "CUSHMAN", "rstate": "MA" },
+        {"lcity": "AGAWAM",  "lstate": "MA" },
+        {"lcity": "CUSHMAN", "lstate": "MA" }]
+}

--- a/qscript/src/main/scala/quasar/qscript/MapFuncCore.scala
+++ b/qscript/src/main/scala/quasar/qscript/MapFuncCore.scala
@@ -363,6 +363,14 @@ object MapFuncCore {
       case _ => none
     }
 
+  // normalize but don't rewrite
+  def transform[T[_[_]]: BirecursiveT: EqualT, A: Equal]
+      : CoMapFuncR[T, A] => CoMapFuncR[T, A] =
+    orOriginal(DedupeGuards[T, A]) <<<
+    repeatedly(applyTransforms(
+      foldConstant[T, A].apply(_) ∘ (const => rollMF[T, A](MFC(Constant(const)))),
+      ExtractFiltering[T, A]))
+
   def normalize[T[_[_]]: BirecursiveT: EqualT, A: Equal]
       : CoMapFuncR[T, A] => CoMapFuncR[T, A] =
     orOriginal(DedupeGuards[T, A]) <<<


### PR DESCRIPTION
This fixes the old `SimplifyJoin` rewrite. The new integration test will catch this bug when we finally move this rewrite to QSU.