### PR TITLE
Plate interpretation in Table.parseJson

### DIFF
--- a/yggdrasil/src/main/scala/quasar/yggdrasil/TableModule.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/TableModule.scala
@@ -16,6 +16,7 @@
 
 package quasar.yggdrasil
 
+import quasar.ParseInstruction
 import quasar.common.CPath
 import quasar.precog.common._
 import quasar.yggdrasil.vfs.ResourceError
@@ -160,6 +161,7 @@ trait TableModule extends TransSpecModule {
 
     def parseJson[M[_]: Monad: MonadFinalizers[?[_], IO]: LiftIO](
         bytes: fs2.Stream[IO, Byte],
+        instructions: List[ParseInstruction],
         precise: Boolean = false)(
         implicit ec: ExecutionContext)
         : M[Table]

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/CPathPlate.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/CPathPlate.scala
@@ -21,7 +21,7 @@ import quasar.common.{CPathField, CPathIndex, CPathMeta, CPathNode}
 
 import tectonic.{DelegatingPlate, Plate, Signal}
 
-trait CPathPlate[A] extends Plate[A] {
+private[table] trait CPathPlate[A] extends Plate[A] {
   protected var cursor: List[CPathNode] = Nil
   protected var nextIndex: List[Int] = 0 :: Nil
 

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/ColumnarTableModule.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/ColumnarTableModule.scala
@@ -17,6 +17,7 @@
 package quasar.yggdrasil
 package table
 
+import quasar.ParseInstruction
 import quasar.blueeyes._
 import quasar.common.{CPath, CPathArray, CPathField, CPathIndex, CPathMeta, CPathNode}
 import quasar.contrib.fs2.convert
@@ -370,14 +371,30 @@ trait ColumnarTableModule
           : MonadFinalizers[?[_], IO]
           : LiftIO](
         bytes: fs2.Stream[IO, Byte],
+        instructions: List[ParseInstruction],
         precise: Boolean = false)(
         implicit ec: ExecutionContext)
         : M[Table] = {
 
       import fs2.{Chunk, Stream}
+      import tectonic.Plate
       import tectonic.json.Parser
 
-      val parser = Parser(new SlicePlate(precise), Parser.ValueStream)
+      val plate = instructions.foldRight(new SlicePlate(precise): Plate[List[Slice]]) {
+        case (ParseInstruction.Ids, plate) =>
+          new IdsPlate(plate)
+
+        case (instr @ ParseInstruction.Wrap(_, _), plate) =>
+          new WrapPlate(instr, plate)
+
+        case (instr @ ParseInstruction.Mask(_), plate) =>
+          new MaskPlate(instr, plate)
+
+        case (instr @ ParseInstruction.Pivot(_, _, _), plate) =>
+          new PivotPlate(instr, plate)
+      }
+
+      val parser = Parser(plate, Parser.ValueStream)
 
       val absorbed: Stream[IO, Chunk[Slice]] =
         bytes.chunks evalMap { bc =>

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/IdsPlate.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/IdsPlate.scala
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package quasar.mimir.evaluate
+package quasar.yggdrasil.table
 
 import tectonic.{Plate, Signal}
 
-final class IdsPlate[A](delegate: Plate[A]) extends Plate[A] {
+private[table] final class IdsPlate[A](delegate: Plate[A]) extends Plate[A] {
   private var sawSomething = false
   private var id = 0L   // 450 exabytes is enough for anyone
 

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/MaskPlate.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/MaskPlate.scala
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
-package quasar.mimir.evaluate
+package quasar.yggdrasil.table
 
 import quasar.{ParseInstruction, ParseType}
 import quasar.common.{CPathField, CPathIndex, CPathMeta, CPathNode}
-import quasar.yggdrasil.table.CPathPlate
 
 import tectonic.{DelegatingPlate, Plate, Signal}
 
-final class MaskPlate[A](
+private[table] final class MaskPlate[A](
     mask: ParseInstruction.Mask,
     delegate: Plate[A])
     extends DelegatingPlate(delegate)

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/PivotPlate.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/PivotPlate.scala
@@ -14,18 +14,17 @@
  * limitations under the License.
  */
 
-package quasar.mimir.evaluate
+package quasar.yggdrasil.table
 
 import quasar.{IdStatus, ParseInstruction, ParseType}
 import quasar.common.{CPathField, CPathIndex, CPathMeta, CPathNode}
-import quasar.yggdrasil.table.CPathPlate
 
 import tectonic.{DelegatingPlate, Plate, Signal}
 
 import scala.annotation.tailrec
 
 // currently assumes retain = false, meaning you *cannot* have any non-shifted stuff in the row
-final class PivotPlate[A](
+private[table] final class PivotPlate[A](
     pivot: ParseInstruction.Pivot,
     delegate: Plate[A])
     extends DelegatingPlate(delegate)

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/WrapPlate.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/WrapPlate.scala
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
-package quasar.mimir.evaluate
+package quasar.yggdrasil.table
 
 import quasar.ParseInstruction
 import quasar.common.CPathField
-import quasar.yggdrasil.table.CPathPlate
 
 import tectonic.{DelegatingPlate, Plate, Signal}
 
-final class WrapPlate[A](
+private[table] final class WrapPlate[A](
     wrap: ParseInstruction.Wrap,
     delegate: Plate[A])
     extends DelegatingPlate(delegate)

--- a/yggdrasil/src/test/scala/quasar/yggdrasil/table/TectonicParseInstructionSpec.scala
+++ b/yggdrasil/src/test/scala/quasar/yggdrasil/table/TectonicParseInstructionSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package quasar.mimir.evaluate
+package quasar.yggdrasil.table
 
 import quasar.ParseInstructionSpec
 

--- a/yggdrasilPerf/src/main/scala/quasar/yggdrasil/perf/TableConstructionBenchmark.scala
+++ b/yggdrasilPerf/src/main/scala/quasar/yggdrasil/perf/TableConstructionBenchmark.scala
@@ -102,7 +102,7 @@ class TableConstructionBenchmark {
     } else if (mode == "old") {
       parseWithJawn.compile.to[Stream].map(P.Table.fromRValues(_, None)).liftM[WriterT[?[_], List[IO[Unit]], ?]]
     } else if (mode == "tectonic") {
-      P.Table.parseJson[WriterT[IO, List[IO[Unit]], ?]](data)
+      P.Table.parseJson[WriterT[IO, List[IO[Unit]], ?]](data, Nil)
     } else {
       sys.error("invalid mode")
     }


### PR DESCRIPTION
Had to move the plates out of mimir and into yggdrasil in order to keep `parseJson`'s implementation confined to that package. Ties the knot on everything mimir-related though.