### PR TITLE
Ability to preserve array indices in SSTs

### DIFF
--- a/datagen/src/test/scala/quasar/datagen/GenerateSpec.scala
+++ b/datagen/src/test/scala/quasar/datagen/GenerateSpec.scala
@@ -98,7 +98,7 @@ final class GenerateSpec extends quasar.Qspec {
         val asst =
           sst(
             TypeStat.coll(1.0, Some(3.0), Some(3.0)),
-            TypeF.arr(IList(a, b, c).left))
+            TypeF.arr(IList(a, b, c), None))
 
         valuesShould(asst)(_ ≟ J.arr(List(J.char('a'), J.char('b'), J.char('c'))))
       }
@@ -113,7 +113,7 @@ final class GenerateSpec extends quasar.Qspec {
         val vsst =
           sst(
             TypeStat.coll(100.0, Some(2.0), Some(5.0)),
-            TypeF.arr(IList(a, b, c, d, e).left))
+            TypeF.arr(IList(a, b, c, d, e), None))
 
         val ab = J.arr(List('a', 'b') map (J.char(_)))
         val abcd = J.arr(List('a', 'b', 'c', 'd') map (J.char(_)))
@@ -129,7 +129,7 @@ final class GenerateSpec extends quasar.Qspec {
         val kta =
           sst(
             TypeStat.coll(2.0, Some(3.0), Some(7.0)),
-            TypeF.arr((k ⊹ t).right))
+            TypeF.arr(IList[S](), Some(k ⊹ t)))
 
         valuesShould(kta)(J.arr.exist { js =>
           js.length >= 3 &&
@@ -145,12 +145,34 @@ final class GenerateSpec extends quasar.Qspec {
         val wza =
           sst(
             TypeStat.coll(2.0, None, None),
-            TypeF.arr((w ⊹ z).right))
+            TypeF.arr(IList[S](), Some(w ⊹ z)))
 
         valuesShould(wza)(J.arr.exist { js =>
           js.length <= maxL &&
           js.all(j => j >= J.char('w') && j <= J.char('z'))
         })
+      }
+
+      "variable length of known values according to probabilities with trailing lubs" >> {
+        val a = sstL(tsJ(100, J.char('a')), SimpleType.Char)
+        val b = sstL(tsJ(100, J.char('b')), SimpleType.Char)
+        val c = sstL(tsJ( 70, J.char('c')), SimpleType.Char)
+        val d = sstL(tsJ( 70, J.char('d')), SimpleType.Char)
+        val e = sstL(tsJ( 30, J.char('e')), SimpleType.Char)
+        val f = sstL(tsJ(100, J.char('f')), SimpleType.Char)
+
+        val vsst =
+          sst(
+            TypeStat.coll(100.0, Some(2.0), Some(7.0)),
+            TypeF.arr(IList(a, b, c, d, e), Some(f)))
+
+        val ab = J.arr(List('a', 'b') map (J.char(_)))
+        val abcd = J.arr(List('a', 'b', 'c', 'd') map (J.char(_)))
+        val abcde = J.arr(List('a', 'b', 'c', 'd', 'e') map (J.char(_)))
+        val abcdef = J.arr(List('a', 'b', 'c', 'd', 'e', 'f') map (J.char(_)))
+        val abcdeff = J.arr(List('a', 'b', 'c', 'd', 'e', 'f', 'f') map (J.char(_)))
+
+        valuesShould(vsst)(List(ab, abcd, abcde, abcdef, abcdeff) element _)
       }
     }
 

