### PR TITLE
Prune Symmetric DimEdit Nodes Before ApplyProv

### DIFF
--- a/qsu/src/main/scala/quasar/qsu/LPtoQS.scala
+++ b/qsu/src/main/scala/quasar/qsu/LPtoQS.scala
@@ -56,6 +56,8 @@ final class LPtoQS[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT]
       debug("RecognizeDistinct")             >==>
       ExtractFreeMap[T, F]                   >==>
       debug("ExtractFreeMap")                >==>
+      PruneSymmetricDimEdits[T, F]           >==>
+      debug("PruneSymmetricDimEdits")        >==>
       ApplyProvenance[T, F]                  >==>
       debug("ApplyProvenance")               >==>
       ReifyBuckets[T, F]                     >==>

--- a/qsu/src/main/scala/quasar/qsu/LPtoQS.scala
+++ b/qsu/src/main/scala/quasar/qsu/LPtoQS.scala
@@ -18,6 +18,7 @@ package quasar.qsu
 
 import slamdata.Predef._
 import quasar.{RenderTreeT, RenderTree}, RenderTree.ops._
+import quasar.common.{PhaseResult, PhaseResultTell}
 import quasar.common.effect.NameGenerator
 import quasar.frontend.logicalplan.LogicalPlan
 import quasar.qscript.MonadPlannerErr
@@ -25,6 +26,7 @@ import quasar.qscript.MonadPlannerErr
 import matryoshka.{delayShow, showTShow, BirecursiveT, EqualT, ShowT}
 import org.slf4s.Logging
 import scalaz.{Cord, Functor, Kleisli => K, Monad, Show}
+import scalaz.syntax.functor._
 import scalaz.syntax.show._
 
 final class LPtoQS[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT]
@@ -33,40 +35,40 @@ final class LPtoQS[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT]
 
   import LPtoQS.MapSyntax
 
-  def apply[F[_]: Monad: MonadPlannerErr: NameGenerator](lp: T[LogicalPlan])
+  def apply[F[_]: Monad: MonadPlannerErr: PhaseResultTell: NameGenerator](lp: T[LogicalPlan])
       : F[T[QScriptEducated]] = {
 
     val agraph =
       ApplyProvenance.AuthenticatedQSU.graph[T]
 
     val lpToQs =
-      K(ReadLP[T, F])                        >-
+      K(ReadLP[T, F])                        >==>
       debug("ReadLP")                        >==>
-      RewriteGroupByArrays[T, F]             >-
+      RewriteGroupByArrays[T, F]             >==>
       debug("RewriteGroupByArrays")          >-
-      EliminateUnary[T]                      >-
+      EliminateUnary[T]                      >==>
       debug("EliminateUnary")                >==>
-      InlineNullary[T, F]                    >-
+      InlineNullary[T, F]                    >==>
       debug("InlineNullary")                 >-
-      CoalesceUnaryMappable[T]               >-
+      CoalesceUnaryMappable[T]               >==>
       debug("CoalesceUnaryMappable")         >-
-      RecognizeDistinct[T]                   >-
+      RecognizeDistinct[T]                   >==>
       debug("RecognizeDistinct")             >==>
-      ExtractFreeMap[T, F]                   >-
+      ExtractFreeMap[T, F]                   >==>
       debug("ExtractFreeMap")                >==>
-      ApplyProvenance[T, F]                  >-
-      debug("ApplyProv")                     >==>
-      ReifyBuckets[T, F]                     >-
+      ApplyProvenance[T, F]                  >==>
+      debug("ApplyProvenance")               >==>
+      ReifyBuckets[T, F]                     >==>
       debug("ReifyBuckets")                  >==>
-      MinimizeAutoJoins[T, F]                >-
+      MinimizeAutoJoins[T, F]                >==>
       debug("MinimizeAutoJoins")             >==>
-      ReifyAutoJoins[T, F]                   >-
+      ReifyAutoJoins[T, F]                   >==>
       debug("ReifyAutoJoins")                >==>
-      ExpandShifts[T, F]                     >-
+      ExpandShifts[T, F]                     >==>
       debug("ExpandShifts")                  >-
-      agraph.modify(ResolveOwnIdentities[T]) >-
+      agraph.modify(ResolveOwnIdentities[T]) >==>
       debug("ResolveOwnIdentities")          >==>
-      ReifyIdentities[T, F]                  >-
+      ReifyIdentities[T, F]                  >==>
       debug("ReifyIdentities")               >==>
       Graduate[T, F]
 
@@ -75,8 +77,10 @@ final class LPtoQS[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT]
     lpToQs(lp)
   }
 
