### PR TITLE
Delete unnecessary components of coalesceQC

### DIFF
--- a/qscript/src/main/scala/quasar/qscript/rewrites/Normalizable.scala
+++ b/qscript/src/main/scala/quasar/qscript/rewrites/Normalizable.scala
@@ -112,7 +112,7 @@ class NormalizableT[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends T
   lazy val rewrite = new Rewrite[T]
 
   def freeTC(free: FreeQS): FreeQS =
-    free.transCata[FreeQS](liftCo(rewrite.normalizeTJCoEnv[QScriptTotal]))
+    free.transCata[FreeQS](liftCo(rewrite.normalizeCoEnv[QScriptTotal]))
 
   def freeTCEq(free: FreeQS): Option[FreeQS] = {
     val freeNormalized = freeTC(free)

--- a/qscript/src/main/scala/quasar/qscript/rewrites/Rewrite.scala
+++ b/qscript/src/main/scala/quasar/qscript/rewrites/Rewrite.scala
@@ -34,11 +34,11 @@ class Rewrite[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends TTypes[
 
   def normalize[G[a] <: ACopK[a]: Traverse, H[_]: Functor]
     (implicit QC: QScriptCore :<<: G,
-              J: SimplifyJoin.Aux[T, G, H],
+              J: ThetaToEquiJoin.Aux[T, G, H],
               C: Coalesce.Aux[T, G, G],
               N: Normalizable[G])
       : T[G] => T[H] =
-    normalizeAll[G].apply(_).transCata[T[H]](J.simplifyJoin[J.G](idPrism.reverseGet))
+    normalizeAll[G].apply(_).transCata[T[H]](J.rewrite[J.G](idPrism.reverseGet))
 
   private def normalizeAll[G[a] <: ACopK[a]: Traverse]
     (implicit QC: QScriptCore :<<: G,

--- a/qscript/src/main/scala/quasar/qscript/rewrites/Unirewrite.scala
+++ b/qscript/src/main/scala/quasar/qscript/rewrites/Unirewrite.scala
@@ -40,7 +40,7 @@ object Unirewrite {
     implicit
       FC: Functor[CopK[L, ?]],
       TC0: Traverse[CopK[L, ?]],
-      J: SimplifyJoin.Aux[T, QScriptRead[T, ?], CopK[L, ?]],
+      J: ThetaToEquiJoin.Aux[T, QScriptRead[T, ?], CopK[L, ?]],
       C: Coalesce.Aux[T, QScriptRead[T, ?], QScriptRead[T, ?]],
       N: Normalizable[QScriptRead[T, ?]])
       : Unirewrite[T, L] =

--- a/qscript/src/main/scala/quasar/qscript/rewrites/Unirewrite.scala
+++ b/qscript/src/main/scala/quasar/qscript/rewrites/Unirewrite.scala
@@ -47,7 +47,7 @@ object Unirewrite {
     new Unirewrite[T, L] {
       def apply[F[_]: Monad: MonadPlannerErr](r: Rewrite[T])
           : T[QScriptRead[T, ?]] => F[T[CopK[L, ?]]] = { qs =>
-        r.simplifyJoinOnNorm[QScriptRead[T, ?], CopK[L, ?]]
+        r.normalize[QScriptRead[T, ?], CopK[L, ?]]
           .apply(qs).point[F]
       }
   }

--- a/qscript/src/test/scala/quasar/qscript/rewrites/RewriteSpec.scala
+++ b/qscript/src/test/scala/quasar/qscript/rewrites/RewriteSpec.scala
@@ -40,7 +40,7 @@ class RewriteSpec extends quasar.Qspec with QScriptHelpers {
   val rewrite = new Rewrite[Fix]
 
   def normalizeExpr(expr: Fix[QS]): Fix[QS] =
-    expr.transCata[Fix[QS]](rewrite.normalizeTJ[QS])
+    expr.transCata[Fix[QS]](rewrite.normalizeT[QS])
 
   def simplifyJoinExpr(expr: Fix[QS]): Fix[QST] =
     expr.transCata[Fix[QST]](SimplifyJoin[Fix, QS, QST].simplifyJoin(idPrism.reverseGet))

--- a/qscript/src/test/scala/quasar/qscript/rewrites/RewriteSpec.scala
+++ b/qscript/src/test/scala/quasar/qscript/rewrites/RewriteSpec.scala
@@ -16,7 +16,6 @@
 
 package quasar.qscript.rewrites
 
-import slamdata.Predef._
 import quasar._
 import quasar.api.resource.ResourcePath
 import quasar.common.JoinType
@@ -25,7 +24,6 @@ import quasar.contrib.iota._
 import quasar.contrib.iota.SubInject
 import quasar.qscript._
 
-import matryoshka._
 import matryoshka.data.Fix
 import matryoshka.implicits._
 import pathy.Path._
@@ -34,16 +32,13 @@ import scalaz._, Scalaz._
 import iotaz.{CopK, TNilK}
 import iotaz.TListK.:::
 
-class RewriteSpec extends quasar.Qspec with QScriptHelpers {
+object RewriteSpec extends quasar.Qspec with QScriptHelpers {
   import IdStatus.ExcludeId
 
   val rewrite = new Rewrite[Fix]
 
   def normalizeExpr(expr: Fix[QS]): Fix[QS] =
     expr.transCata[Fix[QS]](rewrite.normalizeT[QS])
-
-  def simplifyJoinExpr(expr: Fix[QS]): Fix[QST] =
-    expr.transCata[Fix[QST]](SimplifyJoin[Fix, QS, QST].simplifyJoin(idPrism.reverseGet))
 
   type QSI[A] = CopK[QScriptCore ::: ThetaJoin ::: TNilK, A]
 
@@ -80,102 +75,6 @@ class RewriteSpec extends quasar.Qspec with QScriptHelpers {
           ShiftType.Array,
           OnUndefined.Omit,
           func.RightSide).unFix.some)
-    }
-
-    "simplify an outer ThetaJoin with a statically known condition" in {
-      val exp: Fix[QS] = {
-        import qsdsl._
-        fix.ThetaJoin(
-          fix.Unreferenced,
-          free.Read[ResourcePath](ResourcePath.leaf(rootDir </> file("foo")), ExcludeId),
-          free.Read[ResourcePath](ResourcePath.leaf(rootDir </> file("bar")), ExcludeId),
-          func.Eq(
-            func.Constant(json.int(0)),
-            func.Constant(json.int(1))),
-          JoinType.FullOuter,
-          func.ConcatMaps(func.LeftSide, func.RightSide))
-      }
-
-      simplifyJoinExpr(exp) must equal {
-        import qstdsl._
-        fix.Map(
-          fix.EquiJoin(
-            fix.Unreferenced,
-            free.Read[ResourcePath](ResourcePath.leaf(rootDir </> file("foo")), ExcludeId),
-            free.Read[ResourcePath](ResourcePath.leaf(rootDir </> file("bar")), ExcludeId),
-            List((
-              func.Constant(json.int(0)),
-              func.Constant(json.int(1)))),
-            JoinType.FullOuter,
-            func.StaticMapS(
-              SimplifyJoin.LeftK -> func.LeftSide,
-              SimplifyJoin.RightK -> func.RightSide)),
-          recFunc.ConcatMaps(
-            recFunc.ProjectKeyS(recFunc.Hole, SimplifyJoin.LeftK),
-            recFunc.ProjectKeyS(recFunc.Hole, SimplifyJoin.RightK)))
-      }
-    }
-
-    "simplify a ThetaJoin" in {
-      val exp: Fix[QS] = {
-        import qsdsl._
-        fix.ThetaJoin(
-          fix.Unreferenced,
-          free.Read[ResourcePath](ResourcePath.leaf(rootDir </> file("foo")), ExcludeId),
-          free.Read[ResourcePath](ResourcePath.leaf(rootDir </> file("bar")), ExcludeId),
-          func.And(func.And(
-            // reversed equality
-            func.Eq(
-              func.ProjectKeyS(func.RightSide, "r_id"),
-              func.ProjectKeyS(func.LeftSide, "l_id")),
-            // more complicated expression, duplicated refs
-            func.Eq(
-              func.Add(
-                func.ProjectKeyS(func.LeftSide, "l_min"),
-                func.ProjectKeyS(func.LeftSide, "l_max")),
-              func.Subtract(
-                func.ProjectKeyS(func.RightSide, "l_max"),
-                func.ProjectKeyS(func.RightSide, "l_min")))),
-            // inequality
-            func.Lt(
-              func.ProjectKeyS(func.LeftSide, "l_lat"),
-              func.ProjectKeyS(func.RightSide, "r_lat"))),
-          JoinType.Inner,
-          func.ConcatMaps(func.LeftSide, func.RightSide))
-      }
-
-      simplifyJoinExpr(exp) must equal {
-        import qstdsl._
-        fix.Map(
-          fix.Filter(
-            fix.EquiJoin(
-              fix.Unreferenced,
-              free.Read[ResourcePath](ResourcePath.leaf(rootDir </> file("foo")), ExcludeId),
-              free.Read[ResourcePath](ResourcePath.leaf(rootDir </> file("bar")), ExcludeId),
-              List(
-                (func.ProjectKeyS(func.Hole, "l_id"),
-                  func.ProjectKeyS(func.Hole, "r_id")),
-                (func.Add(
-                  func.ProjectKeyS(func.Hole, "l_min"),
-                  func.ProjectKeyS(func.Hole, "l_max")),
-                  func.Subtract(
-                    func.ProjectKeyS(func.Hole, "l_max"),
-                    func.ProjectKeyS(func.Hole, "l_min")))),
-              JoinType.Inner,
-              func.StaticMapS(
-                SimplifyJoin.LeftK -> func.LeftSide,
-                SimplifyJoin.RightK -> func.RightSide)),
-            recFunc.Lt(
-              recFunc.ProjectKeyS(
-                recFunc.ProjectKeyS(recFunc.Hole, SimplifyJoin.LeftK),
-                "l_lat"),
-              recFunc.ProjectKeyS(
-                recFunc.ProjectKeyS(recFunc.Hole, SimplifyJoin.RightK),
-                "r_lat"))),
-          recFunc.ConcatMaps(
-            recFunc.ProjectKeyS(recFunc.Hole, SimplifyJoin.LeftK),
-            recFunc.ProjectKeyS(recFunc.Hole, SimplifyJoin.RightK)))
-      }
     }
 
     "extract filter from join condition" >> {

--- a/qscript/src/test/scala/quasar/qscript/rewrites/ThetaToEquiJoinSpec.scala
+++ b/qscript/src/test/scala/quasar/qscript/rewrites/ThetaToEquiJoinSpec.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qscript.rewrites
+
+import slamdata.Predef._
+import quasar.IdStatus.ExcludeId
+import quasar.api.resource.ResourcePath
+import quasar.common.JoinType
+import quasar.contrib.iota._
+import quasar.fp._
+import quasar.qscript.QScriptHelpers
+
+import matryoshka.data.Fix
+import matryoshka.implicits._
+import pathy.Path._
+
+object ThetaToEquiJoinSpec extends quasar.Qspec with QScriptHelpers {
+
+  def simplifyJoinExpr(expr: Fix[QS]): Fix[QST] =
+    expr.transCata[Fix[QST]](ThetaToEquiJoin[Fix, QS, QST].rewrite(idPrism.reverseGet))
+
+  "simplify an outer ThetaJoin with a statically known condition" in {
+    val exp: Fix[QS] = {
+      import qsdsl._
+      fix.ThetaJoin(
+        fix.Unreferenced,
+        free.Read[ResourcePath](ResourcePath.leaf(rootDir </> file("foo")), ExcludeId),
+        free.Read[ResourcePath](ResourcePath.leaf(rootDir </> file("bar")), ExcludeId),
+        func.Eq(
+          func.Constant(json.int(0)),
+          func.Constant(json.int(1))),
+        JoinType.FullOuter,
+        func.ConcatMaps(func.LeftSide, func.RightSide))
+    }
+
+    simplifyJoinExpr(exp) must equal {
+      import qstdsl._
+      fix.Map(
+        fix.EquiJoin(
+          fix.Unreferenced,
+          free.Read[ResourcePath](ResourcePath.leaf(rootDir </> file("foo")), ExcludeId),
+          free.Read[ResourcePath](ResourcePath.leaf(rootDir </> file("bar")), ExcludeId),
+          List((
+            func.Constant(json.int(0)),
+            func.Constant(json.int(1)))),
+          JoinType.FullOuter,
+          func.StaticMapS(
+            ThetaToEquiJoin.LeftK -> func.LeftSide,
+            ThetaToEquiJoin.RightK -> func.RightSide)),
+        recFunc.ConcatMaps(
+          recFunc.ProjectKeyS(recFunc.Hole, ThetaToEquiJoin.LeftK),
+          recFunc.ProjectKeyS(recFunc.Hole, ThetaToEquiJoin.RightK)))
+    }
+  }
+
+  "simplify a ThetaJoin" in {
+    val exp: Fix[QS] = {
+      import qsdsl._
+      fix.ThetaJoin(
+        fix.Unreferenced,
+        free.Read[ResourcePath](ResourcePath.leaf(rootDir </> file("foo")), ExcludeId),
+        free.Read[ResourcePath](ResourcePath.leaf(rootDir </> file("bar")), ExcludeId),
+        func.And(func.And(
+          // reversed equality
+          func.Eq(
+            func.ProjectKeyS(func.RightSide, "r_id"),
+            func.ProjectKeyS(func.LeftSide, "l_id")),
+          // more complicated expression, duplicated refs
+          func.Eq(
+            func.Add(
+              func.ProjectKeyS(func.LeftSide, "l_min"),
+              func.ProjectKeyS(func.LeftSide, "l_max")),
+            func.Subtract(
+              func.ProjectKeyS(func.RightSide, "l_max"),
+              func.ProjectKeyS(func.RightSide, "l_min")))),
+          // inequality
+          func.Lt(
+            func.ProjectKeyS(func.LeftSide, "l_lat"),
+            func.ProjectKeyS(func.RightSide, "r_lat"))),
+        JoinType.Inner,
+        func.ConcatMaps(func.LeftSide, func.RightSide))
+    }
+
+    simplifyJoinExpr(exp) must equal {
+      import qstdsl._
+      fix.Map(
+        fix.Filter(
+          fix.EquiJoin(
+            fix.Unreferenced,
+            free.Read[ResourcePath](ResourcePath.leaf(rootDir </> file("foo")), ExcludeId),
+            free.Read[ResourcePath](ResourcePath.leaf(rootDir </> file("bar")), ExcludeId),
+            List(
+              (func.ProjectKeyS(func.Hole, "l_id"),
+                func.ProjectKeyS(func.Hole, "r_id")),
+              (func.Add(
+                func.ProjectKeyS(func.Hole, "l_min"),
+                func.ProjectKeyS(func.Hole, "l_max")),
+                func.Subtract(
+                  func.ProjectKeyS(func.Hole, "l_max"),
+                  func.ProjectKeyS(func.Hole, "l_min")))),
+            JoinType.Inner,
+            func.StaticMapS(
+              ThetaToEquiJoin.LeftK -> func.LeftSide,
+              ThetaToEquiJoin.RightK -> func.RightSide)),
+          recFunc.Lt(
+            recFunc.ProjectKeyS(
+              recFunc.ProjectKeyS(recFunc.Hole, ThetaToEquiJoin.LeftK),
+              "l_lat"),
+            recFunc.ProjectKeyS(
+              recFunc.ProjectKeyS(recFunc.Hole, ThetaToEquiJoin.RightK),
+              "r_lat"))),
+        recFunc.ConcatMaps(
+          recFunc.ProjectKeyS(recFunc.Hole, ThetaToEquiJoin.LeftK),
+          recFunc.ProjectKeyS(recFunc.Hole, ThetaToEquiJoin.RightK)))
+    }
+  }
+}


### PR DESCRIPTION
Depends on #3968 

What's remaining in `coalesceQC` are the rewrites that I'm expecting we'll need, along with the machinery to recurse into `FreeQS`. 

The plan forward (not in this PR) is threefold:
1) We can rewrite what is current `Coalesce` to act directly on `QScriptEducated`. This will remove the many lines of boilerplate machinery and make it easier to work within.
2) `Normalizable` is currently _also_ recursing into `FreeQS`, applying the entire `Rewrite` as well as `MapFunc` normalization (as well as possibly other rabbit hole atrocities). We need to centralize this recursion, and split out the `MapFunc` normalizations from the `Coalesce` normalizations. I think we'll be able to apply the `MapFunc` normalizations as a separate pass after we've coalesced nodes. Imagine two separate `PhaseResult` for these two steps!
3) We are calling `Normalizable` directly twice (for no reason) and calling both `Normalizable` and `Coalesce` who knows how many times via `repeatedly`. There _may_ (but may not) still be a use case for `repeatedly`, but we will stop calling it arbitrarily.