--- a/frontend/src/test/scala/quasar/tpe/TypeFArbitrary.scala
+++ b/frontend/src/test/scala/quasar/tpe/TypeFArbitrary.scala
@@ -33,16 +33,16 @@ trait TypeFArbitrary {
     new PatternArbitrary[TypeF[J, ?]] {
       def leafGenerators[A] =
         uniformly(
-          Gen.const(                bottom[J, A]() ),
-          Gen.const(                   top[J, A]() ),
+          Gen.const(bottom[J, A]()),
+          Gen.const(top[J, A]()),
           arbitrary[SimpleType] ^^ (simple[J, A](_)),
-          arbitrary[J]          ^^ ( const[J, A](_)))
+          arbitrary[J] ^^ (const[J, A](_)))
 
       def branchGenerators[A: Arbitrary] =
         uniformly(
-          arbitrary[IList[A] \/ A]                ^^ (      arr[J, A](_)),
-          arbitrary[(IMap[J, A], Option[(A, A)])] ^^ (      map[J, A](_)),
-          arbitrary[(A, A)]                       ^^ (coproduct[J, A](_)))
+          arbitrary[(IList[A], Option[A])] ^^ (arr[J, A](_)),
+          arbitrary[(IMap[J, A], Option[(A, A)])] ^^ (map[J, A](_)),
+          arbitrary[(A, A)] ^^ (coproduct[J, A](_)))
     }
 }
 

--- a/frontend/src/test/scala/quasar/tpe/TypeFSpec.scala
+++ b/frontend/src/test/scala/quasar/tpe/TypeFSpec.scala
@@ -114,32 +114,38 @@ final class TypeFSpec extends Spec with TypeFArbitrary with EJsonArbitrary {
       isSubtypeOf[J](m, n) ≟ (isSubtypeOf[J](t, v) && isSubtypeOf[J](u, w))
     }
 
