### PR TITLE
Generalize ParseInstruction.Pivot

### DIFF
--- a/api/src/test/scala/quasar/api/table/MockTables.scala
+++ b/api/src/test/scala/quasar/api/table/MockTables.scala
@@ -126,7 +126,7 @@ final class MockTables[F[_]: Monad: MockTables.TablesMockState]
       store.put(updatedMap)
     }
 
-    cancelled >> ().point[F]
+    cancelled.void
   }
 
   // the live data is the query

--- a/frontend/src/main/scala/quasar/ParseInstruction.scala
+++ b/frontend/src/main/scala/quasar/ParseInstruction.scala
@@ -24,6 +24,7 @@ import scalaz.{Cord, Equal, Show}
 import scalaz.std.map._
 import scalaz.std.set._
 import scalaz.std.string._
+import scalaz.std.tuple._
 import scalaz.syntax.equal._
 import scalaz.syntax.show._
 
@@ -53,21 +54,17 @@ object ParseInstruction {
 
   /**
    * Pivots the indices and keys out of arrays and objects, respectively,
-   * according to the `structure`, maintaining their association with the original
-   * corresponding value.
+   * according to the provided structure, performing a full cross of all pivoted
+   * values.
    *
    * `idStatus` determines how the values is returned:
    *   - `IncludeId` wraps the key/value pair in a two element array.
    *   - `IdOnly` returns the value unwrapped.
    *   - `ExcludeId` returns the value unwrapped.
    *
-   * We plan to add a boolean `retain` parameter. Currently, `retain` implicitly
-   * defaults to `false`. `retain` will indicate two things:
-   *   1) In the case of a successful pivot, if surrounding structure should be retained.
-   *   2) In the case of an unsuccessful pivot (`path` does not reference a value of
-   *      the provided `structure`), if the row should be returned.
+   * No values outside of the pivot loci should be retained.
    */
-  final case class Pivot(path: CPath, idStatus: IdStatus, structure: CompositeParseType)
+  final case class Pivot(pivots: Map[CPath, (IdStatus, CompositeParseType)])
       extends ParseInstruction
 
   ////
@@ -77,7 +74,7 @@ object ParseInstruction {
       case (Ids, Ids) => true
       case (Wrap(p1, n1), Wrap(p2, n2)) => p1 === p2 && n1 === n2
       case (Mask(m1), Mask(m2)) => m1 === m2
-      case (Pivot(p1, i1, s1), Pivot(p2, i2, s2)) => p1 === p2 && i1 === i2 && s1 === s2
+      case (Pivot(p1), Pivot(p2)) => p1 === p2
       case (_, _) => false
     }
 
@@ -86,7 +83,6 @@ object ParseInstruction {
       case Ids => Cord("Ids")
       case Wrap(p, n) => Cord("Wrap(") ++ p.show ++ Cord(", ") ++ n.show ++ Cord(")")
       case Mask(m) => Cord("Mask(") ++ m.show ++ Cord(")")
-      case Pivot(p, i, s) =>
-        Cord("Pivot(") ++ p.show ++ Cord(", ") ++ i.show ++ Cord(", ") ++ s.show ++ Cord(")")
+      case Pivot(p) => Cord("Pivot(") ++ p.show ++ Cord(")")
     }
 }

--- a/frontend/src/test/scala/quasar/ParseInstructionSpec.scala
+++ b/frontend/src/test/scala/quasar/ParseInstructionSpec.scala
@@ -1055,7 +1055,7 @@ object ParseInstructionSpec {
         expected: JsonStream)
         : Matcher[JsonStream] =
       bestSemanticEqual(expected) ^^ { str: JsonStream =>
-        evalPivot(Pivot(CPath.parse(path), idStatus, structure), str)
+        evalPivot(Pivot(Map((CPath.parse(path), (idStatus, structure)))), str)
       }
   }
 }

--- a/mimir/src/test/scala/quasar/mimir/evaluate/RValueParseInstructionSpec.scala
+++ b/mimir/src/test/scala/quasar/mimir/evaluate/RValueParseInstructionSpec.scala
@@ -36,7 +36,13 @@ object RValueParseInstructionSpec
     stream.flatMap(RValueParseInstructionInterpreter.interpretMask(mask, _).toList)
 
   def evalPivot(pivot: Pivot, stream: JsonStream): JsonStream =
