### PR TITLE
Implement CONTAINS_KEY

### DIFF
--- a/core/src/main/scala/quasar/compile/Compiler.scala
+++ b/core/src/main/scala/quasar/compile/Compiler.scala
@@ -267,6 +267,7 @@ final class Compiler[M[_], T: Equal]
       CIName("map_concat")              -> structural.MapConcat,
       CIName("array_concat")            -> structural.ArrayConcat,
       CIName("delete_key")              -> structural.DeleteKey,
+      CIName("contains_key")            -> structural.ContainsKey,
       CIName("flatten_map")             -> structural.FlattenMap,
       CIName("flatten_array")           -> structural.FlattenArray,
       CIName("shift_map")               -> structural.ShiftMap,

--- a/frontend/src/main/scala/quasar/std/structural.scala
+++ b/frontend/src/main/scala/quasar/std/structural.scala
@@ -85,6 +85,11 @@ trait StructuralLib extends Library {
     "Deletes a specified key from a map",
     noSimplification)
 
+  val ContainsKey: BinaryFunc = BinaryFunc(
+    Mapping,
+    "Checks for the existence of the specified key in a map",
+    noSimplification)
+
   val FlattenMap = UnaryFunc(
     Expansion,
     "Zooms in on the values of a map, extending the current dimension with the keys",

--- a/frontend/src/test/scala/quasar/std/StdLibSpec.scala
+++ b/frontend/src/test/scala/quasar/std/StdLibSpec.scala
@@ -1531,7 +1531,7 @@ abstract class StdLibSpec extends Qspec {
         "arbitrary double" >> prop { (d: Double) =>
           val n = BigDecimal(d)
           val data =
-            // testing with the generated double if it is not a Long or 
+            // testing with the generated double if it is not a Long or
             // if it is an exact double
             if ((d != d.toLong) || (n.isExactDouble)) Data.Dec(n)
             // .. but if it is a Long but not an exact double then we test with
@@ -3150,6 +3150,40 @@ abstract class StdLibSpec extends Qspec {
             Data.Obj("a" -> Data.Int(1), "b" -> Data.Int(2)),
             Data.Str("c"),
             Data.Obj("a" -> Data.Int(1), "b" -> Data.Int(2)))
+        }
+      }
+
+      "ContainsKey" >> {
+        """CONTAINS_KEY({a:42, b:true}, "b")""" >> {
+          binary(
+            ContainsKey(_, _).embed,
+            Data.Obj("a" -> Data.Int(42), "b" -> Data.Bool(true)),
+            Data.Str("b"),
+            Data.Bool(true))
+        }
+
+        """CONTAINS_KEY({a:42, b:true}, "c")""" >> {
+          binary(
+            ContainsKey(_, _).embed,
+            Data.Obj("a" -> Data.Int(42), "b" -> Data.Bool(true)),
+            Data.Str("c"),
+            Data.Bool(false))
+        }
+
+        """CONTAINS_KEY({a:42, b:true + 12}, "b")""" >> {
+          binary(
+            ContainsKey(_, _).embed,
+            Data.Obj("a" -> Data.Int(42), "b" -> Data.NA),
+            Data.Str("b"),
+            Data.Bool(false))
+        }
+
+        """CONTAINS_KEY("derp", "b")""" >> {
+          binary(
+            ContainsKey(_, _).embed,
+            Data.Str("derp"),
+            Data.Str("b"),
+            Data.Bool(false))
         }
       }
 

--- a/frontend/src/test/scala/quasar/std/StdLibSpec.scala
+++ b/frontend/src/test/scala/quasar/std/StdLibSpec.scala
@@ -3183,7 +3183,7 @@ abstract class StdLibSpec extends Qspec {
             ContainsKey(_, _).embed,
             Data.Str("derp"),
             Data.Str("b"),
-            Data.Bool(false))
+            Data.NA)
         }
       }
 