-    "<array> <: []" >> prop { a: IList[T] \/ T =>
-      isSubtypeOf[J](
-        arr[J, T](a           ).embed,
-        arr[J, T](IList().left).embed)
+    "<array> <: []" >> prop { (k: IList[T], u: Option[T]) =>
+      isSubtypeOf[J](arr[J, T](k, u).embed, arr[J, T](IList[T](), None).embed)
     }
 
     "[x, y] <: z[] iff (x <: z) && (y <: z)" >> prop { (a: T, b: T, c: T) =>
       val (x, y, z) = (orT(a), orT(b), orT(c))
       isSubtypeOf[J](
-        arr[J, T](IList(x, y).left).embed,
-        arr[J, T](         z.right).embed
+        arr[J, T](IList(x, y), None).embed,
+        arr[J, T](IList[T](), Some(z)).embed
       ) ≟ (isSubtypeOf[J](x, z) && isSubtypeOf[J](y, z))
     }
 
     "[t, u] <: [v, w] iff (t <: v) && (u <: w)" >> prop { (a: T, b: T, c: T, d: T) =>
       val (t, u, v, w) = (orT(a), orT(b), orT(c), orT(d))
       isSubtypeOf[J](
-        arr[J, T](IList(t, u).left).embed,
-        arr[J, T](IList(v, w).left).embed
+        arr[J, T](IList(t, u), None).embed,
+        arr[J, T](IList(v, w), None).embed
       ) ≟ (isSubtypeOf[J](t, v) && isSubtypeOf[J](u, w))
     }
 
     "[a, b] <: [a]" >> prop { (as: IList[T], b: T) =>
       isSubtypeOf[J](
-        arr[J, T]((as ::: IList(b)).left).embed,
-        arr[J, T]( as.left              ).embed)
+        arr[J, T](as ::: IList(b), None).embed,
+        arr[J, T](as, None).embed)
+    }
+
+    "[a, b, x, y] <: [a, b ? c] iff (x <: c) && (y <: c)" >> prop { (a: T, b: T, c: T, d: T, e: T) =>
+      val (v, w, x, y, z) = (orT(a), orT(b), orT(c), orT(d), orT(e))
+      isSubtypeOf[J](
+        arr[J, T](IList(v, w, x, y), None).embed,
+        arr[J, T](IList(v, w), Some(z)).embed
+      ) ≟ (isSubtypeOf[J](x, z) && isSubtypeOf[J](y, z))
     }
 
     "(x ∧ y) <: x && (x ∧ y) <: y" >> prop { (x: T, y: T) =>

--- a/impl/src/main/scala/quasar/impl/datasources/DefaultDatasources.scala
+++ b/impl/src/main/scala/quasar/impl/datasources/DefaultDatasources.scala
@@ -58,7 +58,7 @@ final class DefaultDatasources[
 
   def datasourceRef(datasourceId: I): F[ExistentialError[I] \/ DatasourceRef[C]] =
     EitherT(lookupRef[ExistentialError[I]](datasourceId))
-    .map(c => control.sanitizeRef(c)).run
+      .map(c => control.sanitizeRef(c)).run
 
   def datasourceStatus(datasourceId: I): F[ExistentialError[I] \/ Condition[Exception]] =
     EitherT(lookupRef[ExistentialError[I]](datasourceId))

--- a/impl/src/main/scala/quasar/impl/schema/SstConfig.scala
+++ b/impl/src/main/scala/quasar/impl/schema/SstConfig.scala
@@ -27,6 +27,7 @@ import eu.timepit.refined.auto._
   *
   * @param arrayMaxLength arrays larger than this will be compressed
   * @param mapMaxSize maps larger than this will be compressed
+  * @param retainIndicesSize the number array indices to retain during compression
   * @param retainKeysSize the number of map keys to retain, per type, during compression
   * @param stringMaxLength all strings longer than this are compressed
   * @param stringPreserveStructure whether to preserve structure when compressing strings
@@ -35,6 +36,7 @@ import eu.timepit.refined.auto._
 final case class SstConfig[J, A](
     arrayMaxLength: Natural,
     mapMaxSize: Natural,
+    retainIndicesSize: Natural,
     retainKeysSize: Natural,
     stringMaxLength: Natural,
     stringPreserveStructure: Boolean,
@@ -47,6 +49,7 @@ final case class SstConfig[J, A](
 object SstConfig {
   val DefaultArrayMaxLength: Natural = 10L
   val DefaultMapMaxSize: Natural = 32L
+  val DefaultRetainIndicesSize: Natural = 0L
   val DefaultRetainKeysSize: Natural = 0L
   val DefaultStringMaxLength: Natural = 0L
   val DefaultStringPreserveStructure: Boolean = false
@@ -56,6 +59,7 @@ object SstConfig {
     SstConfig[J, A](
       arrayMaxLength = DefaultArrayMaxLength,
       mapMaxSize = DefaultMapMaxSize,
+      retainIndicesSize = DefaultRetainIndicesSize,
       retainKeysSize = DefaultRetainKeysSize,
       stringMaxLength = DefaultStringMaxLength,
       stringPreserveStructure = DefaultStringPreserveStructure,

--- a/impl/src/main/scala/quasar/impl/schema/package.scala
+++ b/impl/src/main/scala/quasar/impl/schema/package.scala
@@ -70,7 +70,7 @@ package object schema {
         orOriginal(applyTransforms(
           compression.limitStrings[J, A](config.stringMaxLength, config.stringPreserveStructure)))
 
-      compression.limitArrays[J, A](config.arrayMaxLength)
+      compression.limitArrays[J, A](config.arrayMaxLength, config.retainIndicesSize)
         .andThen(_.bimap(_.transAna[SST[J, A]](independent), independent))
     }
 

--- a/impl/src/test/scala/quasar/impl/schema/ExtractSstSpec.scala
+++ b/impl/src/test/scala/quasar/impl/schema/ExtractSstSpec.scala
@@ -75,11 +75,11 @@ final class ExtractSstSpec extends quasar.Qspec {
       TypeST(TypeF.map[J, S](IMap(
         J.str("foo") -> envT(
           TypeStat.coll(Real(1), Real(2).some, Real(2).some),
-          TypeST(TypeF.arr[J, S](ints(1, 2).list.left))).embed,
+          TypeST(TypeF.arr[J, S](ints(1, 2).list, None))).embed,
 
         J.str("bar") -> envT(
           TypeStat.coll(Real(1), Real(3).some, Real(3).some),
-          TypeST(TypeF.arr[J, S](ints(1, 2, 3).suml1.right))).embed
+          TypeST(TypeF.arr[J, S](IList[S](), Some(ints(1, 2, 3).suml1)))).embed
       ), None))).embed
 
     verify(config.copy(arrayMaxLength = 2L), input, expected)
@@ -100,9 +100,9 @@ final class ExtractSstSpec extends quasar.Qspec {
             strings.StructuralString,
             envT(
               TypeStat.coll(Real(1), Real(6).some, Real(6).some),
-              TypeST(TypeF.arr[J, S](envT(
+              TypeST(TypeF.arr[J, S](IList[S](), Some(envT(
                 TypeStat.char(strSS("abcdef"), 'a', 'f'),
-                TypeST(TypeF.simple[J, S](SimpleType.Char))).embed.right))
+                TypeST(TypeF.simple[J, S](SimpleType.Char))).embed)))
             ).embed))
           ).embed,
 
@@ -166,7 +166,7 @@ final class ExtractSstSpec extends quasar.Qspec {
                 envT(
                   TypeStat.char(strSS("x"), 'x', 'x'),
                   TypeST(TypeF.const[J, S](J.char('x')))).embed
-              ).left))).embed))).embed,
+              ), None))).embed))).embed,
         envT(
           TypeStat.int(SampleStats.freq(Real(4), Real(1)), BigInt(1), BigInt(1)),
           TypeST(TypeF.const[J, S](J.int(1)))
@@ -214,7 +214,7 @@ final class ExtractSstSpec extends quasar.Qspec {
                 envT(
                   TypeStat.char(strSS("x"), 'x', 'x'),
                   TypeST(TypeF.const[J, S](J.char('x')))).embed
-              ).left))).embed))).embed,
+              ), None))).embed))).embed,
           fourOnes))))).embed
 
     verify(config.copy(mapMaxSize = 3L, retainKeysSize = 2L, unionMaxSize = 1L), input, expected)
