### PR TITLE
Added tests for tectonic slice breaking and fixed off-by-one issue

### DIFF
--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/SlicePlate.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/SlicePlate.scala
@@ -259,7 +259,6 @@ private[table] final class SlicePlate(
       val slice = Slice(size, columns.to[λ[α => Map[ColumnRef, Column]]])
       completed += slice
 
-      nextThreshold = defaultMinRows
       size = 0
       columns.clear()
     }

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/SlicePlate.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/SlicePlate.scala
@@ -31,7 +31,11 @@ private[table] abstract class EmptyFinishRowPlate[A] extends Plate[A] {
   def finishRow() = ()
 }
 
-private[table] final class SlicePlate(precise: Boolean)
+private[table] final class SlicePlate(
+    precise: Boolean,
+    defaultMinRows: Int = Config.defaultMinRows,
+    maxSliceRows: Int = Config.maxSliceRows,
+    maxSliceColumns: Int = Config.maxSliceColumns)
     extends EmptyFinishRowPlate[List[Slice]]    // <3 Scala
     with ContinuingNestPlate[List[Slice]]
     with CPathPlate[List[Slice]] {
@@ -49,7 +53,7 @@ private[table] final class SlicePlate(precise: Boolean)
 
   private val Nil = scala.Nil
 
-  private var nextThreshold = Config.defaultMinRows
+  private var nextThreshold = defaultMinRows
 
   private var size = 0    // rows in process don't count toward size
   private val columns = mutable.Map[ColumnRef, ArrayColumn[_]]()
@@ -192,7 +196,7 @@ private[table] final class SlicePlate(precise: Boolean)
     super.finishRow()
     size += 1
 
-    if (size > Config.maxSliceRows || columns.size > Config.maxSliceColumns) {
+    if (size >= maxSliceRows || columns.size > maxSliceColumns) {
       finishSlice()
     }
   }
@@ -255,7 +259,7 @@ private[table] final class SlicePlate(precise: Boolean)
       val slice = Slice(size, columns.to[λ[α => Map[ColumnRef, Column]]])
       completed += slice
 
-      nextThreshold = Config.defaultMinRows
+      nextThreshold = defaultMinRows
       size = 0
       columns.clear()
     }


### PR DESCRIPTION
You'll notice that the unit test actually shows that we go one column *over* the limit. This is because we can't know that we've exceeded the column limit… until we actually exceed it. Fixing this in the current implementation would require undoing data that has already been put into columns and then re-doing that work against a new slice, which sounds hard, slow, and probably not worth it for right now. Ticketing for future improvement.

[ch2955]
[ch2350]