--- a/mimir/src/main/scala/quasar/mimir/MapFuncCorePlanner.scala
+++ b/mimir/src/main/scala/quasar/mimir/MapFuncCorePlanner.scala
@@ -272,7 +272,9 @@ final class MapFuncCorePlanner[T[_[_]]: RecursiveT, F[_]: Applicative]
       case MapFuncsCore.DeleteKey(src, field) => errorNotImplemented
 
       case MapFuncsCore.ContainsKey(src, ConstLiteral(CString(key), _)) =>
-        (IsType[A](src, JObjectFixedT(Map(key -> JType.JUniverseT))): TransSpec[A]).point[F]
+        (IsType[A](
+          Typed[A](src, JObjectUnfixedT),
+          JObjectFixedT(Map(key -> JType.JUniverseT))): TransSpec[A]).point[F]
 
       // mimir doesn't have a way to implement this
       case MapFuncsCore.ContainsKey(_, _) => errorNotImplemented

--- a/mimir/src/main/scala/quasar/mimir/MapFuncCorePlanner.scala
+++ b/mimir/src/main/scala/quasar/mimir/MapFuncCorePlanner.scala
@@ -271,6 +271,12 @@ final class MapFuncCorePlanner[T[_[_]]: RecursiveT, F[_]: Applicative]
       // mimir doesn't have a way to implement this
       case MapFuncsCore.DeleteKey(src, field) => errorNotImplemented
 
+      case MapFuncsCore.ContainsKey(src, ConstLiteral(CString(key), _)) =>
+        (IsType[A](src, JObjectFixedT(Map(key -> JType.JUniverseT))): TransSpec[A]).point[F]
+
+      // mimir doesn't have a way to implement this
+      case MapFuncsCore.ContainsKey(_, _) => errorNotImplemented
+
       case MapFuncsCore.Meta(a1) => errorNotImplemented
 
       case MapFuncsCore.Range(from, to) =>