@@ -250,7 +250,7 @@ final class ExtractSstSpec extends quasar.Qspec {
                 envT(
                   TypeStat.char(strSS("x"), 'x', 'x'),
                   TypeST(TypeF.const[J, S](J.char('x')))).embed
-              ).left))).embed))).embed,
+              ), None))).embed))).embed,
         envT(
           TypeStat.int(SampleStats.freq(Real(4), Real(1)), BigInt(1), BigInt(1)),
           TypeST(TypeF.const[J, S](J.int(1)))

--- a/impl/src/test/scala/quasar/impl/schema/ExtractSstSpec.scala
+++ b/impl/src/test/scala/quasar/impl/schema/ExtractSstSpec.scala
@@ -45,7 +45,7 @@ final class ExtractSstSpec extends quasar.Qspec {
     Show.showFromToString
 
   val J = Fixed[J]
-  val config = SstConfig[J, Real](1000L, 1000L, 1000L, 1000L, true, 1000L)
+  val config = SstConfig[J, Real](1000L, 1000L, 0L, 0L, 1000L, true, 1000L)
 
   def verify(cfg: SstConfig[J, Real], input: List[Data], expected: S) =
     Stream.emits(input)
@@ -83,6 +83,27 @@ final class ExtractSstSpec extends quasar.Qspec {
       ), None))).embed
 
     verify(config.copy(arrayMaxLength = 2L), input, expected)
