### PR TITLE
Allow plugin files to be specified in repl

### DIFF
--- a/impl/src/main/scala/quasar/impl/external/ExternalConfig.scala
+++ b/impl/src/main/scala/quasar/impl/external/ExternalConfig.scala
@@ -21,8 +21,9 @@ import slamdata.Predef._
 import java.nio.file.{Files, Path}
 
 import cats.effect.Sync
+import cats.syntax.applicativeError._
 import scalaz.std.list._
-import scalaz.syntax.traverse._
+import scalaz.syntax.all._
 import shims._
 
 sealed trait ExternalConfig extends Product with Serializable
@@ -44,6 +45,23 @@ object ExternalConfig {
     }
 
     entriesF.map(ExternalConfig.ExplodedDirs(_))
+  }
+
+  def sanitize[F[_]: Sync](cfg: ExternalConfig): F[ExternalConfig] = {
+    cfg match {
+      case ExplodedDirs(_) => cfg.pure[F]
+      case PluginDirectory(dir) => cfg.pure[F]
+      case PluginFiles(files) =>
+        for {
+          fileErrs <- files.traverse(path => Sync[F].delay(path).attempt)
+
+          validPaths = fileErrs.flatMap(_.right.toSeq)    // ignore the errors
+
+          tested <- validPaths traverse { path =>
+            Sync[F].delay(List(path).filter(_ => path.toFile.exists()))
+          }
+        } yield ExternalConfig.PluginFiles(tested.join)
+    }
   }
 
   /**

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -126,6 +126,7 @@ object Dependencies {
 
   def repl = Seq(
     "com.github.tototoshi" %% "scala-csv" % "1.3.4",
+    "com.github.xuwei-k" %% "optparse-applicative" % "0.8.0",
     "org.jline" % "jline" % "3.8.0"
   )
 

--- a/repl/src/main/scala/quasar/repl/Main.scala
+++ b/repl/src/main/scala/quasar/repl/Main.scala
@@ -119,7 +119,7 @@ object Main extends IOApp {
         } yield qs
       case Failure(f) =>
         val (s, exitCode) = renderFailure(f, "repl")
-        IO.delay(println(s)) >> ExitCode(exitCode.toInt).pure[IO]
+        IO.delay(println(s)).as(ExitCode(exitCode.toInt))
     }
 
   }

--- a/repl/src/main/scala/quasar/repl/Paths.scala
+++ b/repl/src/main/scala/quasar/repl/Paths.scala
@@ -38,6 +38,9 @@ object Paths {
       : F[JPath] =
     F.delay(JFiles.createTempFile(prefix, suffix))
 
+  def fromString[F[_]](s: String)(implicit F: Sync[F]): F[JPath] =
+    F.delay(Try(getPath(NonEmptyList(s)))).flatMap(F.fromTry)
+
   def getBasePath[F[_]](implicit F: Sync[F]): F[JPath] =
     getUserHome.map(h => h.map(_.resolve(getPath(QuasarDirNames)))
       .getOrElse(getPath(TmpQuasarReplDirNames)))

--- a/repl/src/main/scala/quasar/repl/Paths.scala
+++ b/repl/src/main/scala/quasar/repl/Paths.scala
@@ -54,6 +54,10 @@ object Paths {
   def mkdirs[F[_]](p: JPath)(implicit F: Sync[F]): F[Boolean] =
     F.delay(p.toFile.mkdirs())
 
+  def ensureFile[F[_]](p: JPath)(implicit F: Sync[F]): F[Unit] =
+    F.delay(p.toFile.isFile())
+      .flatMap(_.unlessM(F.raiseError(new java.lang.RuntimeException(s"$p is not an existing file"))))
+
   ////
 
   private def getPath(names: NonEmptyList[String]): JPath =

--- a/repl/src/main/scala/quasar/repl/Paths.scala
+++ b/repl/src/main/scala/quasar/repl/Paths.scala
@@ -39,7 +39,7 @@ object Paths {
     F.delay(JFiles.createTempFile(prefix, suffix))
 
   def fromString[F[_]](s: String)(implicit F: Sync[F]): F[JPath] =
-    F.delay(Try(getPath(NonEmptyList(s)))).flatMap(F.fromTry)
+    F.delay(getPath(NonEmptyList(s)))
 
   def getBasePath[F[_]](implicit F: Sync[F]): F[JPath] =
     getUserHome.map(h => h.map(_.resolve(getPath(QuasarDirNames)))


### PR DESCRIPTION
With this you can start with plugins without any extracting into `~/.config/quasar/plugin`.
Just assemble the plugins with `datasourceAssemblePlugin`.

Example `repl/run` invocation from `sbt`:

`repl/run -P path-to/quasar-datasource-s3/datasource/target/scala-2.12/plugin-build/s3.plugin -P path-to/quasar-datasource-azure/datasource/target/scala-2.12/plugin-build/azure.plugin`