### PR TITLE
Added file case to ExternalConfig

### DIFF
--- a/impl/src/main/scala/quasar/impl/external/ExternalConfig.scala
+++ b/impl/src/main/scala/quasar/impl/external/ExternalConfig.scala
@@ -57,6 +57,13 @@ object ExternalConfig {
   final case class PluginDirectory(dir: Path) extends ExternalConfig
 
   /**
+   * Similar to PluginDirectory, but explicitly referencing files. This
+   * makes it possible to specify plugin files that are in different
+   * directories, rather than forcing them all to be gathered in one location
+   */
+  final case class PluginFiles(files: List[Path]) extends ExternalConfig
+
+  /**
    * Any files in the classpath will be loaded as jars; any directories
    * will be assumed to contain class files (e.g. the target output of
    * SBT compile).  The class name should be the fully qualified Java

--- a/impl/src/main/scala/quasar/impl/external/ExternalDatasources.scala
+++ b/impl/src/main/scala/quasar/impl/external/ExternalDatasources.scala
@@ -56,7 +56,9 @@ object ExternalDatasources extends Logging {
   val PluginChunkSize = 8192
 
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-  def apply[F[_]: ContextShift: Timer](config: ExternalConfig, blockingPool: ExecutionContext)(
+  def apply[F[_]: ContextShift: Timer](
+      config: ExternalConfig,
+      blockingPool: ExecutionContext)(
       implicit F: ConcurrentEffect[F])
       : Stream[F, IMap[DatasourceType, DatasourceModule]] = {
 
@@ -65,6 +67,9 @@ object ExternalDatasources extends Logging {
         convert.fromJavaStream(F.delay(Files.list(directory)))
           .filter(_.getFileName.toString.endsWith(PluginExtSuffix))
           .flatMap(loadPlugin[F](_, blockingPool))
+
+      case PluginFiles(files) =>
+        Stream.emits(files).flatMap(loadPlugin[F](_, blockingPool))
 
       case ExplodedDirs(modules) =>
         for {


### PR DESCRIPTION
This is necessary to allow SDBE to specify a list of plugin files, rather than relying on the plugin directory included in the config. This *in turn* is extremely important because it allows the launcher to function reliably.