+  }
+
+  "compress arrays, retaining 1 key" >> {
+    val input = List(
+      _obj(ListMap("foo" -> _arr(List(_int(1), _int(2))))),
+      _obj(ListMap("bar" -> _arr(List(_int(1), _int(2), _int(3)))))
+    )
+
+    val expected = envT(
+      TypeStat.coll(Real(2), Real(1).some, Real(1).some),
+      TypeST(TypeF.map[J, S](IMap(
+        J.str("foo") -> envT(
+          TypeStat.coll(Real(1), Real(2).some, Real(2).some),
+          TypeST(TypeF.arr[J, S](ints(1, 2).list, None))).embed,
+
+        J.str("bar") -> envT(
+          TypeStat.coll(Real(1), Real(3).some, Real(3).some),
+          TypeST(TypeF.arr[J, S](ints(1).list, Some(ints(2, 3).suml1)))).embed
+      ), None))).embed
+
+    verify(config.copy(arrayMaxLength = 2L, retainIndicesSize = 1L), input, expected)
   }
 
   "compress long strings" >> {

--- a/run/src/main/scala/quasar/run/QuasarError.scala
+++ b/run/src/main/scala/quasar/run/QuasarError.scala
@@ -16,7 +16,7 @@
 
 package quasar.run
 
-import slamdata.Predef.{Exception, Product, Serializable, Throwable}
+import slamdata.Predef.{Exception, Product, Serializable, String, StringContext, Throwable}
 import quasar.api.datasource.DatasourceError.CreateError
 import quasar.compile.SemanticErrors
 import quasar.connector.ResourceError
@@ -74,5 +74,7 @@ object QuasarError {
 
   ////
 
-  private final case class QuasarException(qe: QuasarError) extends Exception
+  private final case class QuasarException(qe: QuasarError) extends Exception {
+    override def toString: String = s"QuasarException: $qe"
+  }
 }

--- a/sst/src/main/scala/quasar/sst/TypeStat.scala
+++ b/sst/src/main/scala/quasar/sst/TypeStat.scala
@@ -120,19 +120,22 @@ object TypeStat extends TypeStatInstances {
     J: Recursive.Aux[J, EJson],
     F: Field[A]
   ): Algebra[TypeF[J, ?], TypeStat[A]] = {
-    case TypeF.Bottom()              => count(F.zero)
-    case TypeF.Top()                 => count(cnt)
-    case TypeF.Simple(_)             => count(cnt)
-    case TypeF.Const(j)              => fromEJson(cnt, j)
-    case TypeF.Arr(-\/(xs))          => fromFoldable(maxOr(cnt, xs), xs)
-    case TypeF.Arr(\/-(x))           => coll(x.size, none, none)
-    case TypeF.Map(xs, None)         => fromFoldable(maxOr(cnt, xs), xs)
+    case TypeF.Bottom() => count(F.zero)
+    case TypeF.Top() => count(cnt)
+    case TypeF.Simple(_) => count(cnt)
+    case TypeF.Const(j) => fromEJson(cnt, j)
 
+    case TypeF.Arr(xs, None) => fromFoldable(maxOr(cnt, xs), xs)
+    case TypeF.Arr(xs, Some(ux)) =>
+      val n = NonEmptyList.nel(ux, xs).maximumOf1(_.size)
+      coll(n, some(F.fromInt(xs.length)), none)
+
+    case TypeF.Map(xs, None) => fromFoldable(maxOr(cnt, xs), xs)
     case TypeF.Map(xs, Some((a, b))) =>
       val n = OneAnd(a, OneAnd(b, xs)).maximumOf1(_.size)
-      coll(n, some(F fromInt xs.size), none)
+      coll(n, some(F.fromInt(xs.size)), none)
 
-    case TypeF.Union(a, b, cs)       => nel(a, b :: cs).suml1
+    case TypeF.Union(a, b, cs) => nel(a, b :: cs).suml1
   }
 
   ////

--- a/sst/src/main/scala/quasar/sst/compression.scala
+++ b/sst/src/main/scala/quasar/sst/compression.scala
@@ -142,11 +142,13 @@ object compression {
       case EnvT((_, TagST(Tagged(strings.StructuralString, _)))) =>
         sst.left
 
-      case EnvT((ts, TypeST(TypeF.Arr(-\/(elts @ ICons(h, t)))))) if elts.length > maxLength.value =>
+      case EnvT((ts, TypeST(TypeF.Arr(elts @ ICons(h, t), u)))) if elts.length > maxLength.value =>
         val (cnt, len) = (ts.size, A fromInt elts.length)
         envT(
-          TypeStat.coll(cnt, some(len), some(len)),
-          TypeST(TypeF.arr[J, SST[J, A]](\/-(NonEmptyList.nel(h, t).suml1)))).right
+          TypeStat.coll(cnt, some(len), u.fold(some(len))(_ => none)),
+          TypeST(TypeF.arr[J, SST[J, A]](
+            IList[SST[J, A]](),
+            some(NonEmptyList.nel(h, t).suml1) |+| u))).right
 
       case other =>
         other.right

--- a/sst/src/main/scala/quasar/sst/compression.scala
+++ b/sst/src/main/scala/quasar/sst/compression.scala
@@ -133,7 +133,7 @@ object compression {
   }
 
   /** Replace statically known arrays longer than the given limit with a lub array. */
-  def limitArrays[J: Order, A: Order](maxLength: Natural)(
+  def limitArrays[J: Order, A: Order](maxLength: Natural, retainCount: Natural)(
       implicit
       A : Field[A],
       JR: Recursive.Aux[J, EJson])
@@ -142,13 +142,9 @@ object compression {
       case EnvT((_, TagST(Tagged(strings.StructuralString, _)))) =>
         sst.left
 
-      case EnvT((ts, TypeST(TypeF.Arr(elts @ ICons(h, t), u)))) if elts.length > maxLength.value =>
-        val (cnt, len) = (ts.size, A fromInt elts.length)
-        envT(
-          TypeStat.coll(cnt, some(len), u.fold(some(len))(_ => none)),
-          TypeST(TypeF.arr[J, SST[J, A]](
-            IList[SST[J, A]](),
-            some(NonEmptyList.nel(h, t).suml1) |+| u))).right
+      case EnvT((ts, TypeST(TypeF.Arr(elts, u)))) if elts.length > maxLength.value =>
+        val (ret, lim) = elts.splitAt(retainCount.value.toInt)
+        envT(ts, TypeST(TypeF.arr[J, SST[J, A]](ret, lim.suml1Opt |+| u))).right
 
       case other =>
         other.right

--- a/sst/src/main/scala/quasar/sst/strings.scala
+++ b/sst/src/main/scala/quasar/sst/strings.scala
@@ -25,7 +25,6 @@ import quasar.contrib.iota.copkTraverse
 import matryoshka.{Corecursive, Recursive}
 import scalaz.{IList, Order}
 import scalaz.std.option._
-import scalaz.syntax.either._
 import scalaz.syntax.foldable._
 import spire.algebra.Field
 import spire.math.ConvertableTo
@@ -51,11 +50,11 @@ object strings {
       s.toIterable.foldMap(c => some(TypeStat.fromEJson(A.one, EJson.char(c))))
 
     val charArr =
-      charStat.fold(IList.empty[T].left[T]) { ts =>
-        C.embed(envT(ts, TypeST(TypeF.simple(SimpleType.Char)))).right
+      charStat map { ts =>
+        C.embed(envT(ts, TypeST(TypeF.simple(SimpleType.Char))))
       }
 
-    stringTagged(strStat, C.embed(envT(strStat, TypeST(TypeF.arr(charArr)))))
+    stringTagged(strStat, C.embed(envT(strStat, TypeST(TypeF.arr(IList[T](), charArr)))))
   }
 
   def simple[T, J, A](strStat: TypeStat[A]): SSTF[J, A, T] =

--- a/sst/src/test/scala/quasar/sst/CompressionSpec.scala
+++ b/sst/src/test/scala/quasar/sst/CompressionSpec.scala
@@ -328,8 +328,8 @@ final class CompressionSpec extends quasar.Qspec
       val coll = TypeStat.coll(Real(1), rlen, rlen)
       val lubarr = envT(coll, TypeST(TypeF.arr[J, S](IList[S](), Some(sum)))).embed
 
-      val req = xsst.elgotApo[S](compression.limitArrays(alen))
-      val rlt = xsst.elgotApo[S](compression.limitArrays(lt))
+      val req = xsst.elgotApo[S](compression.limitArrays(alen, 0L))
+      val rlt = xsst.elgotApo[S](compression.limitArrays(lt, 0L))
 
       (req must_= xsst) and (rlt must_= lubarr)
     }}
@@ -340,8 +340,28 @@ final class CompressionSpec extends quasar.Qspec
       val lim: Natural = Natural((s.length - 1).toLong) getOrElse 0L
       val stringSst = strings.widen[J, Real](Real(1), s).embed
 
-      stringSst.elgotApo[S](compression.limitArrays(lim)) must_= stringSst
+      stringSst.elgotApo[S](compression.limitArrays(lim, 0L)) must_= stringSst
     }}
