### PR TITLE
Singleton ds should list resource as a resource

### DIFF
--- a/connector/src/main/scala/quasar/connector/datasource/SingletonDatasource.scala
+++ b/connector/src/main/scala/quasar/connector/datasource/SingletonDatasource.scala
@@ -55,6 +55,7 @@ final class SingletonDatasource[F[_]: MonadResourceErr, G[_]: Applicative, R] pr
   def prefixedChildPaths(prefixPath: ResourcePath)
       : F[Option[G[(ResourceName, ResourcePathType)]]] =
     F.point(location.relativeTo(prefixPath) collect {
+      case h /: ResourcePath.Root => (ResourceName(h), ResourcePathType.leafResource).point[G]
       case h /: _ => (ResourceName(h), ResourcePathType.prefix).point[G]
     })
 }

--- a/connector/src/test/scala/quasar/connector/datasource/SingletonDatasourceSpec.scala
+++ b/connector/src/test/scala/quasar/connector/datasource/SingletonDatasourceSpec.scala
@@ -16,7 +16,7 @@
 
 package quasar.connector.datasource
 
-import slamdata.Predef.{Left, List, String}
+import slamdata.Predef.{Left, List, Some, String}
 
 import quasar.api.datasource.DatasourceType
 import quasar.api.resource._
@@ -26,6 +26,8 @@ import quasar.contrib.scalaz.MonadError_
 import cats.effect.IO
 import eu.timepit.refined.auto._
 import scalaz.std.list._
+import scalaz.std.option._
+import scalaz.std.tuple._
 import shims._
 
 object SingletonDatasourceSpec extends DatasourceSpec[IO, List] {
@@ -40,6 +42,11 @@ object SingletonDatasourceSpec extends DatasourceSpec[IO, List] {
   val nonExistentPath = path / ResourceName("baz")
   def gatherMultiple[A](xs: List[A]) = IO.pure(xs)
 
+  "listing the parent of the resource should return the resource" >>* {
+    datasource.prefixedChildPaths(ResourcePath.root() / ResourceName("foo")) map { paths =>
+      paths must_= Some(List((ResourceName("bar"), ResourcePathType.leafResource)))
+    }
+  }
 
   "evaluating resource path returns resource" >>* {
     datasource.evaluate(path).map(_ must_=== "data")


### PR DESCRIPTION
Fixes an issue where listing the parent path of the singleton resource would return the resource name typed as a prefix instead of a resource.