### PR TITLE
Restore string-specific measure to SSTs

### DIFF
--- a/datagen/src/test/scala/quasar/datagen/GenerateSpec.scala
+++ b/datagen/src/test/scala/quasar/datagen/GenerateSpec.scala
@@ -50,7 +50,7 @@ final class GenerateSpec extends quasar.Qspec {
     sst(ts, TypeF.simple(st))
 
   def sstS(n: Int, s: String): S =
-    strings.widen[J, Double](n.toDouble, s).embed
+    strings.widen[J, Double](tsJ(n, J.str(s)), s).embed
 
   def tsJ(n: Int, j: J): TypeStat[Double] =
     TypeStat.fromEJson(n.toDouble, j)
@@ -249,11 +249,10 @@ final class GenerateSpec extends quasar.Qspec {
       valuesShould(csst)(J.char.exist(c => (c >= 'e') && (c <= 'l')))
     }
 
-    "str within length range and char range" >> {
+    "str within length range and char range of min/max values" >> {
       val ssst =
         NonEmptyList("foo", "quux", "xex", "orp") foldMap1 { s =>
-          val strStat = TypeStat.fromEJson(1.0, J.str(s))
-          strings.compress[S, J, Double](strStat, s).embed
+          sstL(tsJ1(J.str(s)), SimpleType.Str)
         }
 
       valuesShould(ssst)(J.str.exist { s =>
@@ -262,7 +261,19 @@ final class GenerateSpec extends quasar.Qspec {
       })
     }
 
-    "str within length range and positional char range" >> {
+    "structural str within length range and char range" >> {
+      val ssst =
+        NonEmptyList("foo", "quux", "xex", "orp") foldMap1 { s =>
+          strings.compress[S, J, Double](tsJ1(J.str(s)), s).embed
+        }
+
+      valuesShould(ssst)(J.str.exist { s =>
+        (s.length ≟ 4 || s.length ≟ 3) &&
+        s.toList.all(c => c >= 'e' && c <= 'x')
+      })
+    }
+
+    "structural str within length range and positional char range" >> {
       val ssst =
         NonEmptyList("foo", "quux", "xex", "orp") foldMap1 (sstS(1, _))
 

--- a/impl/src/main/scala/quasar/impl/schema/SstConfig.scala
+++ b/impl/src/main/scala/quasar/impl/schema/SstConfig.scala
@@ -51,7 +51,7 @@ object SstConfig {
   val DefaultMapMaxSize: Natural = 32L
   val DefaultRetainIndicesSize: Natural = 0L
   val DefaultRetainKeysSize: Natural = 0L
-  val DefaultStringMaxLength: Natural = 0L
+  val DefaultStringMaxLength: Natural = 64L
   val DefaultStringPreserveStructure: Boolean = false
   val DefaultUnionMaxSize: Positive = 1L
 

--- a/impl/src/main/scala/quasar/impl/schema/package.scala
+++ b/impl/src/main/scala/quasar/impl/schema/package.scala
@@ -75,8 +75,8 @@ package object schema {
 
     val reduction: SSTF[J, A, SST[J, A]] => Option[SSTF[J, A, SST[J, A]]] =
       applyTransforms(
-        compression.coalesceWithUnknown[J, A](config.retainKeysSize),
-        compression.coalesceKeys[J, A](config.mapMaxSize, config.retainKeysSize),
+        compression.coalesceWithUnknown[J, A](config.retainKeysSize, config.stringPreserveStructure),
+        compression.coalesceKeys[J, A](config.mapMaxSize, config.retainKeysSize, config.stringPreserveStructure),
         compression.coalescePrimary[J, A](config.stringPreserveStructure),
         compression.narrowUnion[J, A](config.unionMaxSize, config.stringPreserveStructure))
 

--- a/impl/src/test/scala/quasar/impl/schema/ProgressiveSstSpec.scala
+++ b/impl/src/test/scala/quasar/impl/schema/ProgressiveSstSpec.scala
@@ -116,7 +116,7 @@ object ProgressiveSstSpec extends quasar.Qspec {
       TypeStat.coll(Real(2), Real(1).some, Real(1).some),
       TypeST(TypeF.map[J, S](IMap(
         J.str("foo") -> envT(
-          TypeStat.coll(Real(1), Real(6).some, Real(6).some),
+          TypeStat.str(Real(1), Real(6), Real(6), "abcde", "abcde"),
           TagST[J](Tagged(
             strings.StructuralString,
             envT(
@@ -128,7 +128,7 @@ object ProgressiveSstSpec extends quasar.Qspec {
           ).embed,
 
         J.str("bar") -> envT(
-          TypeStat.coll(Real(1), Real(5).some, Real(5).some),
+          TypeStat.str(Real(1), Real(5), Real(5), "abcde", "abcde"),
           TypeST(TypeF.const[J, S](J.str("abcde")))
         ).embed
       ), None))).embed
@@ -146,11 +146,11 @@ object ProgressiveSstSpec extends quasar.Qspec {
       TypeStat.coll(Real(2), Real(1).some, Real(1).some),
       TypeST(TypeF.map[J, S](IMap(
         J.str("foo") -> envT(
-          TypeStat.coll(Real(1), Real(6).some, Real(6).some),
+          TypeStat.str(Real(1), Real(6), Real(6), "abcde", "abcde"),
           TypeST(TypeF.simple[J, S](SimpleType.Str))).embed,
 
         J.str("bar") -> envT(
-          TypeStat.coll(Real(1), Real(5).some, Real(5).some),
+          TypeStat.str(Real(1), Real(5), Real(5), "abcde", "abcde"),
           TypeST(TypeF.const[J, S](J.str("abcde")))).embed
       ), None))).embed
 
@@ -169,7 +169,7 @@ object ProgressiveSstSpec extends quasar.Qspec {
       TypeStat.coll(Real(4), Real(1).some, Real(1).some),
       TypeST(TypeF.map[J, S](IMap.empty[J, S], Some((
         envT(
-          TypeStat.coll(Real(4), Real(3).some, Real(4).some),
+          TypeStat.str(Real(4), Real(3), Real(4), "bar", "quux"),
           TagST[J](Tagged(
             strings.StructuralString,
             envT(
@@ -217,7 +217,7 @@ object ProgressiveSstSpec extends quasar.Qspec {
           J.str("a") -> fourOnes,
           J.str("b") -> fourOnes),
         Some((envT(
-          TypeStat.coll(Real(4), Real(3).some, Real(4).some),
+          TypeStat.str(Real(4), Real(3), Real(4), "bar", "quux"),
           TagST[J](Tagged(
             strings.StructuralString,
             envT(
@@ -253,7 +253,7 @@ object ProgressiveSstSpec extends quasar.Qspec {
       TypeStat.coll(Real(4), Real(1).some, Real(1).some),
       TypeST(TypeF.map[J, S](IMap.empty[J, S], Some((
         envT(
-          TypeStat.coll(Real(4), Real(3).some, Real(4).some),
+          TypeStat.str(Real(4), Real(3), Real(4), "bar", "quux"),
           TagST[J](Tagged(
             strings.StructuralString,
             envT(

--- a/sst/src/main/scala/quasar/sst/TypeStat.scala
+++ b/sst/src/main/scala/quasar/sst/TypeStat.scala
@@ -54,6 +54,8 @@ sealed abstract class TypeStat[A] {
       case (Char(s1, min1, max1), Char(s2, min2, max2)) => char(s1 + s2, mn(min1, min2), mx(max1, max2))
       case (Int(s1, min1, max1), Int(s2, min2, max2)) => int(s1 + s2, mn(min1, min2), mx(max1, max2))
       case (Dec(s1, min1, max1), Dec(s2, min2, max2)) => dec(s1 + s2, mn(min1, min2), mx(max1, max2))
+      case (Int(s1, min1, max1), Dec(s2, min2, max2)) => dec(s1 + s2, mn(BigDecimal(min1), min2), mx(BigDecimal(max1), max2))
+      case (Dec(s1, min1, max1), Int(s2, min2, max2)) => dec(s1 + s2, mn(min1, BigDecimal(min2)), mx(max1, BigDecimal(max2)))
       case (Coll(c1, min1, max1), Coll(c2, min2, max2)) => coll(c1 + c2, mn(min1, min2), mx(max1, max2))
       case (x, y) => count(x.size + y.size)
     }

--- a/sst/src/main/scala/quasar/sst/TypeStat.scala
+++ b/sst/src/main/scala/quasar/sst/TypeStat.scala
@@ -39,6 +39,7 @@ sealed abstract class TypeStat[A] {
   def size(implicit A: AdditiveSemigroup[A]): A = this match {
     case Bool(t, f) => A.plus(t, f)
     case Char(s, _, _) => s.size
+    case Str(c, _, _, _, _) => c
     case Int(s, _, _) => s.size
     case Dec(s, _, _) => s.size
     case Coll(c, _, _) => c
@@ -52,11 +53,23 @@ sealed abstract class TypeStat[A] {
     (this, other) match {
       case (Bool(t1, f1), Bool(t2, f2)) => bool(t1 + t2, f1 + f2)
       case (Char(s1, min1, max1), Char(s2, min2, max2)) => char(s1 + s2, mn(min1, min2), mx(max1, max2))
+
+      case (Str(s1, minl1, maxl1, min1, max1), Str(s2, minl2, maxl2, min2, max2)) =>
+        str(s1 + s2, mn(minl1, minl2), mx(maxl1, maxl2), mn(min1, min2), mx(max1, max2))
+
+      case (Str(s1, minl1, maxl1, min1, max1), Char(s2, min2, max2)) =>
+        str(s1 + s2.size, mn(minl1, F.one), mx(maxl1, F.one), mn(min1, min2.toString), mx(max1, max2.toString))
+
+      case (Char(s1, min1, max1), Str(s2, minl2, maxl2, min2, max2)) =>
+        str(s1.size + s2, mn(F.one, minl2), mx(F.one, maxl2), mn(min1.toString, min2), mx(max1.toString, max2))
+
       case (Int(s1, min1, max1), Int(s2, min2, max2)) => int(s1 + s2, mn(min1, min2), mx(max1, max2))
       case (Dec(s1, min1, max1), Dec(s2, min2, max2)) => dec(s1 + s2, mn(min1, min2), mx(max1, max2))
       case (Int(s1, min1, max1), Dec(s2, min2, max2)) => dec(s1 + s2, mn(BigDecimal(min1), min2), mx(BigDecimal(max1), max2))
       case (Dec(s1, min1, max1), Int(s2, min2, max2)) => dec(s1 + s2, mn(min1, BigDecimal(min2)), mx(max1, BigDecimal(max2)))
+
       case (Coll(c1, min1, max1), Coll(c2, min2, max2)) => coll(c1 + c2, mn(min1, min2), mx(max1, max2))
+
       case (x, y) => count(x.size + y.size)
     }
 
@@ -68,6 +81,7 @@ sealed abstract class TypeStat[A] {
 object TypeStat extends TypeStatInstances {
   final case class Bool[A](trues: A, falses: A) extends TypeStat[A]
   final case class Char[A](stats: SampleStats[A], min: SChar, max: SChar) extends TypeStat[A]
+  final case class Str[A](cnt: A, minLen: A, maxLen: A, min: String, max: String) extends TypeStat[A]
   final case class Int[A](stats: SampleStats[A], min: BigInt, max: BigInt) extends TypeStat[A]
   final case class Dec[A](stats: SampleStats[A], min: BigDecimal, max: BigDecimal) extends TypeStat[A]
   final case class Coll[A](cnt: A, minSize: Option[A], maxSize: Option[A]) extends TypeStat[A]
@@ -80,6 +94,10 @@ object TypeStat extends TypeStatInstances {
   def char[A] = Prism.partial[TypeStat[A], (SampleStats[A], SChar, SChar)] {
     case Char(ss, min, max) => (ss, min, max)
   } ((Char[A](_, _, _)).tupled)
+
+  def str[A] = Prism.partial[TypeStat[A], (A, A, A, String, String)] {
+    case Str(c, minl, maxl, min, max) => (c, minl, maxl, min, max)
+  } ((Str[A](_, _, _, _, _)).tupled)
 
   def int[A] = Prism.partial[TypeStat[A], (SampleStats[A], BigInt, BigInt)] {
     case Int(ss, min, max) => (ss, min, max)
@@ -107,7 +125,7 @@ object TypeStat extends TypeStatInstances {
       case C(ejs.Null())  => count(cnt)
       case C(ejs.Bool(b)) => bool(b.fold(cnt, M.zero), b.fold(M.zero, cnt))
       case E(ejs.Char(c)) => char(SampleStats.freq(cnt, A fromInt c.toInt), c, c)
-      case C(ejs.Str(s)) => coll(cnt, some(A fromInt s.length), some(A fromInt s.length))
+      case C(ejs.Str(s)) => str(cnt, A fromInt s.length, A fromInt s.length, s, s)
       case E(ejs.Int(i)) => int(SampleStats.freq(cnt, A fromBigInt i), i, i)
       case C(ejs.Dec(d)) => dec(SampleStats.freq(cnt, A fromBigDecimal d), d, d)
       case C(ejs.Arr(xs)) => fromFoldable(cnt, xs)
@@ -180,6 +198,15 @@ sealed abstract class TypeStatInstances {
             case Kind.Char =>
               dist[SChar](j) map (TypeStat.char(_))
 
+            case Kind.Str =>
+              (
+                j.decodedKeyS[A](CountKey) |@|
+                j.decodedKeyS[A](MinLenKey) |@|
+                j.decodedKeyS[A](MaxLenKey) |@|
+                j.decodedKeyS[String](MinKey) |@|
+                j.decodedKeyS[String](MaxKey)
+              )(TypeStat.str(_, _, _, _, _))
+
             case Kind.Int =>
               dist[BigInt](j) map (TypeStat.int(_))
 
@@ -191,7 +218,7 @@ sealed abstract class TypeStatInstances {
 
             case Kind.Coll =>
               (
-                j.decodedKeyS[A](CountKey)                |@|
+                j.decodedKeyS[A](CountKey) |@|
                 j.keyS(MinLenKey).traverse(_.decodeAs[A]) |@|
                 j.keyS(MaxLenKey).traverse(_.decodeAs[A])
               )(TypeStat.coll(_, _, _))
@@ -216,6 +243,7 @@ sealed abstract class TypeStatInstances {
     Equal.equal((a, b) => (a, b) match {
       case (Bool(x1, x2), Bool(y1, y2)) => x1 ≟ y1 && x2 ≟ y2
       case (Char(x1, x2, x3), Char(y1, y2, y3)) => x1 ≟ y1 && x2 ≟ y2 && x3 ≟ y3
+      case (Str(x1, x2, x3, x4, x5), Str(y1, y2, y3, y4, y5)) => x1 ≟ y1 && x2 ≟ y2 && x3 ≟ y3 && x4 ≟ y4 && x5 ≟ y5
       case (Int(x1, x2, x3), Int(y1, y2, y3)) => x1 ≟ y1 && x2 ≟ y2 && x3 ≟ y3
       case (Dec(x1, x2, x3), Dec(y1, y2, y3)) => x1 ≟ y1 && x2 ≟ y2 && x3 ≟ y3
       case (Coll(x1, x2, x3), Coll(y1, y2, y3)) => x1 ≟ y1 && x2 ≟ y2 && x3 ≟ y3
@@ -227,6 +255,7 @@ sealed abstract class TypeStatInstances {
     Show.shows {
       case Bool(t, f) => s"Bool(${t.shows}, ${f.shows})"
       case Char(s, min, max) => s"Char(${s.shows}, ${min.shows}, ${max.shows})"
+      case Str(c, minl, maxl, min, max) => s"Str(${c.shows}, ${minl.shows}, ${maxl.shows}, $min, $max)"
       case Int(s, min, max) => s"Int(${s.shows}, ${min.shows}, ${max.shows})"
       case Dec(s, min, max) => s"Dec(${s.shows}, ${min.shows}, ${max.shows})"
       case Coll(c, min, max) => s"Coll(${c.shows}, ${min.shows}, ${max.shows})"
@@ -258,6 +287,7 @@ sealed abstract class TypeStatInstances {
   private object Kind {
     val Boolean = "boolean"
     val Char = "char"
+    val Str = "string"
     val Coll = "collection"
     val Count = "count"
     val Dec = "decimal"
@@ -324,6 +354,15 @@ sealed abstract class TypeStatInstances {
 
       case Char(s, mn, mx) =>
         dist(Kind.Char, s, mn, mx)
+
+      case Str(c, mnl, mxl, mn, mx) =>
+        kmap(
+          Kind.Str,
+          CountKey -> c.asEJson[J],
+          MinLenKey -> mnl.asEJson[J],
+          MaxLenKey -> mxl.asEJson[J],
+          MinKey -> mn.asEJson[J],
+          MaxKey -> mx.asEJson[J])
 
       case Int(s, mn, mx) =>
         dist(Kind.Int, s, mn, mx)

--- a/sst/src/main/scala/quasar/sst/package.scala
+++ b/sst/src/main/scala/quasar/sst/package.scala
@@ -27,7 +27,6 @@ import quasar.ejson.{
   Meta,
   Null,
   SizedType,
-  Str,
   TypeTag,
   Type => EType
 }
@@ -118,8 +117,7 @@ package object sst {
   def primaryTagOf[J](ejs: J)(implicit J: Recursive.Aux[J, EJson]): PrimaryTag =
     ejs.project match {
       case E(Meta(_, Embed(EType(tag)))) => tag.right
-      case C(Str(_))                     => strings.StructuralString.right
-      case _                             => primaryTypeOf(ejs).left
+      case _ => primaryTypeOf(ejs).left
     }
 
   implicit def sstQDataEncode[J: Order, A: ConvertableTo: Field: Order](

--- a/sst/src/main/scala/quasar/sst/strings.scala
+++ b/sst/src/main/scala/quasar/sst/strings.scala
@@ -54,26 +54,26 @@ object strings {
         C.embed(envT(ts, TypeST(TypeF.simple(SimpleType.Char))))
       }
 
-    stringTagged(strStat, C.embed(envT(strStat, TypeST(TypeF.arr(IList[T](), charArr)))))
+    val arrStat =
+      TypeStat.coll(strStat.size, some(A.fromInt(s.length)), some(A.fromInt(s.length)))
+
+    stringTagged(strStat, C.embed(envT(arrStat, TypeST(TypeF.arr(IList[T](), charArr)))))
   }
 
   def simple[T, J, A](strStat: TypeStat[A]): SSTF[J, A, T] =
     envT(strStat, TypeST[J, T](TypeF.Simple(SimpleType.Str)))
 
-  /** Widens a string into an array of its characters.
-    *
-    * FIXME: Overly specific, define in terms of [Co]Recursive.
-    */
-  def widen[J: Order, A: ConvertableTo: Field: Order](count: A, s: String)(
+  /** Widens a string into an array of its characters. */
+  def widen[J: Order, A: ConvertableTo: Field: Order](strStat: TypeStat[A], s: String)(
       implicit
       JC: Corecursive.Aux[J, EJson],
       JR: Recursive.Aux[J, EJson])
       : SSTF[J, A, SST[J, A]] = {
 
     val charArr =
-      SST.fromEJson(count, EJson.arr(s.map(EJson.char[J](_)) : _*))
+      SST.fromEJson(strStat.size, EJson.arr(s.map(EJson.char[J](_)) : _*))
 
-    stringTagged(charArr.copoint, charArr)
+    stringTagged(strStat, charArr)
   }
 
   ////

--- a/sst/src/test/scala/quasar/sst/StringsSpec.scala
+++ b/sst/src/test/scala/quasar/sst/StringsSpec.scala
@@ -31,7 +31,6 @@ import matryoshka.data.Fix
 import matryoshka.implicits._
 import scalaz.{IList, NonEmptyList, Show}
 import scalaz.syntax.foldable1._
-import scalaz.syntax.std.option._
 import spire.math.Real
 
 final class StringsSpec extends quasar.Qspec {
@@ -41,9 +40,10 @@ final class StringsSpec extends quasar.Qspec {
 
   "widen string yields an array of its characters" >> {
     val exp = EJson.arr(List('f', 'o', 'o') map (EJson.char[J](_)) : _*)
+    val strS = TypeStat.fromEJson(Real(5), EJson.str[J]("foo"))
     val wid0 = SST.fromEJson(Real(5), exp)
-    val wid = envT(wid0.copoint, TagST[J](Tagged(strings.StructuralString, wid0))).embed
-    strings.widen[J, Real](Real(5), "foo").embed must_= wid
+    val wid = envT(strS, TagST[J](Tagged(strings.StructuralString, wid0))).embed
+    strings.widen[J, Real](strS, "foo").embed must_= wid
   }
 
   "compress string yields a generic array sampled from its characters" >> {
@@ -53,13 +53,14 @@ final class StringsSpec extends quasar.Qspec {
     val char =
       envT(char0, TypeST(TypeF.simple[J, SST[J, Real]](SimpleType.Char))).embed
 
-    val ts = TypeStat.coll(Real(5), Real(3).some, Real(3).some)
+    val ss = TypeStat.str(Real(5), Real(3), Real(3), "foo", "foo")
+    val cs = TypeStat.coll(Real(5), Some(Real(3)), Some(Real(3)))
 
     val comp =
-      envT(ts, TagST[J](Tagged(
+      envT(ss, TagST[J](Tagged(
         strings.StructuralString,
-        envT(ts, TypeST(TypeF.arr[J, SST[J, Real]](IList[SST[J, Real]](), Some(char)))).embed))).embed
+        envT(cs, TypeST(TypeF.arr[J, SST[J, Real]](IList[SST[J, Real]](), Some(char)))).embed))).embed
 
-    strings.compress[SST[J, Real], J, Real](ts, "foo").embed must_= comp
+    strings.compress[SST[J, Real], J, Real](ss, "foo").embed must_= comp
   }
 }

--- a/sst/src/test/scala/quasar/sst/TypeStatArbitrary.scala
+++ b/sst/src/test/scala/quasar/sst/TypeStatArbitrary.scala
@@ -24,6 +24,7 @@ import scalaz._
 import scalaz.std.math.bigInt._
 import scalaz.std.math.bigDecimal._
 import scalaz.std.option._
+import scalaz.std.string._
 import scalaz.syntax.apply._
 import scalaz.syntax.order._
 import scalaz.scalacheck.ScalaCheckBinding._
@@ -41,6 +42,7 @@ trait TypeStatArbitrary {
       genBool[A],
       genColl[A],
       arbitrary[A] map (count[A](_)),
+      (arbitrary[A] |@| genRange[A] |@| genRange[String])((c, r, s) => str[A](c, r._1, r._2, s._1, s._2)),
       (arbitrary[SampleStats[A]] |@| genRange[SChar])((s, r) => char(s, r._1, r._2)),
       (arbitrary[SampleStats[A]] |@| genRange[BigInt])((s, r) => int[A](s, r._1, r._2)),
       (arbitrary[SampleStats[A]] |@| genRange[BigDecimal])((s, r) => dec[A](s, r._1, r._2)))


### PR DESCRIPTION
Restores the `Str` case to `TypeStat` in order to collect min/max values in addition to lengths for strings.

[ch2352]