### PR TITLE
include rows when outer join key is undefined

### DIFF
--- a/it/src/main/resources/tests/joins/selfFullOuterJoin.test
+++ b/it/src/main/resources/tests/joins/selfFullOuterJoin.test
@@ -2,8 +2,8 @@
     "name": "[qa_s07] self full outer join",
 
     "backends": {
-        "lwc_local": "pendingIgnoreFieldOrder",
-        "mimir": "pendingIgnoreFieldOrder"
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
     },
 
     "data": "selfjoin.data",

--- a/it/src/main/resources/tests/joins/selfLeftOuterJoin.test
+++ b/it/src/main/resources/tests/joins/selfLeftOuterJoin.test
@@ -2,8 +2,8 @@
     "name": "[qa_s07] self left outer join",
 
     "backends": {
-        "lwc_local": "pendingIgnoreFieldOrder",
-        "mimir": "pendingIgnoreFieldOrder"
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
     },
 
     "data": "selfjoin.data",

--- a/it/src/main/resources/tests/joins/selfRightOuterJoin.test
+++ b/it/src/main/resources/tests/joins/selfRightOuterJoin.test
@@ -2,8 +2,8 @@
     "name": "[qa_s07] self right outer join",
 
     "backends": {
-        "lwc_local": "pendingIgnoreFieldOrder",
-        "mimir": "pendingIgnoreFieldOrder"
+        "lwc_local": "ignoreFieldOrder",
+        "mimir": "ignoreFieldOrder"
     },
 
     "data": "selfjoin.data",

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/ColumnarTableModule.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/ColumnarTableModule.scala
@@ -622,9 +622,13 @@ trait ColumnarTableModule
       * Cogroups this table with another table, using equality on the specified
       * transformation on rows of the table.
       */
-    def cogroup(leftKey: TransSpec1, rightKey: TransSpec1, that: Table)(leftResultTrans: TransSpec1,
-                                                                        rightResultTrans: TransSpec1,
-                                                                        bothResultTrans: TransSpec2)
+    def cogroup(
+      leftKey: TransSpec1,
+      rightKey: TransSpec1,
+      that: Table)(
+      leftResultTrans: TransSpec1,
+      rightResultTrans: TransSpec1,
+      bothResultTrans: TransSpec2)
     : Table = {
 
       // println("Cogrouping with respect to\nleftKey: " + leftKey + "\nrightKey: " + rightKey)
@@ -1030,9 +1034,8 @@ trait ColumnarTableModule
         } // end of step
 
         val initialState = for {
-          // We have to compact both sides to avoid any rows for which the key is completely undefined
-          leftUnconsed <- self.compact(leftKey).slices.uncons
-          rightUnconsed <- that.compact(rightKey).slices.uncons
+          leftUnconsed <- self.slices.uncons
+          rightUnconsed <- that.slices.uncons
 
           back <- {
             val cogroup = for {

--- a/yggdrasil/src/test/scala/quasar/yggdrasil/CogroupSpec.scala
+++ b/yggdrasil/src/test/scala/quasar/yggdrasil/CogroupSpec.scala
@@ -406,14 +406,21 @@ trait CogroupSpec extends TableModuleTestSupport with SpecificationLike with Sca
     import JParser.parseUnsafe
 
     val ltable = fromSample(SampleData(Stream(
+      parseUnsafe("""{ "val" : 0 }"""),
+      parseUnsafe("""{ "val" : 2 }"""),
       parseUnsafe("""{ "id" : "foo", "val" : 4 }"""))))
 
     val rtable = fromSample(SampleData(Stream(
-      parseUnsafe("""{ "id" : "foo", "val" : 2 }"""),
+      parseUnsafe("""{ "val" : 1 }"""),
       parseUnsafe("""{ "val" : 3 }"""),
+      parseUnsafe("""{ "id" : "foo", "val" : 2 }"""),
       parseUnsafe("""{ "id" : "foo", "val" : 4 }"""))))
 
     val expected = Stream(
+      parseUnsafe("""{ "left": 0 }"""),
+      parseUnsafe("""{ "left": 2 }"""),
+      parseUnsafe("""{ "right" : 1 }"""),
+      parseUnsafe("""{ "right" : 3 }"""),
       parseUnsafe("""{ "id": "foo", "left": 4, "right": 2 }"""),
       parseUnsafe("""{ "id": "foo", "left": 4, "right": 4 }""")
     )
@@ -425,7 +432,7 @@ trait CogroupSpec extends TableModuleTestSupport with SpecificationLike with Sca
                         WrapObject(DerefObjectStatic(Leaf(SourceRight), CPathField("val")), "right")))
 
     toJson(result).getJValues must_== expected
-  }
+  }.pendingUntilFixed
 
   def testLongEqualSpansOnRight = {
     val record = JParser.parseUnsafe("""{"key":"Bob","value":42}""")

--- a/yggdrasil/src/test/scala/quasar/yggdrasil/CogroupSpec.scala
+++ b/yggdrasil/src/test/scala/quasar/yggdrasil/CogroupSpec.scala
@@ -417,10 +417,10 @@ trait CogroupSpec extends TableModuleTestSupport with SpecificationLike with Sca
       parseUnsafe("""{ "id" : "foo", "val" : 4 }"""))))
 
     val expected = Stream(
-      parseUnsafe("""{ "left": 0 }"""),
-      parseUnsafe("""{ "left": 2 }"""),
-      parseUnsafe("""{ "right" : 1 }"""),
-      parseUnsafe("""{ "right" : 3 }"""),
+      parseUnsafe("""{ "val": 0 }"""),
+      parseUnsafe("""{ "val": 2 }"""),
+      parseUnsafe("""{ "val" : 1 }"""),
+      parseUnsafe("""{ "val" : 3 }"""),
       parseUnsafe("""{ "id": "foo", "left": 4, "right": 2 }"""),
       parseUnsafe("""{ "id": "foo", "left": 4, "right": 4 }""")
     )
@@ -430,9 +430,8 @@ trait CogroupSpec extends TableModuleTestSupport with SpecificationLike with Sca
       OuterObjectConcat(WrapObject(DerefObjectStatic(Leaf(SourceLeft), CPathField("id")), "id"),
                         WrapObject(DerefObjectStatic(Leaf(SourceLeft), CPathField("val")), "left"),
                         WrapObject(DerefObjectStatic(Leaf(SourceRight), CPathField("val")), "right")))
-
     toJson(result).getJValues must_== expected
-  }.pendingUntilFixed
+  }
 
   def testLongEqualSpansOnRight = {
     val record = JParser.parseUnsafe("""{"key":"Bob","value":42}""")


### PR DESCRIPTION
Now includes rows when outer join key is undefined. This changes the results of left, right and full outer joins if there are undefined join keys.

Full outer joins were originally (that is, with the fix for left and right joins) multiplying rows with undefined keys, but are in ae96456 changed to be summing them instead.