-    stream.flatMap(RValueParseInstructionInterpreter.interpretPivot(pivot, _))
+    if (pivot.pivots.size == 1)
+      pivot.pivots.head match {
+        case (path, (status, structure)) =>
+          stream.flatMap(RValueParseInstructionInterpreter.interpretPivot(path, status, structure, _))
+      }
+    else
+      scala.sys.error(s"Multiple pivots not supported")
 
   def evalWrap(wrap: Wrap, stream: JsonStream): JsonStream =
     stream.map(RValueParseInstructionInterpreter.interpretWrap(wrap, _))

--- a/qscript/src/main/scala/quasar/qscript/rewrites/RewritePushdown.scala
+++ b/qscript/src/main/scala/quasar/qscript/rewrites/RewritePushdown.scala
@@ -105,7 +105,7 @@ final class RewritePushdown[T[_[_]]: BirecursiveT: EqualT] extends TTypes[T] {
           val instructions: List[ParseInstruction] = List(
             Mask(SMap((path, Set(tpe)))),
             Wrap(compactedPath, ShiftedKey),
-            Pivot(compactedPath \ ShiftedKey, shiftStatus, tpe))
+            Pivot(SMap((compactedPath \ ShiftedKey, (shiftStatus, tpe)))))
 
           val src: T[F] = ER.inj(Const[InterpretedRead[A], T[F]](
             InterpretedRead[A](sr.path, instructions))).embed

--- a/qscript/src/test/scala/quasar/qscript/rewrites/RewritePushdownSpec.scala
+++ b/qscript/src/test/scala/quasar/qscript/rewrites/RewritePushdownSpec.scala
@@ -224,7 +224,7 @@ object RewritePushdownSpec extends Qspec {
               List(
                 Mask(SMap((CPath.Identity, Set(ParseType.Object)))),
                 Wrap(CPath.Identity, ShiftedKey),
-                Pivot(CPath(CPathField(ShiftedKey)), IncludeId, ParseType.Object))),
+                Pivot(SMap((CPath(CPathField(ShiftedKey)), (IncludeId, ParseType.Object)))))),
             recFuncE.ConcatMaps(
               recFuncE.MakeMapS("k1",
                 recFuncE.ProjectIndexI(recFuncE.ProjectKeyS(recFuncE.Hole, ShiftedKey), 0)),
@@ -251,7 +251,7 @@ object RewritePushdownSpec extends Qspec {
               List(
                 Mask(SMap((CPath.Identity, Set(ParseType.Object)))),
                 Wrap(CPath.Identity, ShiftedKey),
-                Pivot(CPath(CPathField(ShiftedKey)), IdOnly, ParseType.Object))),
+                Pivot(SMap((CPath(CPathField(ShiftedKey)), (IdOnly, ParseType.Object)))))),
             recFuncE.MakeMapS("k1",
               recFuncE.ProjectKeyS(recFuncE.Hole, ShiftedKey)))
 
@@ -275,7 +275,7 @@ object RewritePushdownSpec extends Qspec {
               List(
                 Mask(SMap((CPath.Identity, Set(ParseType.Object)))),
                 Wrap(CPath.Identity, ShiftedKey),
-                Pivot(CPath(CPathField(ShiftedKey)), ExcludeId, ParseType.Object))),
+                Pivot(SMap((CPath(CPathField(ShiftedKey)), (ExcludeId, ParseType.Object)))))),
             recFuncE.MakeMapS("v1",
               recFuncE.ProjectKeyS(recFuncE.Hole, ShiftedKey)))
 
@@ -303,7 +303,7 @@ object RewritePushdownSpec extends Qspec {
               List(
                 Mask(SMap((CPath.Identity, Set(ParseType.Object)))),
                 Wrap(CPath.Identity, ShiftedKey),
-                Pivot(CPath(CPathField(ShiftedKey)), ExcludeId, ParseType.Object))),
+                Pivot(SMap((CPath(CPathField(ShiftedKey)), (ExcludeId, ParseType.Object)))))),
             recFuncE.MakeMapS("v1",
               recFuncE.ProjectKeyS(recFuncE.Hole, ShiftedKey))),
           recFuncE.Constant(ejs.bool(true)))
