### PR TITLE
Add integration tests for shifting through object projections

### DIFF
--- a/it/src/main/resources/tests/deep-giraffe-plus.data
+++ b/it/src/main/resources/tests/deep-giraffe-plus.data
@@ -1,0 +1,11 @@
+{"first":{"second":{"b2fe01ea-a7e0-452c-95e6-7047a62ecc71":{"S":{"to":["ethan@example.com"],"rId":"2fe76790"},"dateTime":1518610539149.4202, "testField":"A"}, "X": "P"}}}
+{"first":{"second":{"f5fb62c9-564d-4c3f-b0a5-a804a3cc4d25":{"S":{"to":["jacques@example.com"],"rId":"8e820358"},"dateTime":1518610554083.7378, "testField":"B"}, "X": "Q"}}}
+{"first":{"second":{"d153fccb-1707-42e3-ba90-03c473687964":{"S":{"to":["deshawn@example.com"],"rId":"28642fbe"},"dateTime":1518610722075.8232, "testField":"C"}, "X": "R"}}}
+{"first":{"second":{"b5207e48-10b4-4a42-8e6e-9a4551a88249":{"MAS":{"sId":"661929ef","rId":"08a42ad4"},"dateTime":1518610493869.1462, "testField":"D"}, "X": "S"}}}
+{"first":{"second":{"cfc2c0d5-b81e-4f3c-9bf4-d6d06e4ba82f":{"MAS":{"sId":"c12c935b","rId":"0b609f84"},"dateTime":1518610653487.1868, "testField":"E"}, "X": "T"}}}
+{"first":{"second":{"shifted": false}}}
+{"first":{"second":{"shifted": {"shifted": true}}}}
+{}
+[]
+[3, 5, 7, 11]
+123.456

--- a/it/src/main/resources/tests/shiftDeepGiraffeExcludeId.test
+++ b/it/src/main/resources/tests/shiftDeepGiraffeExcludeId.test
@@ -1,0 +1,18 @@
+{
+    "name": "shift deep-giraffe-plus with ExcludeId",
+    "backends": {
+        "lwc_local": "ignoreFieldOrder",
+        "mimir":     "ignoreFieldOrder"
+    },
+    "data": "deep-giraffe-plus.data",
+    "query": "select first.second{_}.testField as testField from `deep-giraffe-plus.data`",
+    "predicate": "exactly",
+    "ignoreResultOrder": true,
+    "expected": [
+      {"testField":"A"},
+      {"testField":"B"},
+      {"testField":"C"},
+      {"testField":"D"},
+      {"testField":"E"}
+    ]
+}

--- a/it/src/main/resources/tests/shiftDeepGiraffeIdOnly.test
+++ b/it/src/main/resources/tests/shiftDeepGiraffeIdOnly.test
@@ -1,0 +1,25 @@
+{
+    "name": "shift deep-giraffe-plus with IdOnly",
+    "backends": {
+        "lwc_local": "ignoreFieldOrder",
+        "mimir":     "ignoreFieldOrder"
+    },
+    "data": "deep-giraffe-plus.data",
+    "query": "select first.second{_:} as key from `deep-giraffe-plus.data`",
+    "predicate": "exactly",
+    "ignoreResultOrder": true,
+    "expected": [
+      {"key":"b2fe01ea-a7e0-452c-95e6-7047a62ecc71"},
+      {"key":"X"},
+      {"key":"f5fb62c9-564d-4c3f-b0a5-a804a3cc4d25"},
+      {"key":"X"},
+      {"key":"d153fccb-1707-42e3-ba90-03c473687964"},
+      {"key":"X"},
+      {"key":"b5207e48-10b4-4a42-8e6e-9a4551a88249"},
+      {"key":"X"},
+      {"key":"cfc2c0d5-b81e-4f3c-9bf4-d6d06e4ba82f"},
+      {"key":"X"},
+      {"key":"shifted"},
+      {"key":"shifted"}
+    ]
+}

--- a/it/src/main/resources/tests/shiftDeepGiraffeIncludeId.test
+++ b/it/src/main/resources/tests/shiftDeepGiraffeIncludeId.test
@@ -1,0 +1,25 @@
+{
+    "name": "shift deep-giraffe-plus with IncludeId",
+    "backends": {
+        "lwc_local": "ignoreFieldOrder",
+        "mimir":     "ignoreFieldOrder"
+    },
+    "data": "deep-giraffe-plus.data",
+    "query": "select first.second{_}.testField as testField, first.second{_:} as key from `deep-giraffe-plus.data`",
+    "predicate": "exactly",
+    "ignoreResultOrder": true,
+    "expected": [
+      {"testField":"A","key":"b2fe01ea-a7e0-452c-95e6-7047a62ecc71"},
+      {"key":"X"},
+      {"testField":"B","key":"f5fb62c9-564d-4c3f-b0a5-a804a3cc4d25"},
+      {"key":"X"},
+      {"testField":"C","key":"d153fccb-1707-42e3-ba90-03c473687964"},
+      {"key":"X"},
+      {"testField":"D","key":"b5207e48-10b4-4a42-8e6e-9a4551a88249"},
+      {"key":"X"},
+      {"testField":"E","key":"cfc2c0d5-b81e-4f3c-9bf4-d6d06e4ba82f"},
+      {"key":"X"},
+      {"key":"shifted"},
+      {"key":"shifted"}
+    ]
+}

--- a/it/src/main/resources/tests/shiftDeepGiraffeIncludeIdAndField.test
+++ b/it/src/main/resources/tests/shiftDeepGiraffeIncludeIdAndField.test
@@ -1,0 +1,25 @@
+{
+    "name": "shift deep-giraffe-plus with IncludeId and field",
+    "backends": {
+        "lwc_local": "ignoreFieldOrder",
+        "mimir":     "ignoreFieldOrder"
+    },
+    "data": "deep-giraffe-plus.data",
+    "query": "select first.second{_}.testField as testField, first.second{_:} as key, first.second.X as x from `deep-giraffe-plus.data`",
+    "predicate": "exactly",
+    "ignoreResultOrder": true,
+    "expected": [
+      {"key":"X","x":"P"},
+      {"testField":"A","key":"b2fe01ea-a7e0-452c-95e6-7047a62ecc71","x":"P"},
+      {"key":"X","x":"Q"},
+      {"testField":"B","key":"f5fb62c9-564d-4c3f-b0a5-a804a3cc4d25","x":"Q"},
+      {"key":"X","x":"R"},
+      {"testField":"C","key":"d153fccb-1707-42e3-ba90-03c473687964","x":"R"},
+      {"key":"X","x":"S"},
+      {"testField":"D","key":"b5207e48-10b4-4a42-8e6e-9a4551a88249","x":"S"},
+      {"key":"X","x":"T"},
+      {"testField":"E","key":"cfc2c0d5-b81e-4f3c-9bf4-d6d06e4ba82f","x":"T"},
+      {"key":"shifted"},
+      {"key":"shifted"}
+    ]
+}


### PR DESCRIPTION
Analogous tests as the ones added in #3834, this time with the shifts post-projection.