### PR TITLE
Fixed multi-path node removal/rename

### DIFF
--- a/qsu/src/main/scala/quasar/qsu/PruneSymmetricDimEdits.scala
+++ b/qsu/src/main/scala/quasar/qsu/PruneSymmetricDimEdits.scala
@@ -53,7 +53,7 @@ final class PruneSymmetricDimEdits[T[_[_]]] private () extends QSUTTypes[T] {
               back <- tip traverse { sg =>
                 roots.foldLeftM(sg) {
                   case (g, target @ DimEdit(parent, _)) =>
-                    g.replaceWithRename[G](target.root, parent.root)
+                    g.replaceWithRename[G]("psde", target.root, parent.root)
 
                   case (g, _ ) => g.point[G]
                 }

--- a/qsu/src/main/scala/quasar/qsu/QSUGraph.scala
+++ b/qsu/src/main/scala/quasar/qsu/QSUGraph.scala
@@ -149,7 +149,7 @@ final case class QSUGraph[T[_[_]]](
               bare = pattern.map(_.root)
               renamed <- withName(bare)
               verts2 = pattern.foldLeft(SMap[Symbol, QScriptUniform[T, Symbol]]())(_ ++ _.vertices)
-            } yield renamed.copy(vertices = verts2 ++ renamed.vertices)
+            } yield this ++: renamed
         }
       }
     } else {

--- a/qsu/src/main/scala/quasar/qsu/QSUGraph.scala
+++ b/qsu/src/main/scala/quasar/qsu/QSUGraph.scala
@@ -148,8 +148,9 @@ final case class QSUGraph[T[_[_]]](
               pattern <- unfold.traverse(_.replaceWithRename[F](prefix, src, target))
               bare = pattern.map(_.root)
               renamed <- withName(bare)
-              verts2 = pattern.foldLeft(SMap[Symbol, QScriptUniform[T, Symbol]]())(_ ++ _.vertices)
-            } yield this ++: renamed
+              patternVerts = pattern.foldLeft(SMap[Symbol, QScriptUniform[T, Symbol]]())(_ ++ _.vertices)
+              back = this ++: renamed
+            } yield back.copy(vertices = back.vertices ++ patternVerts)
         }
       }
     } else {

--- a/qsu/src/main/scala/quasar/qsu/QSUGraph.scala
+++ b/qsu/src/main/scala/quasar/qsu/QSUGraph.scala
@@ -126,11 +126,13 @@ final case class QSUGraph[T[_[_]]](
   @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
   def replaceWithRename[
       F[_]: Monad: NameGenerator: MonadState_[?[_], QSUGraph.RevIdx[T]]](
-      src: Symbol, target: Symbol): F[QSUGraph[T]] = {
+      prefix: String,
+      src: Symbol,
+      target: Symbol): F[QSUGraph[T]] = {
 
     import QScriptUniform._
 
-    val withName = QSUGraph.withName[T, F]("qsu")_
+    val withName = QSUGraph.withName[T, F](prefix) _
 
     if (src =/= target) {
 
@@ -143,7 +145,7 @@ final case class QSUGraph[T[_[_]]](
 
           case _ =>
             for {
-              pattern <- unfold.traverse(_.replaceWithRename[F](src, target))
+              pattern <- unfold.traverse(_.replaceWithRename[F](prefix, src, target))
               bare = pattern.map(_.root)
               renamed <- withName(bare)
               verts2 = pattern.foldLeft(SMap[Symbol, QScriptUniform[T, Symbol]]())(_ ++ _.vertices)

--- a/qsu/src/main/scala/quasar/qsu/RewriteGroupByArrays.scala
+++ b/qsu/src/main/scala/quasar/qsu/RewriteGroupByArrays.scala
@@ -40,7 +40,7 @@ final class RewriteGroupByArrays[T[_[_]]: BirecursiveT: ShowT] private () extend
           // this is a bizarre rewrite, because it generates invalid graphs along the way
           // this happens because inner and target don't necessarily exist in key's vertices
           for {
-            key2 <- key.replaceWithRename[G](target.root, inner.root)
+            key2 <- key.replaceWithRename[G]("rga", target.root, inner.root)
             replaced <- QSUGraph.withName[T, G]("rga")(QSU.GroupBy[T, Symbol](inner.root, key2.root))
           } yield replaced :++ inner :++ key2
         }

--- a/qsu/src/test/scala/quasar/qsu/PruneSymmetricDimEditsSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/PruneSymmetricDimEditsSpec.scala
@@ -144,6 +144,31 @@ object PruneSymmetricDimEditsSpec extends Qspec with QSUTTypes[Fix] {
         case AutoJoin2(Read(_), Unreferenced(), _) => ok
       }
     }
+
+    "retain pointers to vertices with multiple inbound edges" in {
+      val qgraph = QSUGraph.fromTree[Fix](
+        qsu.autojoin2((
+          qsu.autojoin2((
+            qsu.dimEdit((
+              qsu.map(
+                qsu.read(afile),
+                recFunc.ProjectKeyS(recFunc.Hole, "bar")),
+              QSU.DTrans.Squash())),
+            qsu.dimEdit((
+              qsu.map(
+                qsu.read(afile),
+                recFunc.ProjectKeyS(recFunc.Hole, "baz")),
+              QSU.DTrans.Squash())),
+            _(MapFuncsCore.Add(_, _)))),
+          qsu.dimEdit((
+            qsu.map(
+              qsu.read(afile),
+              recFunc.ProjectKeyS(recFunc.Hole, "bar")),
+            QSU.DTrans.Squash())),
+          _(MapFuncsCore.Add(_, _)))))
+
+      runOn(qgraph) must not(throwA[Exception])
+    }
   }
 
   private def runOn(g: QSUGraph): QSUGraph = {


### PR DESCRIPTION
This was the issue with `replaceWithRename` that I referenced to @alissapajer 

[ch3067]