-  private def debug[A: Show](name: String): A => A =
-    a => { log.debug((Cord(name + "\n") ++ a.show).shows); a }
+  private def debug[F[_]: Functor: PhaseResultTell, A: Show](name: String): A => F[A] = { a =>
+    log.debug((Cord(name + "\n") ++ a.show).shows)
+    PhaseResultTell[F].tell(Vector(PhaseResult.detail(s"QSU ($name)", a.shows))).as(a)
+  }
 }
 
 object LPtoQS {

--- a/qsu/src/main/scala/quasar/qsu/PruneSymmetricDimEdits.scala
+++ b/qsu/src/main/scala/quasar/qsu/PruneSymmetricDimEdits.scala
@@ -33,15 +33,8 @@ final class PruneSymmetricDimEdits[T[_[_]]] private () extends QSUTTypes[T] {
   private type RootsMemo = SMap[Symbol, Set[QSUGraph]]
 
   def apply[F[_]: Monad: NameGenerator: MonadPlannerErr](g: QSUGraph): F[QSUGraph] = {
-    type G[A] = StateT[
-      // we need to memoize to avoid O(n^2) retraversals
-      StateT[
-        F,
-        RootsMemo,
-        ?],
-      // replacewithName needs this
-      QSUGraph.RevIdx[T],
-      A]
+    // we need to memoize to avoid O(n^2) retraversals
+    type G[A] = StateT[StateT[F, RootsMemo, ?], QSUGraph.RevIdx[T], A]
 
     val backM = g rewriteM[G] {
       case g @ (AutoJoin2(_, _, _) | AutoJoin3(_, _, _, _)) =>

--- a/qsu/src/main/scala/quasar/qsu/PruneSymmetricDimEdits.scala
+++ b/qsu/src/main/scala/quasar/qsu/PruneSymmetricDimEdits.scala
@@ -57,12 +57,16 @@ final class PruneSymmetricDimEdits[T[_[_]]] private () extends QSUTTypes[T] {
           }
 
           if (shouldPrune) {
-            roots.foldLeftM(g) {
-              case (g, target @ DimEdit(parent, _)) =>
-                g.replaceWithRename[G](target.root, parent.root)
+            for {
+              back <- roots.foldLeftM(g) {
+                case (g, target @ DimEdit(parent, _)) =>
+                  g.replaceWithRename[G](target.root, parent.root)
 
-              case (g, _ ) => g.point[G]
-            }
+                case (g, _ ) => g.point[G]
+              }
+
+              _ <- MonadState_[G, RootsMemo].put(SMap())  // wipe the roots memo if we rewrite the graph
+            } yield back
           } else {
             g.point[G]
           }

--- a/qsu/src/main/scala/quasar/qsu/PruneSymmetricDimEdits.scala
+++ b/qsu/src/main/scala/quasar/qsu/PruneSymmetricDimEdits.scala
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qsu
+
+import slamdata.Predef._
+
+import quasar.common.effect.NameGenerator
+import quasar.contrib.scalaz.MonadState_
+import quasar.qscript.MonadPlannerErr
+import quasar.qsu.{QScriptUniform => QSU}
+
+import scalaz.{Monad, StateT}
+import scalaz.std.list._
+import scalaz.syntax.foldable._
+import scalaz.syntax.monad._
+
+import scala.collection.immutable.{Map => SMap}
+
+final class PruneSymmetricDimEdits[T[_[_]]] private () extends QSUTTypes[T] {
+  import QSUGraph.Extractors._
+
+  private type RootsMemo = SMap[Symbol, Set[QSUGraph]]
+
+  def apply[F[_]: Monad: NameGenerator: MonadPlannerErr](g: QSUGraph): F[QSUGraph] = {
+    type G[A] = StateT[
+      // we need to memoize to avoid O(n^2) retraversals
+      StateT[
+        F,
+        RootsMemo,
+        ?],
+      // replacewithName needs this
+      QSUGraph.RevIdx[T],
+      A]
+
+    val backM = g rewriteM[G] {
+      case g @ (AutoJoin2(_, _, _) | AutoJoin3(_, _, _, _)) =>
+        provRoots[G](g) flatMap { rootsS =>
+          val roots = rootsS.toList
+
+          val shouldPrune = roots forall {
+            case DimEdit(_, QSU.DTrans.Squash()) => true
+            case _ => false
+          }
+
+          if (shouldPrune) {
+            roots.foldLeftM(g) {
+              case (g, target @ DimEdit(parent, _)) =>
+                g.replaceWithRename[G](target.root, parent.root)
+
+              case (g, _ ) => g.point[G]
+            }
+          } else {
+            g.point[G]
+          }
+        }
+    }
+
+    backM.eval(g.generateRevIndex).eval(SMap())
+  }
+
+  // does not return Unreferenced()
+  @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
+  private def provRoots[
+      G[_]: Monad: MonadState_[?[_], RootsMemo]](
+      g: QSUGraph)
+      : G[Set[QSUGraph]] = stateMemo(g) {
+
+    case Distinct(parent) => provRoots[G](parent)
+    case QSFilter(parent, _) => provRoots[G](parent)
+    case QSSort(parent, _, _) => provRoots[G](parent)
+    case Map(parent, _) => provRoots[G](parent)
+
+    case AutoJoin2(left, right, _) =>
+      (provRoots[G](left) |@| provRoots[G](right))(_ ++ _)
+
+    case AutoJoin3(left, center, right, _) =>
+      (provRoots[G](left) |@| provRoots[G](center) |@| provRoots[G](right))(_ ++ _ ++ _)
+
+    case Unreferenced() => Set().point[G]
+
+    case g => Set(g).point[G]
+  }
+
+  private def stateMemo[
+      G[_]: Monad: MonadState_[?[_], RootsMemo]](
+      g: QSUGraph)(
+      f: QSUGraph => G[Set[QSUGraph]])
+      : G[Set[QSUGraph]] = {
+
+    for {
+      table <- MonadState_[G, RootsMemo].get
+
+      back <- table.get(g.root) match {
+        case Some(results) =>
+          results.point[G]
+
+        case None =>
+          for {
+            results <- f(g)
+            _ <- MonadState_[G, RootsMemo].put(table + (g.root -> results))
+          } yield results
+      }
+    } yield back
+  }
+}
+
+object PruneSymmetricDimEdits {
+  def apply[
+      T[_[_]],
+      F[_]: Monad: NameGenerator: MonadPlannerErr]
+      (graph: QSUGraph[T])
+      : F[QSUGraph[T]] =
+    taggedInternalError("PruneSymmetricDimEdits", new PruneSymmetricDimEdits[T].apply[F](graph))
+}

--- a/qsu/src/test/scala/quasar/qsu/PruneSymmetricDimEditsSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/PruneSymmetricDimEditsSpec.scala
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qsu
+
+import slamdata.Predef._
+
+import quasar.Qspec
+import quasar.common.SortDir
+import quasar.qscript.{construction, MapFuncsCore, PlannerError}
+import quasar.qsu.{QScriptUniform => QSU}
+
+import matryoshka.data.Fix
+
+import pathy.Path, Path._
+
+import scalaz.{EitherT, StateT, Need, NonEmptyList => NEL}
+
+object PruneSymmetricDimEditsSpec extends Qspec with QSUTTypes[Fix] {
+  import QSUGraph.Extractors._
+
+  type F[A] = EitherT[StateT[Need, Long, ?], PlannerError, A]
+
+  val qsu = QScriptUniform.DslT[Fix]
+  val func = construction.Func[Fix]
+  val recFunc = construction.RecFunc[Fix]
+
+  val afile = Path.rootDir[Sandboxed] </> Path.file("afile")
+
+  "pruning of symmetric DimEdit roots" should {
+    "remove trivial left/right roots" in {
+      val qgraph = QSUGraph.fromTree[Fix](
+        qsu.autojoin2((
+          qsu.dimEdit((
+            qsu.read(afile),
+            QSU.DTrans.Squash())),
+          qsu.dimEdit((
+            qsu.distinct(qsu.read(afile)),
+            QSU.DTrans.Squash())),
+          _(MapFuncsCore.Add(_, _)))))
+
+      runOn(qgraph) must beLike {
+        case AutoJoin2(Read(_), Distinct(Read(_)), _) => ok
+      }
+    }
+
+    "remove edits various dimensional no-ops" >> {
+      "distinct" >> {
+        val qgraph = QSUGraph.fromTree[Fix](
+          qsu.autojoin2((
+            qsu.distinct(
+              qsu.dimEdit((
+                qsu.read(afile),
+                QSU.DTrans.Squash()))),
+            qsu.dimEdit((
+              qsu.distinct(qsu.read(afile)),
+              QSU.DTrans.Squash())),
+            _(MapFuncsCore.Add(_, _)))))
+
+        runOn(qgraph) must beLike {
+          case AutoJoin2(Distinct(Read(_)), Distinct(Read(_)), _) => ok
+        }
+      }
+
+      "filter" >> {
+        val qgraph = QSUGraph.fromTree[Fix](
+          qsu.autojoin2((
+            qsu.qsFilter((
+              qsu.dimEdit((
+                qsu.read(afile),
+                QSU.DTrans.Squash())),
+              recFunc.Hole)),
+            qsu.dimEdit((
+              qsu.distinct(qsu.read(afile)),
+              QSU.DTrans.Squash())),
+            _(MapFuncsCore.Add(_, _)))))
+
+        runOn(qgraph) must beLike {
+          case AutoJoin2(QSFilter(Read(_), _), Distinct(Read(_)), _) => ok
+        }
+      }
+
+      "sort" >> {
+        val qgraph = QSUGraph.fromTree[Fix](
+          qsu.autojoin2((
+            qsu.qsSort((
+              qsu.dimEdit((
+                qsu.read(afile),
+                QSU.DTrans.Squash())),
+              Nil,
+              NEL((func.Hole, SortDir.Ascending)))),
+            qsu.dimEdit((
+              qsu.distinct(qsu.read(afile)),
+              QSU.DTrans.Squash())),
+            _(MapFuncsCore.Add(_, _)))))
+
+        runOn(qgraph) must beLike {
+          case AutoJoin2(QSSort(Read(_), _, _), Distinct(Read(_)), _) => ok
+        }
+      }
+
+      "map" >> {
+        val qgraph = QSUGraph.fromTree[Fix](
+          qsu.autojoin2((
+            qsu.map((
+              qsu.dimEdit((
+                qsu.read(afile),
+                QSU.DTrans.Squash())),
+              recFunc.Hole)),
+            qsu.dimEdit((
+              qsu.distinct(qsu.read(afile)),
+              QSU.DTrans.Squash())),
+            _(MapFuncsCore.Add(_, _)))))
+
+        runOn(qgraph) must beLike {
+          case AutoJoin2(Map(Read(_), _), Distinct(Read(_)), _) => ok
+        }
+      }
+    }
+  }
+
+  private def runOn(g: QSUGraph): QSUGraph = {
+    val resultsF = PruneSymmetricDimEdits[Fix, F](g)
+
+    val results = resultsF.run.eval(0L).value.toEither
+    results must beRight
+
+    results.right.get
+  }
+}

--- a/qsu/src/test/scala/quasar/qsu/PruneSymmetricDimEditsSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/PruneSymmetricDimEditsSpec.scala
@@ -130,6 +130,20 @@ object PruneSymmetricDimEditsSpec extends Qspec with QSUTTypes[Fix] {
         }
       }
     }
+
+    "remove trivial left root when right unreferenced" in {
+      val qgraph = QSUGraph.fromTree[Fix](
+        qsu.autojoin2((
+          qsu.dimEdit((
+            qsu.read(afile),
+            QSU.DTrans.Squash())),
+          qsu.unreferenced(),
+          _(MapFuncsCore.Add(_, _)))))
+
+      runOn(qgraph) must beLike {
+        case AutoJoin2(Read(_), Unreferenced(), _) => ok
+      }
+    }
   }
 
   private def runOn(g: QSUGraph): QSUGraph = {


### PR DESCRIPTION
This resolves the issues of a single `Transpose` turning into two `LeftShift`s in `ApplyProvenance`. It appears we have an unrelated issue in `CollapseShifts` which has the same symptom.

[ch2113]