@@ -330,7 +330,7 @@ object RewritePushdownSpec extends Qspec {
               List(
                 Mask(SMap((CPath(CPathField("xyz")), Set(ParseType.Object)))),
                 Wrap(CPath(CPathField("xyz")), ShiftedKey),
-                Pivot(CPath(CPathField("xyz"), CPathField(ShiftedKey)), IncludeId, ParseType.Object))),
+                Pivot(SMap((CPath(CPathField("xyz"), CPathField(ShiftedKey)), (IncludeId, ParseType.Object)))))),
             recFuncE.ConcatMaps(
               recFuncE.MakeMapS("k1",
                 recFuncE.ProjectIndexI(
@@ -372,7 +372,7 @@ object RewritePushdownSpec extends Qspec {
               List(
                 Mask(SMap((CPath(CPathField("aaa"), CPathField("bbb"), CPathField("ccc")), Set(ParseType.Object)))),
                 Wrap(CPath(CPathField("aaa"), CPathField("bbb"), CPathField("ccc")), ShiftedKey),
-                Pivot(CPath(CPathField("aaa"), CPathField("bbb"), CPathField("ccc"), CPathField(ShiftedKey)), IncludeId, ParseType.Object))),
+                Pivot(SMap((CPath(CPathField("aaa"), CPathField("bbb"), CPathField("ccc"), CPathField(ShiftedKey)), (IncludeId, ParseType.Object)))))),
             recFuncE.ConcatMaps(
               recFuncE.MakeMapS("k1",
                 recFuncE.ProjectIndexI(
@@ -415,7 +415,7 @@ object RewritePushdownSpec extends Qspec {
               List(
                 Mask(SMap((CPath(CPathField("aaa"), CPathIndex(42), CPathField("ccc")), Set(ParseType.Object)))),
                 Wrap(CPath(CPathField("aaa"), CPathIndex(0), CPathField("ccc")), ShiftedKey),
-                Pivot(CPath(CPathField("aaa"), CPathIndex(0), CPathField("ccc"), CPathField(ShiftedKey)), IncludeId, ParseType.Object))),
+                Pivot(SMap((CPath(CPathField("aaa"), CPathIndex(0), CPathField("ccc"), CPathField(ShiftedKey)), (IncludeId, ParseType.Object)))))),
             recFuncE.ConcatMaps(
               recFuncE.MakeMapS("k1",
                 recFuncE.ProjectIndexI(
@@ -457,7 +457,7 @@ object RewritePushdownSpec extends Qspec {
               List(
                 Mask(SMap((CPath(CPathIndex(17), CPathIndex(42), CPathField("ccc")), Set(ParseType.Object)))),
                 Wrap(CPath(CPathIndex(0), CPathIndex(0), CPathField("ccc")), ShiftedKey),
-                Pivot(CPath(CPathIndex(0), CPathIndex(0), CPathField("ccc"), CPathField(ShiftedKey)), IncludeId, ParseType.Object))),
+                Pivot(SMap((CPath(CPathIndex(0), CPathIndex(0), CPathField("ccc"), CPathField(ShiftedKey)), (IncludeId, ParseType.Object)))))),
             recFuncE.ConcatMaps(
               recFuncE.MakeMapS("k1",
                 recFuncE.ProjectIndexI(

--- a/qscript/src/test/scala/quasar/qscript/rewrites/RewritePushdownSpec.scala
+++ b/qscript/src/test/scala/quasar/qscript/rewrites/RewritePushdownSpec.scala
@@ -21,7 +21,7 @@ import slamdata.Predef.{Map => SMap, _}
 import quasar.{ParseType, Qspec}
 import quasar.IdStatus.{ExcludeId, IdOnly, IncludeId}
 import quasar.ParseInstruction.{Mask, Pivot, Wrap}
-import quasar.common.{CPath, CPathField, CPathIndex}
+import quasar.common.CPath
 import quasar.contrib.iota._
 import quasar.contrib.pathy._
 import quasar.ejson.{EJson, Fixed}
@@ -78,12 +78,12 @@ object RewritePushdownSpec extends Qspec {
 
     "find the path of a single object projection" >> {
       pushdown.findPath(funcE.ProjectKeyS(funcE.Hole, "xyz")) must equal(
-        Some(CPath(CPathField("xyz"))))
+        Some(CPath.parse(".xyz")))
     }
 
     "find the path of a single array projection" >> {
       pushdown.findPath(funcE.ProjectIndexI(funcE.Hole, 7)) must equal(
-        Some(CPath(CPathIndex(7))))
+        Some(CPath.parse("[7]")))
     }
 
     "find the path of a triple object projection" >> {
@@ -97,7 +97,7 @@ object RewritePushdownSpec extends Qspec {
           "ccc")
 
       pushdown.findPath(fm) must equal(
-        Some(CPath(CPathField("aaa"), CPathField("bbb"), CPathField("ccc"))))
+        Some(CPath.parse(".aaa.bbb.ccc")))
     }
 
     "find the path of a triple array projection" >> {
@@ -111,7 +111,7 @@ object RewritePushdownSpec extends Qspec {
           0)
 
       pushdown.findPath(fm) must equal(
-        Some(CPath(CPathIndex(2), CPathIndex(6), CPathIndex(0))))
+        Some(CPath.parse("[2][6][0]")))
     }
 
     "find the path of an array projection and object projection" >> {
@@ -125,7 +125,7 @@ object RewritePushdownSpec extends Qspec {
           "ccc")
 
       pushdown.findPath(fm) must equal(
-        Some(CPath(CPathField("aaa"), CPathIndex(42), CPathField("ccc"))))
+        Some(CPath.parse(".aaa[42].ccc")))
     }
 
     "fail find the path of an object projection with a non-string key" >> {
@@ -224,7 +224,7 @@ object RewritePushdownSpec extends Qspec {
               List(
                 Mask(SMap((CPath.Identity, Set(ParseType.Object)))),
                 Wrap(CPath.Identity, ShiftedKey),
-                Pivot(SMap((CPath(CPathField(ShiftedKey)), (IncludeId, ParseType.Object)))))),
+                Pivot(SMap((CPath.parse(s".$ShiftedKey"), (IncludeId, ParseType.Object)))))),
             recFuncE.ConcatMaps(
               recFuncE.MakeMapS("k1",
                 recFuncE.ProjectIndexI(recFuncE.ProjectKeyS(recFuncE.Hole, ShiftedKey), 0)),
@@ -251,7 +251,7 @@ object RewritePushdownSpec extends Qspec {
               List(
                 Mask(SMap((CPath.Identity, Set(ParseType.Object)))),
                 Wrap(CPath.Identity, ShiftedKey),
-                Pivot(SMap((CPath(CPathField(ShiftedKey)), (IdOnly, ParseType.Object)))))),
+                Pivot(SMap((CPath.parse(s".$ShiftedKey"), (IdOnly, ParseType.Object)))))),
             recFuncE.MakeMapS("k1",
               recFuncE.ProjectKeyS(recFuncE.Hole, ShiftedKey)))
 
