### PR TITLE
Make join test pending instead of skipped

### DIFF
--- a/it/src/main/resources/tests/joins/crossJoinWithOneSidedConditions.test
+++ b/it/src/main/resources/tests/joins/crossJoinWithOneSidedConditions.test
@@ -2,11 +2,9 @@
     "name": "[qa_s07] cross join with conditions that must be pushed ahead of the join (or else the join explodes, taking several minutes to complete)",
 
     "backends": {
-        "lwc_local":         "skip",
-        "mimir":             "skip"
+        "lwc_local": "pendingIgnoreFieldOrder",
+        "mimir":     "pendingIgnoreFieldOrder"
     },
-
-    "NB2": "Disabled in mimir because it times out (on the qsu branch).",
 
     "data": ["../largeZips.data", "../zips.data"],
 


### PR DESCRIPTION
This tests returns results in a few seconds. The results are a very large number of rows each with `{"b":"CHICO"}`, like so:
```
{"b":"CHICO"}
{"b":"CHICO"}
{"b":"CHICO"}
...
```