--- a/qscript/src/main/scala/quasar/qscript/MapFunc.scala
+++ b/qscript/src/main/scala/quasar/qscript/MapFunc.scala
@@ -122,6 +122,7 @@ object MapFunc {
     case structural.ArrayProject => (a1, a2) => MFC(C.ProjectIndex(a1, a2))
     case structural.MapProject => (a1, a2) => MFC(C.ProjectKey(a1, a2))
     case structural.DeleteKey => (a1, a2) => MFC(C.DeleteKey(a1, a2))
+    case structural.ContainsKey => (a1, a2) => MFC(C.ContainsKey(a1, a2))
     case string.Concat
        | structural.ArrayConcat
        | structural.ConcatOp => (a1, a2) => MFC(C.ConcatArrays(a1, a2))

--- a/qscript/src/main/scala/quasar/qscript/MapFuncCore.scala
+++ b/qscript/src/main/scala/quasar/qscript/MapFuncCore.scala
@@ -553,6 +553,7 @@ object MapFuncCore {
         case ProjectIndex(a1, a2) => (f(a1) ⊛ f(a2))(ProjectIndex(_, _))
         case ProjectKey(a1, a2) => (f(a1) ⊛ f(a2))(ProjectKey(_, _))
         case DeleteKey(a1, a2) => (f(a1) ⊛ f(a2))(DeleteKey(_, _))
+        case ContainsKey(a1, a2) => (f(a1) ⊛ f(a2))(ContainsKey(_, _))
         case ConcatArrays(a1, a2) => (f(a1) ⊛ f(a2))(ConcatArrays(_, _))
         case Range(a1, a2) => (f(a1) ⊛ f(a2))(Range(_, _))
         case Split(a1, a2) => (f(a1) ⊛ f(a2))(Split(_, _))
@@ -655,6 +656,7 @@ object MapFuncCore {
         case (ProjectIndex(a1, a2), ProjectIndex(b1, b2)) => in.equal(a1, b1) && in.equal(a2, b2)
         case (ProjectKey(a1, a2), ProjectKey(b1, b2)) => in.equal(a1, b1) && in.equal(a2, b2)
         case (DeleteKey(a1, a2), DeleteKey(b1, b2)) => in.equal(a1, b1) && in.equal(a2, b2)
+        case (ContainsKey(a1, a2), ContainsKey(b1, b2)) => in.equal(a1, b1) && in.equal(a2, b2)
         case (ConcatArrays(a1, a2), ConcatArrays(b1, b2)) => in.equal(a1, b1) && in.equal(a2, b2)
         case (Range(a1, a2), Range(b1, b2)) => in.equal(a1, b1) && in.equal(a2, b2)
         case (Split(a1, a2), Split(b1, b2)) => in.equal(a1, b1) && in.equal(a2, b2)
@@ -758,6 +760,7 @@ object MapFuncCore {
           case ProjectIndex(a1, a2) => shz("ProjectIndex", a1, a2)
           case ProjectKey(a1, a2) => shz("ProjectKey", a1, a2)
           case DeleteKey(a1, a2) => shz("DeleteKey", a1, a2)
+          case ContainsKey(a1, a2) => shz("ContainsKey", a1, a2)
           case ConcatArrays(a1, a2) => shz("ConcatArrays", a1, a2)
           case Range(a1, a2) => shz("Range", a1, a2)
           case SetTimeZone(a1, a2) => shz("SetTimeZone", a1, a2)
@@ -873,6 +876,7 @@ object MapFuncCore {
           case ProjectIndex(a1, a2) => nAry("ProjectIndex", a1, a2)
           case ProjectKey(a1, a2) => nAry("ProjectKey", a1, a2)
           case DeleteKey(a1, a2) => nAry("DeleteKey", a1, a2)
+          case ContainsKey(a1, a2) => nAry("ContainsKey", a1, a2)
           case ConcatArrays(a1, a2) => nAry("ConcatArrays", a1, a2)
           case Range(a1, a2) => nAry("Range", a1, a2)
           case SetTimeZone(a1, a2) => nAry("SetTimeZone", a1, a2)
@@ -1043,6 +1047,11 @@ object MapFuncsCore {
     def a1 = src
     def a2 = key
   }
+  @Lenses final case class ContainsKey[T[_[_]], A](src: A, key: A) extends Binary[T, A] {
+    def a1 = src
+    def a2 = key
+  }
+
   @Lenses final case class Meta[T[_[_]], A](a1: A) extends Unary[T, A]
 
   @Lenses final case class Range[T[_[_]], A](from: A, to: A) extends Binary[T, A] {

--- a/qscript/src/main/scala/quasar/qscript/RenderQScriptDSL.scala
+++ b/qscript/src/main/scala/quasar/qscript/RenderQScriptDSL.scala
@@ -113,7 +113,7 @@ object RenderQScriptDSL {
       }
     }
   }
-  
+
   def ejsonRenderQScriptDSLDelay: Delay[RenderQScriptDSL, EJson] = new Delay[RenderQScriptDSL, EJson] {
     def apply[A](fa: RenderQScriptDSL[A]): RenderQScriptDSL[EJson[A]] = {
       (base: String, a: EJson[A]) =>
@@ -258,6 +258,7 @@ object RenderQScriptDSL {
               case ProjectIndex(a1, a2) => ("ProjectIndex", (fa(base, a1).right :: fa(base, a2).right :: Nil).some)
               case ProjectKey(a1, a2) => ("ProjectKey", (fa(base, a1).right :: fa(base, a2).right :: Nil).some)
               case DeleteKey(a1, a2) => ("DeleteKey", (fa(base, a1).right :: fa(base, a2).right :: Nil).some)
+              case ContainsKey(a1, a2) => ("ContainsKey", (fa(base, a1).right :: fa(base, a2).right :: Nil).some)
               case ConcatArrays(a1, a2) => ("ConcatArrays", (fa(base, a1).right :: fa(base, a2).right :: Nil).some)
               case Range(a1, a2) => ("Range", (fa(base, a1).right :: fa(base, a2).right :: Nil).some)
               case Split(a1, a2) => ("Split", (fa(base, a1).right :: fa(base, a2).right :: Nil).some)


### PR DESCRIPTION
Heads up, @garyb. Publishing as snapshot version `68.2.0-31c90da` which is eviction compatible with 68.2.0. You should be able to test this within the launcher (by appending version directive `quasar:68.2.0-31c90da`).

@alissapajer I would mark this as ☠️ but github is being weird. Please review and merge asap.

[ch2071]