@@ -275,7 +275,7 @@ object RewritePushdownSpec extends Qspec {
               List(
                 Mask(SMap((CPath.Identity, Set(ParseType.Object)))),
                 Wrap(CPath.Identity, ShiftedKey),
-                Pivot(SMap((CPath(CPathField(ShiftedKey)), (ExcludeId, ParseType.Object)))))),
+                Pivot(SMap((CPath.parse(s".$ShiftedKey"), (ExcludeId, ParseType.Object)))))),
             recFuncE.MakeMapS("v1",
               recFuncE.ProjectKeyS(recFuncE.Hole, ShiftedKey)))
 
@@ -303,7 +303,7 @@ object RewritePushdownSpec extends Qspec {
               List(
                 Mask(SMap((CPath.Identity, Set(ParseType.Object)))),
                 Wrap(CPath.Identity, ShiftedKey),
-                Pivot(SMap((CPath(CPathField(ShiftedKey)), (ExcludeId, ParseType.Object)))))),
+                Pivot(SMap((CPath.parse(s".$ShiftedKey"), (ExcludeId, ParseType.Object)))))),
             recFuncE.MakeMapS("v1",
               recFuncE.ProjectKeyS(recFuncE.Hole, ShiftedKey))),
           recFuncE.Constant(ejs.bool(true)))
