### PR TITLE
Delete some unused implicits from the qscript evaluator

### DIFF
--- a/connector/src/main/scala/quasar/connector/QScriptEvaluator.scala
+++ b/connector/src/main/scala/quasar/connector/QScriptEvaluator.scala
@@ -18,9 +18,7 @@ package quasar.connector
 
 import slamdata.Predef.Set
 import quasar.RenderTreeT
-import quasar.contrib.iota.:<<:
 import quasar.contrib.pathy._
-import quasar.fp._
 import quasar.fp.ski.κ
 import quasar.qscript._
 import quasar.qscript.rewrites._
@@ -45,8 +43,6 @@ abstract class QScriptEvaluator[
   type Repr
 
   def QSMFunctor: Functor[QSM]
-  def QSMFromQScriptCore: QScriptCore[T, ?] :<<: QSM
-  def QSMToQScriptTotal: Injectable[QSM, QScriptTotal[T, ?]]
   def UnirewriteT: Unirewrite[T, QS[T]]
 
   /** Returns the result of executing the `Repr`. */
@@ -69,7 +65,5 @@ abstract class QScriptEvaluator[
     } yield result
 
   private final implicit def _QSMFunctor: Functor[QSM] = QSMFunctor
-  private final implicit def _QSMFromQScriptCore: QScriptCore[T, ?] :<<: QSM = QSMFromQScriptCore
-  private final implicit def _QSMToQScriptTotal: Injectable[QSM, QScriptTotal[T, ?]] = QSMToQScriptTotal
   private final implicit def _UnirewriteT: Unirewrite[T, QS[T]] = UnirewriteT
 }

--- a/mimir/src/main/scala/quasar/mimir/evaluate/MimirQScriptEvaluator.scala
+++ b/mimir/src/main/scala/quasar/mimir/evaluate/MimirQScriptEvaluator.scala
@@ -56,26 +56,12 @@ final class MimirQScriptEvaluator[
 
   type Repr = MimirRepr
 
-  implicit def QSMFromQScriptCoreI: Injectable[QScriptCore[T, ?], QSM] =
-    Injectable.inject[QScriptCore[T, ?], QSM]
-
-  implicit def QSMFromEquiJoinI: Injectable[EquiJoin[T, ?], QSM] =
-    Injectable.inject[EquiJoin[T, ?], QSM]
-
-  implicit def QSMFromShiftedReadI: Injectable[Const[ShiftedRead[AFile], ?], QSM] =
-    Injectable.inject[Const[ShiftedRead[AFile], ?], QSM]
-
   implicit def QSMToQScriptTotal: Injectable[QSM, QScriptTotal[T, ?]] =
     mimir.qScriptToQScriptTotal[T]
 
-  def QSMFunctor: Functor[QSM] =
-    Functor[QSM]
+  def QSMFunctor: Functor[QSM] = Functor[QSM]
 
-  def QSMFromQScriptCore: QScriptCore[T, ?] :<<: QSM =
-    CopK.Inject[QScriptCore[T, ?], QSM]
-
-  def UnirewriteT: Unirewrite[T, QS[T]] =
-    implicitly[Unirewrite[T, QS[T]]]
+  def UnirewriteT: Unirewrite[T, QS[T]] = implicitly[Unirewrite[T, QS[T]]]
 
   def optimize: QSM[T[QSM]] => QSM[T[QSM]] = Optimize[T, QSM]
 

--- a/qscript/src/main/scala/quasar/qscript/package.scala
+++ b/qscript/src/main/scala/quasar/qscript/package.scala
@@ -100,13 +100,6 @@ package object qscript {
       CopK.Inject[QScriptCore[T, ?], QScriptEducated[T, ?]].prj(qt)
   }
 
-  /** QScript that has not gone through Read conversion. */
-  type QScript[T[_[_]], A] =
-    CopK[QScriptCore[T, ?] ::: ThetaJoin[T, ?] ::: Const[DeadEnd, ?] ::: TNilK, A]
-
-  implicit def qScriptToQscriptTotal[T[_[_]]]
-      : Injectable[QScript[T, ?], QScriptTotal[T, ?]] = SubInject[QScript[T, ?], QScriptTotal[T, ?]]
-
   /** QScript that has gone through Read conversion.
     *
     * NB: Once QScriptTotal goes away, this could become parametric in the path type.


### PR DESCRIPTION
Weeding through our implicit coproduct requirements, figuring out which ones are actually required.