### PR TITLE
Adds an optimize qscript rewrite stage

### DIFF
--- a/mimir/src/main/scala/quasar/mimir/evaluate/MimirQScriptEvaluator.scala
+++ b/mimir/src/main/scala/quasar/mimir/evaluate/MimirQScriptEvaluator.scala
@@ -28,7 +28,7 @@ import quasar.mimir
 import quasar.mimir.{MimirQScriptCP, MimirRepr}
 import quasar.mimir.MimirCake._
 import quasar.qscript._
-import quasar.qscript.rewrites.Unirewrite
+import quasar.qscript.rewrites.{Optimize, Unirewrite}
 import quasar.yggdrasil.MonadFinalizers
 
 import scala.Predef.implicitly
@@ -76,6 +76,8 @@ final class MimirQScriptEvaluator[
 
   def UnirewriteT: Unirewrite[T, QS[T]] =
     implicitly[Unirewrite[T, QS[T]]]
+
+  def optimize: QSM[T[QSM]] => QSM[T[QSM]] = Optimize[T, QSM]
 
   def execute(repr: Repr): M[Repr] =
     repr.point[M]

--- a/qscript/src/main/scala/quasar/qscript/rewrites/Optimize.scala
+++ b/qscript/src/main/scala/quasar/qscript/rewrites/Optimize.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript.rewrites
+
+import quasar.contrib.iota._
+import quasar.fp.liftFG
+import quasar.qscript._
+import quasar.qscript.MapFuncCore._
+
+import matryoshka._
+import matryoshka.data._
+
+import scalaz.Functor
+import scalaz.syntax.equal._
+
+final class Optimize[T[_[_]]: BirecursiveT: EqualT] extends TTypes[T] {
+
+  def elideNopMap[F[a] <: ACopK[a]: Functor](implicit QC: QScriptCore :<<: F)
+      : QScriptCore[T[F]] => F[T[F]] = {
+    case Map(Embed(src), mf) if mf === HoleR => src
+    case qc => QC.inj(qc)
+  }
+}
+
+object Optimize {
+  def apply[T[_[_]]: BirecursiveT: EqualT, F[a] <: ACopK[a]: Functor](
+      implicit QC: QScriptCore[T, ?] :<<: F)
+      : F[T[F]] => F[T[F]] = {
+    val opt = new Optimize[T]
+    liftFG[QScriptCore[T, ?], F, T[F]](opt.elideNopMap)
+  }
+}

--- a/qscript/src/test/scala/quasar/qscript/rewrites/OptimizeSpec.scala
+++ b/qscript/src/test/scala/quasar/qscript/rewrites/OptimizeSpec.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript.rewrites
+
+import quasar.Qspec
+import quasar.contrib.iota._
+import quasar.contrib.pathy._
+import quasar.ejson.{EJson, Fixed}
+import quasar.fp._
+import quasar.qscript.{ExcludeId, QScriptHelpers}
+
+import matryoshka.data.Fix
+import matryoshka.implicits._
+import pathy.Path._
+
+object OptimizeSpec extends Qspec with QScriptHelpers {
+  import qstdsl.{fix, recFunc}
+
+  val ejs = Fixed[Fix[EJson]]
+
+  def optimize(expr: Fix[QST]): Fix[QST] =
+    expr.transCata[Fix[QST]](Optimize[Fix, QST])
+
+  "optimize" >> {
+
+    "elide outer no-op map" >> {
+      val src: Fix[QST] =
+        fix.ShiftedRead[AFile](rootDir </> file("foo"), ExcludeId)
+
+      optimize(fix.Map(src, recFunc.Hole)) must equal(src)
+    }
+
+    "elide nested no-op map" >> {
+      val src: Fix[QST] =
+        fix.Map(
+          fix.ShiftedRead[AFile](rootDir </> file("foo"), ExcludeId),
+          recFunc.ProjectKeyS(recFunc.Hole, "bar"))
+
+      val qs: Fix[QST] =
+        fix.Filter(
+          fix.Map(src, recFunc.Hole),
+          recFunc.ProjectKeyS(recFunc.Hole, "baz"))
+
+      val expected: Fix[QST] =
+        fix.Filter(
+          src,
+          recFunc.ProjectKeyS(recFunc.Hole, "baz"))
+
+      optimize(qs) must equal(expected)
+    }
+
+    "elide double no-op map" >> {
+      val src: Fix[QST] =
+        fix.ShiftedRead[AFile](rootDir </> file("foo"), ExcludeId)
+
+      optimize(fix.Map(fix.Map(src, recFunc.Hole), recFunc.Hole)) must equal(src)
+    }
+  }
+}


### PR DESCRIPTION
Sets the stage for where we'll perform qscript rewrites that we intend to keep as qscript rewrites and not eventually move to qsu.

This particular rewrite (elide no-op map) will allow us to more consistently match on the pattern
```
LeftShift
├─ ShiftedRead(/giraffe.json, _)
...
```
as currently in master this pattern often appears as
```
LeftShift
├─ Map
│  ├─ ShiftedRead(/giraffe.json, _)
│  ╰─ ○
...
```
We'll be matching this pattern as part of the parse-shift work, because we'll be rewriting certain qscript into an `ExtraShiftedRead`.