@@ -328,9 +328,9 @@ object RewritePushdownSpec extends Qspec {
             fixE.InterpretedRead[AFile](
               rootDir </> file("foo"),
               List(
-                Mask(SMap((CPath(CPathField("xyz")), Set(ParseType.Object)))),
-                Wrap(CPath(CPathField("xyz")), ShiftedKey),
-                Pivot(SMap((CPath(CPathField("xyz"), CPathField(ShiftedKey)), (IncludeId, ParseType.Object)))))),
+                Mask(SMap((CPath.parse(".xyz"), Set(ParseType.Object)))),
+                Wrap(CPath.parse(".xyz"), ShiftedKey),
+                Pivot(SMap((CPath.parse(s".xyz.$ShiftedKey"), (IncludeId, ParseType.Object)))))),
             recFuncE.ConcatMaps(
               recFuncE.MakeMapS("k1",
                 recFuncE.ProjectIndexI(
@@ -370,9 +370,9 @@ object RewritePushdownSpec extends Qspec {
             fixE.InterpretedRead[AFile](
               rootDir </> file("foo"),
               List(
-                Mask(SMap((CPath(CPathField("aaa"), CPathField("bbb"), CPathField("ccc")), Set(ParseType.Object)))),
-                Wrap(CPath(CPathField("aaa"), CPathField("bbb"), CPathField("ccc")), ShiftedKey),
-                Pivot(SMap((CPath(CPathField("aaa"), CPathField("bbb"), CPathField("ccc"), CPathField(ShiftedKey)), (IncludeId, ParseType.Object)))))),
+                Mask(SMap((CPath.parse(".aaa.bbb.ccc"), Set(ParseType.Object)))),
+                Wrap(CPath.parse(".aaa.bbb.ccc"), ShiftedKey),
+                Pivot(SMap((CPath.parse(s".aaa.bbb.ccc.$ShiftedKey"), (IncludeId, ParseType.Object)))))),
             recFuncE.ConcatMaps(
               recFuncE.MakeMapS("k1",
                 recFuncE.ProjectIndexI(
@@ -413,9 +413,9 @@ object RewritePushdownSpec extends Qspec {
             fixE.InterpretedRead[AFile](
               rootDir </> file("foo"),
               List(
-                Mask(SMap((CPath(CPathField("aaa"), CPathIndex(42), CPathField("ccc")), Set(ParseType.Object)))),
-                Wrap(CPath(CPathField("aaa"), CPathIndex(0), CPathField("ccc")), ShiftedKey),
-                Pivot(SMap((CPath(CPathField("aaa"), CPathIndex(0), CPathField("ccc"), CPathField(ShiftedKey)), (IncludeId, ParseType.Object)))))),
+                Mask(SMap((CPath.parse(".aaa[42].ccc"), Set(ParseType.Object)))),
+                Wrap(CPath.parse(".aaa[0].ccc"), ShiftedKey),
+                Pivot(SMap((CPath.parse(s".aaa[0].ccc.$ShiftedKey"), (IncludeId, ParseType.Object)))))),
             recFuncE.ConcatMaps(
               recFuncE.MakeMapS("k1",
                 recFuncE.ProjectIndexI(
@@ -455,9 +455,9 @@ object RewritePushdownSpec extends Qspec {
             fixE.InterpretedRead[AFile](
               rootDir </> file("foo"),
               List(
-                Mask(SMap((CPath(CPathIndex(17), CPathIndex(42), CPathField("ccc")), Set(ParseType.Object)))),
-                Wrap(CPath(CPathIndex(0), CPathIndex(0), CPathField("ccc")), ShiftedKey),
-                Pivot(SMap((CPath(CPathIndex(0), CPathIndex(0), CPathField("ccc"), CPathField(ShiftedKey)), (IncludeId, ParseType.Object)))))),
+                Mask(SMap((CPath.parse("[17][42].ccc"), Set(ParseType.Object)))),
+                Wrap(CPath.parse("[0][0].ccc"), ShiftedKey),
+                Pivot(SMap((CPath.parse(s"[0][0].ccc.$ShiftedKey"), (IncludeId, ParseType.Object)))))),
             recFuncE.ConcatMaps(
               recFuncE.MakeMapS("k1",
                 recFuncE.ProjectIndexI(

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/ColumnarTableModule.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/ColumnarTableModule.scala
@@ -391,8 +391,14 @@ trait ColumnarTableModule
         case (instr @ ParseInstruction.Mask(_), plate) =>
           new MaskPlate(instr, plate)
 
-        case (instr @ ParseInstruction.Pivot(_, _, _), plate) =>
-          new PivotPlate(instr, plate)
+        case (instr @ ParseInstruction.Pivot(pivots), plate) =>
+          if (pivots.size == 1)
+            pivots.head match {
+              case (path, (idStatus, structure)) =>
+                new PivotPlate(path, idStatus, structure, plate)
+            }
+          else
+            sys.error("Multiple pivots not supported")
       }
 
       val jsonMode =

--- a/yggdrasil/src/main/scala/quasar/yggdrasil/table/PivotPlate.scala
+++ b/yggdrasil/src/main/scala/quasar/yggdrasil/table/PivotPlate.scala
@@ -16,8 +16,8 @@
 
 package quasar.yggdrasil.table
 
-import quasar.{IdStatus, ParseInstruction, ParseType}
-import quasar.common.{CPathField, CPathIndex, CPathMeta, CPathNode}
+import quasar.{CompositeParseType, IdStatus, ParseInstruction, ParseType}
+import quasar.common.{CPath, CPathField, CPathIndex, CPathMeta, CPathNode}
 
 import tectonic.{DelegatingPlate, Plate, Signal}
 
@@ -25,12 +25,12 @@ import scala.annotation.tailrec
 
 // currently assumes retain = false, meaning you *cannot* have any non-shifted stuff in the row
 private[table] final class PivotPlate[A](
-    pivot: ParseInstruction.Pivot,
+    path: CPath,
+    idStatus: IdStatus,
+    structure: CompositeParseType,
     delegate: Plate[A])
     extends DelegatingPlate(delegate)
     with CPathPlate[A] {
-
-  import pivot._
 
   private val rfocus = path.nodes.reverse
   private val rfocusPlus1 = CPathIndex(1) :: rfocus

--- a/yggdrasil/src/test/scala/quasar/yggdrasil/table/TectonicParseInstructionSpec.scala
+++ b/yggdrasil/src/test/scala/quasar/yggdrasil/table/TectonicParseInstructionSpec.scala
@@ -36,7 +36,13 @@ object TectonicParseInstructionSpec extends ParseInstructionSpec {
     evalPlate(stream)(new IdsPlate(_))
 
   def evalPivot(pivot: Pivot, stream: JsonStream): JsonStream =
-    evalPlate(stream)(new PivotPlate(pivot, _))
+    if (pivot.pivots.size == 1)
+      pivot.pivots.head match {
+        case (path, (idStatus, structure)) =>
+          evalPlate(stream)(new PivotPlate(path, idStatus, structure, _))
+      }
+    else
+      sys.error(s"Cannot evaluate mutiple pivots")
 
   private def evalPlate(stream: JsonStream)(f: Plate[List[Event]] => Plate[List[Event]]): JsonStream = {
     val plate = f(new ReifiedTerminalPlate)


### PR DESCRIPTION
```json
{ "a": 42, "b": true, "c": [1, 2, 3], "d": ["hi", "there"] }
```
with `b` and `d` retained and `c` pivoted will first be `Mask`ed, then be `Wrap`ed as so:
```json
{ "locus1": { "retain": { "b": true } }, "locus2": [1, 2, 3], "locus3": { "retain": { "d": ["hi", "there"] } } }
```
and then `Pivot`ed as so:
```scala
Pivot(Map((.locus1, ...), (.locus2, ...), (.locus3, ...)))
```