### PR TITLE
Added UTF-8 byte-order mark to output streams from the REPL

### DIFF
--- a/repl/src/main/scala/quasar/repl/Evaluator.scala
+++ b/repl/src/main/scala/quasar/repl/Evaluator.scala
@@ -40,7 +40,6 @@ import quasar.yggdrasil.util.NullRemover
 
 import java.lang.Exception
 import java.nio.CharBuffer
-import java.nio.charset.StandardCharsets
 import java.nio.file.{Path => JPath}
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -541,7 +540,7 @@ final class Evaluator[F[_]: ContextShift: Effect: MonadQuasarErr: PhaseResultLis
       path.fold(f => fileParent(f) </> dir(fileName(f).value), rootDir)
 
     private def writeToPath(path: JPath, s: Stream[F, CharBuffer]): F[Unit] =
-      s.through(pipe.charBufferToByte(StandardCharsets.UTF_8))
+      s.through(pipe.charBufferToByteUtf8(true))
         .through(fs2.io.file.writeAll(path, ec))
         .compile.drain
 }


### PR DESCRIPTION
This is part of [ch3352]. I verified that the mark is correctly handled by both Sublime Text and Safari.