### PR TITLE
More thorough CoalesceUnaryMappable

### DIFF
--- a/qscript/src/test/scala/quasar/qscript/provenance/ProvSpec.scala
+++ b/qscript/src/test/scala/quasar/qscript/provenance/ProvSpec.scala
@@ -135,6 +135,32 @@ final class ProvSpec extends Qspec with ProvFGenerator {
     }
   }
 
+  "conjunction" >> {
+    "(z ≺ y ≺ x) ∧ (w ≺ y ≺ x) == (z ∧ w) ≺ y ≺ x" >> {
+      val l = pk1 ≺: p2 ≺: p1
+      val r = pk2 ≺: p2 ≺: p1
+      (l ∧ r) must_= P.both(pk1, pk2) ≺: p2 ≺: p1
+    }
+
+    "((z ∧ q) ≺ y ≺ x) ∧ ((w ∧ q) ≺ y ≺ x) == (z ∧ w ∧ q) ≺ y ≺ x" >> {
+      val l = (pk1 ∧ v1) ≺: p2 ≺: p1
+      val r = (pk2 ∧ v1) ≺: p2 ≺: p1
+      (l ∧ r) must_= P.both(pk1, P.both(pk2, v1)) ≺: p2 ≺: p1
+    }
+
+    "((a ∧ b) ≺ y ≺ x) ∧ ((c ∧ d) ≺ y ≺ x) == (a ∧ b ∧ c ∧ d) ≺ y ≺ x" >> {
+      val l = (pk1 ∧ v1) ≺: p2 ≺: p1
+      val r = (pk2 ∧ v2) ≺: p2 ≺: p1
+      (l ∧ r) must_= P.both(v2, P.both(pk1, P.both(pk2, v1))) ≺: p2 ≺: p1
+    }
+
+    "(a ≺ b ≺ x) ∧ (c ≺ d ≺ x) == (a ≺ b ∧ c ≺ d) ≺ x" >> {
+      val l = pk1 ≺: v1 ≺: p1
+      val r = pk2 ≺: v2 ≺: p1
+      (l ∧ r) must_= P.both(pk1 ≺: v1, pk2 ≺: v2) ≺: p1
+    }
+  }
+
   "autojoined" >> {
     "p1 θ p1" >> {
       autojoined(p1, p1) must_= ((JoinKeys.empty, true))

--- a/qsu/src/main/scala/quasar/qsu/CoalesceUnaryMappable.scala
+++ b/qsu/src/main/scala/quasar/qsu/CoalesceUnaryMappable.scala
@@ -16,21 +16,81 @@
 
 package quasar.qsu
 
+import slamdata.Predef.{Int, List, Map => SMap, Symbol}
 import quasar.fp._
+import quasar.qscript.{
+  construction,
+  Center,
+  LeftSide,
+  LeftSide3,
+  RightSide,
+  RightSide3
+}
 import quasar.qscript.RecFreeS._
+import quasar.qsu.{QScriptUniform => QSU}
 
+import scalaz.syntax.bind._
 import scalaz.syntax.equal._
 
+import matryoshka.BirecursiveT
+
 /** Coalesces adjacent mappable regions of a single root. */
-final class CoalesceUnaryMappable[T[_[_]]] private () extends QSUTTypes[T] {
+final class CoalesceUnaryMappable[T[_[_]]: BirecursiveT] private () extends QSUTTypes[T] {
+  import QSUGraph.Extractors._
+  import MappableRegion.MaximalUnary
+
+  val mf = construction.Func[T]
+
   def apply(graph: QSUGraph): QSUGraph =
     graph rewrite {
-      case g @ MappableRegion.MaximalUnary(src, fm) if g.root =/= src.root =>
+      case g @ MaximalUnary(src, fm) if g.root =/= src.root =>
         g.overwriteAtRoot(QScriptUniform.Map(src.root, fm.asRec))
+
+      case g @ AutoJoin2(left, right, combine) =>
+        val nodes = mapNodes(List(left, right))
+
+        if (nodes.isEmpty)
+          g
+        else {
+          val (l, lf) = nodes.getOrElse(0, (left.root, mf.Hole))
+          val (r, rf) = nodes.getOrElse(1, (right.root, mf.Hole))
+
+          val cmb = combine flatMap {
+            case LeftSide => lf >> mf.LeftSide
+            case RightSide => rf >> mf.RightSide
+          }
+
+          g.overwriteAtRoot(QSU.AutoJoin2(l, r, cmb))
+        }
+
+      case g @ AutoJoin3(left, center, right, combine) =>
+        val nodes = mapNodes(List(left, center, right))
+
+        if (nodes.isEmpty)
+          g
+        else {
+          val (l, lf) = nodes.getOrElse(0, (left.root, mf.Hole))
+          val (c, cf) = nodes.getOrElse(1, (center.root, mf.Hole))
+          val (r, rf) = nodes.getOrElse(2, (right.root, mf.Hole))
+
+          val cmb = combine flatMap {
+            case LeftSide3 => lf >> mf.LeftSide3
+            case Center => cf >> mf.Center
+            case RightSide3 => rf >> mf.RightSide3
+          }
+
+          g.overwriteAtRoot(QSU.AutoJoin3(l, c, r, cmb))
+        }
+    }
+
+  def mapNodes(gs: List[QSUGraph]): SMap[Int, (Symbol, FreeMap)] =
+    gs.zipWithIndex.foldLeft(SMap[Int, (Symbol, FreeMap)]()) {
+      case (acc, (Map(s, fm), i)) => acc.updated(i, (s.root, fm.linearize))
+      case (acc, _) => acc
     }
 }
 
 object CoalesceUnaryMappable {
-  def apply[T[_[_]]](graph: QSUGraph[T]): QSUGraph[T] =
-    (new CoalesceUnaryMappable[T])(graph)
+  def apply[T[_[_]]: BirecursiveT](graph: QSUGraph[T]): QSUGraph[T] =
+    (new CoalesceUnaryMappable[T]).apply(graph)
 }

--- a/qsu/src/main/scala/quasar/qsu/InlineNullary.scala
+++ b/qsu/src/main/scala/quasar/qsu/InlineNullary.scala
@@ -16,9 +16,8 @@
 
 package quasar.qsu
 
-import slamdata.Predef.{None, Option, Some, String, Symbol}
+import slamdata.Predef.{None, Option, Some, Symbol}
 
-import quasar.common.effect.NameGenerator
 import quasar.qscript.{
   Center,
   HoleF,
@@ -30,9 +29,7 @@ import quasar.qscript.{
   RightSideF,
   RightSide3
 }
-
-import scalaz.{Monad, StateT}
-import scalaz.syntax.monad._
+import scalaz.syntax.bind._
 
 /** Inlines nullary mappable expressions into AutoJoin combiners, reducing or
   * eliminating the AutoJoin.
@@ -41,113 +38,105 @@ final class InlineNullary[T[_[_]]] private () extends QSUTTypes[T] {
   import QSUGraph.Extractors._
   import RecFreeS._
 
-  private val namePrefix: String = "iln"
-
-  def apply[F[_]: Monad: NameGenerator: RevIdxM](graph: QSUGraph): F[QSUGraph] =
-    graph rewriteM[F] {
+  def apply(graph: QSUGraph): QSUGraph =
+    graph rewrite {
       case g @ AutoJoin2(left, right, combine) =>
         (nullary(left), nullary(right)) match {
-          case (Some(l), Some(r)) =>
+          case (Some((u, l)), Some((_, r))) =>
             val fm = combine flatMap {
               case LeftSide => l
               case RightSide => r
             }
+            g.overwriteAtRoot(QSU.Map(u, fm.asRec))
 
-            QSUGraph.withName[T, F](namePrefix)(QSU.Unreferenced[T, Symbol]()) map { u =>
-              g.overwriteAtRoot(QSU.Map(u.root, fm.asRec))
-            }
-
-          case (Some(l), None) =>
+          case (Some((_, l)), None) =>
             val fm = combine flatMap {
               case LeftSide => l
               case RightSide => HoleF[T]
             }
-            g.overwriteAtRoot(QSU.Map(right.root, fm.asRec)).point[F]
+            g.overwriteAtRoot(QSU.Map(right.root, fm.asRec))
 
-          case (None, Some(r)) =>
+          case (None, Some((_, r))) =>
             val fm = combine flatMap {
               case LeftSide => HoleF[T]
               case RightSide => r
             }
-            g.overwriteAtRoot(QSU.Map(left.root, fm.asRec)).point[F]
+            g.overwriteAtRoot(QSU.Map(left.root, fm.asRec))
 
-          case (None, None) => g.point[F]
+          case (None, None) => g
         }
 
       case g @ AutoJoin3(left, center, right, combine) =>
         (nullary(left), nullary(center), nullary(right)) match {
-          case (Some(l), Some(c), Some(r)) =>
+          case (Some((u, l)), Some((_, c)), Some((_, r))) =>
             val fm = combine flatMap {
               case LeftSide3 => l
               case Center => c
               case RightSide3 => r
             }
+            g.overwriteAtRoot(QSU.Map(u, fm.asRec))
 
-            QSUGraph.withName[T, F](namePrefix)(QSU.Unreferenced[T, Symbol]()) map { u =>
-              g.overwriteAtRoot(QSU.Map(u.root, fm.asRec))
-            }
-
-          case (Some(l), Some(c), None) =>
+          case (Some((_, l)), Some((_, c)), None) =>
             val fm = combine flatMap {
               case LeftSide3 => l
               case Center => c
               case RightSide3 => HoleF[T]
             }
-            g.overwriteAtRoot(QSU.Map(right.root, fm.asRec)).point[F]
+            g.overwriteAtRoot(QSU.Map(right.root, fm.asRec))
 
-          case (Some(l), None, Some(r)) =>
+          case (Some((_, l)), None, Some((_, r))) =>
             val fm = combine flatMap {
               case LeftSide3 => l
               case Center => HoleF[T]
               case RightSide3 => r
             }
-            g.overwriteAtRoot(QSU.Map(center.root, fm.asRec)).point[F]
+            g.overwriteAtRoot(QSU.Map(center.root, fm.asRec))
 
-          case (Some(l), None, None) =>
+          case (Some((_, l)), None, None) =>
             val jf = combine flatMap {
               case LeftSide3 => l >> LeftSideF[T]
               case Center => LeftSideF[T]
               case RightSide3 => RightSideF[T]
             }
-            g.overwriteAtRoot(QSU.AutoJoin2(center.root, right.root, jf)).point[F]
+            g.overwriteAtRoot(QSU.AutoJoin2(center.root, right.root, jf))
 
-          case (None, Some(c), Some(r)) =>
+          case (None, Some((_, c)), Some((_, r))) =>
             val fm = combine flatMap {
               case LeftSide3 => HoleF[T]
               case Center => c
               case RightSide3 => r
             }
-            g.overwriteAtRoot(QSU.Map(left.root, fm.asRec)).point[F]
+            g.overwriteAtRoot(QSU.Map(left.root, fm.asRec))
 
-          case (None, Some(c), None) =>
+          case (None, Some((_, c)), None) =>
             val jf = combine flatMap {
               case LeftSide3 => LeftSideF[T]
               case Center => c >> LeftSideF[T]
               case RightSide3 => RightSideF[T]
             }
-            g.overwriteAtRoot(QSU.AutoJoin2(left.root, right.root, jf)).point[F]
+            g.overwriteAtRoot(QSU.AutoJoin2(left.root, right.root, jf))
 
-          case (None, None, Some(r)) =>
+          case (None, None, Some((_, r))) =>
             val jf = combine flatMap {
               case LeftSide3 => LeftSideF[T]
               case Center => RightSideF[T]
               case RightSide3 => r >> LeftSideF[T]
             }
-            g.overwriteAtRoot(QSU.AutoJoin2(left.root, center.root, jf)).point[F]
+            g.overwriteAtRoot(QSU.AutoJoin2(left.root, center.root, jf))
 
-          case (None, None, None) => g.point[F]
+          case (None, None, None) => g
         }
     }
 
   private val QSU = QScriptUniform
 
-  private val nullary: QSUGraph => Option[FreeMap] =
-    MappableRegion.MaximalNullary.unapply[T] _
+  private val nullary: QSUGraph => Option[(Symbol, FreeMap)] = {
+    case Map(u @ Unreferenced(), f) => Some((u.root, f.linearize))
+    case _ => None
+  }
 }
 
 object InlineNullary {
-  def apply[T[_[_]], F[_]: Monad: NameGenerator](graph: QSUGraph[T]): F[QSUGraph[T]] = {
-    type G[A] = StateT[F, QSUGraph.RevIdx[T], A]
-    (new InlineNullary[T])[G](graph).eval(graph.generateRevIndex)
-  }
+  def apply[T[_[_]]](graph: QSUGraph[T]): QSUGraph[T] =
+    (new InlineNullary[T])(graph)
 }

--- a/qsu/src/main/scala/quasar/qsu/LPtoQS.scala
+++ b/qsu/src/main/scala/quasar/qsu/LPtoQS.scala
@@ -45,8 +45,8 @@ final class LPtoQS[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT]
       RewriteGroupByArrays[T, F]             >-
       debug("RewriteGroupByArrays")          >-
       EliminateUnary[T]                      >-
-      debug("EliminateUnary")                >==>
-      InlineNullary[T, F]                    >-
+      debug("EliminateUnary")                >-
+      InlineNullary[T]                       >-
       debug("InlineNullary")                 >-
       CoalesceUnaryMappable[T]               >-
       debug("CoalesceUnaryMappable")         >-

--- a/qsu/src/test/scala/quasar/qsu/ApplyProvenanceSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/ApplyProvenanceSpec.scala
@@ -195,9 +195,11 @@ object ApplyProvenanceSpec extends Qspec with QSUTTypes[Fix] {
 
       tree must haveDimensions(SMap(
         'n0 -> Dimensions.origin(
-          P.both(
-            P.thenn(P.injValue(J.int(0)), P.value(IdAccess.identity('n0))),
-            P.thenn(P.injValue(J.int(1)), P.value(IdAccess.identity('n0)))),
+          P.thenn(
+            P.both(
+              P.injValue(J.int(0)),
+              P.injValue(J.int(1))),
+            P.value(IdAccess.identity('n0))),
           P.prjPath(J.str("foobar"))),
         'n1 -> Dimensions.origin(
           P.prjPath(J.str("foobar")))
@@ -351,7 +353,7 @@ object ApplyProvenanceSpec extends Qspec with QSUTTypes[Fix] {
       }
 
       res.exists(topDim all {
-        case P.both(P.thenn(P.injValue(J.int(i)), _), P.thenn(P.fresh(_), _)) if i == 0 => true
+        case P.thenn(P.both(P.injValue(J.int(i)), P.fresh(_)), _) if i == 0 => true
         case _ => false
       }) must beTrue
     }

--- a/qsu/src/test/scala/quasar/qsu/InlineNullarySpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/InlineNullarySpec.scala
@@ -16,7 +16,6 @@
 
 package quasar.qsu
 
-import slamdata.Predef._
 import quasar.{Qspec, TreeMatchers}
 import quasar.contrib.iota._
 import quasar.contrib.matryoshka._

--- a/qsu/src/test/scala/quasar/qsu/InlineNullarySpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/InlineNullarySpec.scala
@@ -29,7 +29,6 @@ import quasar.qscript.{construction, Hole, JoinSide}
 import matryoshka._
 import matryoshka.data._
 import pathy.Path._
-import scalaz.State
 
 object InlineNullarySpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
   import QSUGraph.Extractors._
@@ -43,7 +42,7 @@ object InlineNullarySpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
   val dataB: AFile = rootDir </> file("dataB")
 
   def inlineNullary(g: QSUGraph): QSUGraph =
-    InlineNullary[Fix, State[Long, ?]](g).eval(1)
+    InlineNullary[Fix](g)
 
   "inlining nullary nodes" should {
     "be identity for nullary Map nodes" >> {

--- a/qsu/src/test/scala/quasar/qsu/MinimizeAutoJoinsSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/MinimizeAutoJoinsSpec.scala
@@ -414,13 +414,11 @@ object MinimizeAutoJoinsSpec extends Qspec with TreeMatchers with QSUTTypes[Fix]
         case m @ Map(r @ QSReduce(_, _, _, _), _) =>
           val expDims =
             Dimensions.origin(
-              qprov.prov.both(
-                qprov.prov.thenn(
+              qprov.prov.thenn(
+                qprov.prov.both(
                   qprov.prov.injValue(J.str("0")),
-                  qprov.prov.value(IdAccess.bucket(r.root, 0))),
-                qprov.prov.thenn(
-                  qprov.prov.injValue(J.str("1")),
-                  qprov.prov.value(IdAccess.bucket(r.root, 0)))))
+                  qprov.prov.injValue(J.str("1"))),
+                qprov.prov.value(IdAccess.bucket(r.root, 0))))
 
           auth.dims(m.root) must_= expDims
       }


### PR DESCRIPTION
Improves `CoalesceUnaryMappable` to coalesce source `Map`s into an `AutoJoin{2,3}`. This ended up requiring better provenance normalization for performance of computing provenance on large `MapFunc`s.

Also updated `InlineNullary` to be more performant as it didn't require the amount of traversing it was performing.