+
+    "preserves the first k indices" >> {
+      val a = BigInt(1)
+      val b = BigInt(2)
+      val c = BigInt(3)
+      val d = BigInt(4)
+
+      val rlen = Real(4).some
+      val ints = NonEmptyList(J.int(a), J.int(b), J.int(c), J.int(d))
+      val xsst = SST.fromEJson(Real(1), J.arr(ints.toList))
+
+      val known = IList(J.int(a), J.int(b)).map(SST.fromEJson(Real(1), _))
+      val sum = NonEmptyList(J.int(c), J.int(d)).foldMap1(SST.fromEJson(Real(1), _))
+      val coll = TypeStat.coll(Real(1), rlen, rlen)
+      val exp = envT(coll, TypeST(TypeF.arr[J, S](known, Some(sum)))).embed
+
+      val res = xsst.elgotApo[S](compression.limitArrays(3L, 2L))
+
+      res must_= exp
+    }
   }
 
   "limitStrings" >> {

--- a/sst/src/test/scala/quasar/sst/CompressionSpec.scala
+++ b/sst/src/test/scala/quasar/sst/CompressionSpec.scala
@@ -326,7 +326,7 @@ final class CompressionSpec extends quasar.Qspec
 
       val sum = ints.foldMap1(x => SST.fromEJson(Real(1), x))
       val coll = TypeStat.coll(Real(1), rlen, rlen)
-      val lubarr = envT(coll, TypeST(TypeF.arr[J, S](sum.right))).embed
+      val lubarr = envT(coll, TypeST(TypeF.arr[J, S](IList[S](), Some(sum)))).embed
 
       val req = xsst.elgotApo[S](compression.limitArrays(alen))
       val rlt = xsst.elgotApo[S](compression.limitArrays(lt))

--- a/sst/src/test/scala/quasar/sst/StringsSpec.scala
+++ b/sst/src/test/scala/quasar/sst/StringsSpec.scala
@@ -16,7 +16,7 @@
 
 package quasar.sst
 
-import slamdata.Predef.List
+import slamdata.Predef.{List, Some}
 import quasar.contrib.algebra._
 import quasar.contrib.matryoshka.envT
 import quasar.ejson.EJson
@@ -29,9 +29,8 @@ import StructuralType.{TagST, TypeST}
 import matryoshka._
 import matryoshka.data.Fix
 import matryoshka.implicits._
-import scalaz.{NonEmptyList, Show}
+import scalaz.{IList, NonEmptyList, Show}
 import scalaz.syntax.foldable1._
-import scalaz.syntax.either._
 import scalaz.syntax.std.option._
 import spire.math.Real
 
@@ -59,7 +58,7 @@ final class StringsSpec extends quasar.Qspec {
     val comp =
       envT(ts, TagST[J](Tagged(
         strings.StructuralString,
-        envT(ts, TypeST(TypeF.arr[J, SST[J, Real]](char.right))).embed))).embed
+        envT(ts, TypeST(TypeF.arr[J, SST[J, Real]](IList[SST[J, Real]](), Some(char)))).embed))).embed
 
     strings.compress[SST[J, Real], J, Real](ts, "foo").embed must_= comp
   }


### PR DESCRIPTION
Updates the array type representation to allow for both known indices of a specific type along with an optional type representing the LUB of the rest of the array, similar to how maps are represented.

Adds a new option to SST schema configuration to preserve a specified number of indices when compressing long arrays.