### PR TITLE
Moar build cleanup

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,4 +31,4 @@ build_script:
   - cmd: .\sbt ++"2.12.7" test:compile
 
 test_script:
-  - cmd: '.\sbt ++"2.12.7" "testOnly -- xonly" "exclusive:testOnly -- xonly"'
+  - cmd: '.\sbt ++"2.12.7" "testOnly -- xonly"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,7 @@ script:
     ./sbt -DisIsolatedEnv=${ISOLATED_ENV:=false} ++$TRAVIS_SCALA_VERSION \
       checkHeaders \
       test:compile \
-      "testOnly -- failtrace" \
-      "exclusive:testOnly -- failtrace"
+      "testOnly -- failtrace"
 
   - |-
     if [ $TRAVIS_PULL_REQUEST == "false" ] && [[ "$TRAVIS_BRANCH" =~ backport/v.*|master ]]; then

--- a/build.sbt
+++ b/build.sbt
@@ -70,9 +70,6 @@ lazy val publishSettings = Seq(
 // Build and publish a project, excluding its tests.
 lazy val commonSettings = buildSettings ++ publishSettings
 
-lazy val isCIBuild = settingKey[Boolean]("True when building in any automated environment (e.g. Travis)")
-lazy val isIsolatedEnv = settingKey[Boolean]("True if running in an isolated environment")
-
 lazy val root = project.in(file("."))
   .settings(commonSettings)
   .settings(noPublishSettings)
@@ -100,10 +97,8 @@ lazy val foundation = project
   .settings(name := "quasar-foundation-internal")
   .settings(commonSettings)
   .settings(
-    buildInfoKeys := Seq[BuildInfoKey](version, isCIBuild, isIsolatedEnv),
+    buildInfoKeys := Seq[BuildInfoKey](version),
     buildInfoPackage := "quasar.build",
-    isCIBuild := isTravisBuild.value,
-    isIsolatedEnv := java.lang.Boolean.parseBoolean(java.lang.System.getProperty("isIsolatedEnv")),
     libraryDependencies ++= Dependencies.foundation)
   .enablePlugins(AutomateHeaderPlugin, BuildInfoPlugin)
 

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,6 @@ lazy val buildSettings = Seq(
 
   // NB: -Xlint triggers issues that need to be fixed
   scalacOptions --= Seq("-Xlint"),
-  scalacOptions --= Seq("-Ybackend:GenBCode"),
 
   // NB: Some warts are disabled in specific projects. Here’s why:
   //   • AsInstanceOf   – wartremover/wartremover#266

--- a/build.sbt
+++ b/build.sbt
@@ -71,17 +71,12 @@ lazy val publishSettings = Seq(
 // Build and publish a project, excluding its tests.
 lazy val commonSettings = buildSettings ++ publishSettings
 
-// not doing this causes NoSuchMethodErrors when using coursier
-lazy val excludeTypelevelScalaLibrary =
-  Seq(excludeDependencies += "org.typelevel" % "scala-library")
-
 lazy val isCIBuild = settingKey[Boolean]("True when building in any automated environment (e.g. Travis)")
 lazy val isIsolatedEnv = settingKey[Boolean]("True if running in an isolated environment")
 
 lazy val root = project.in(file("."))
   .settings(commonSettings)
   .settings(noPublishSettings)
-  .settings(excludeTypelevelScalaLibrary)
   .aggregate(
     api,
     blueeyes,
@@ -111,7 +106,6 @@ lazy val foundation = project
     isCIBuild := isTravisBuild.value,
     isIsolatedEnv := java.lang.Boolean.parseBoolean(java.lang.System.getProperty("isIsolatedEnv")),
     libraryDependencies ++= Dependencies.foundation)
-  .settings(excludeTypelevelScalaLibrary)
   .enablePlugins(AutomateHeaderPlugin, BuildInfoPlugin)
 
 /** Types and interfaces describing Quasar's functionality. */
@@ -120,7 +114,6 @@ lazy val api = project
   .dependsOn(foundation % BothScopes)
   .settings(libraryDependencies ++= Dependencies.api)
   .settings(commonSettings)
-  .settings(excludeTypelevelScalaLibrary)
   .enablePlugins(AutomateHeaderPlugin)
 
 /** A fixed-point implementation of the EJson spec. This should probably become
@@ -131,7 +124,6 @@ lazy val ejson = project
   .dependsOn(foundation % BothScopes)
   .settings(libraryDependencies ++= Dependencies.ejson)
   .settings(commonSettings)
-  .settings(excludeTypelevelScalaLibrary)
   .enablePlugins(AutomateHeaderPlugin)
 
 /** Quasar components shared by both frontend and connector. This includes
@@ -144,7 +136,6 @@ lazy val common = project
     ejson)
   .settings(libraryDependencies ++= Dependencies.common)
   .settings(commonSettings)
-  .settings(excludeTypelevelScalaLibrary)
   .enablePlugins(AutomateHeaderPlugin)
 
 /** Types and operations needed by query language implementations.
@@ -157,21 +148,18 @@ lazy val frontend = project
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Dependencies.frontend)
-  .settings(excludeTypelevelScalaLibrary)
   .enablePlugins(AutomateHeaderPlugin)
 
 lazy val sst = project
   .settings(name := "quasar-sst-internal")
   .dependsOn(frontend % BothScopes)
   .settings(commonSettings)
-  .settings(excludeTypelevelScalaLibrary)
   .enablePlugins(AutomateHeaderPlugin)
 
 lazy val datagen = project
   .settings(name := "quasar-datagen")
   .dependsOn(sst % BothScopes)
   .settings(commonSettings)
-  .settings(excludeTypelevelScalaLibrary)
   .settings(
     mainClass in Compile := Some("quasar.datagen.Main"),
     libraryDependencies ++= Dependencies.datagen)
@@ -183,7 +171,6 @@ lazy val sql = project
   .settings(name := "quasar-sql-internal")
   .dependsOn(common % BothScopes)
   .settings(commonSettings)
-  .settings(excludeTypelevelScalaLibrary)
   .settings(
     libraryDependencies ++= Dependencies.sql)
   .enablePlugins(AutomateHeaderPlugin)
@@ -194,14 +181,12 @@ lazy val qscript = project
     frontend % BothScopes,
     api)
   .settings(commonSettings)
-  .settings(excludeTypelevelScalaLibrary)
   .enablePlugins(AutomateHeaderPlugin)
 
 lazy val qsu = project
   .settings(name := "quasar-qsu-internal")
   .dependsOn(qscript % BothScopes)
   .settings(commonSettings)
-  .settings(excludeTypelevelScalaLibrary)
   .settings(libraryDependencies ++= Dependencies.qsu)
   .settings(scalacOptions ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {
@@ -217,7 +202,6 @@ lazy val connector = project
     foundation % "test->test",
     qscript)
   .settings(commonSettings)
-  .settings(excludeTypelevelScalaLibrary)
   .enablePlugins(AutomateHeaderPlugin)
 
 lazy val core = project
@@ -228,7 +212,6 @@ lazy val core = project
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Dependencies.core)
-  .settings(excludeTypelevelScalaLibrary)
   .enablePlugins(AutomateHeaderPlugin)
 
 /** Implementations of the Quasar API. */
@@ -242,7 +225,6 @@ lazy val impl = project
     sst)
   .settings(commonSettings)
   .settings(libraryDependencies ++= Dependencies.impl)
-  .settings(excludeTypelevelScalaLibrary)
   .enablePlugins(AutomateHeaderPlugin)
 
 lazy val runp = (project in file("run"))
@@ -252,7 +234,6 @@ lazy val runp = (project in file("run"))
     impl,
     qsu)
   .settings(commonSettings)
-  .settings(excludeTypelevelScalaLibrary)
   .enablePlugins(AutomateHeaderPlugin)
 
 /** Integration tests that have some dependency on a running connector.
@@ -266,7 +247,6 @@ lazy val it = project
   .settings(libraryDependencies ++= Dependencies.it)
   .settings(parallelExecution in Test := false)
   .settings(logBuffered in Test := false)
-  .settings(excludeTypelevelScalaLibrary)
   .enablePlugins(AutomateHeaderPlugin)
 
 lazy val blueeyes = project
@@ -279,7 +259,6 @@ lazy val blueeyes = project
   .settings(logBuffered in Test := isTravisBuild.value)
   .settings(headerLicenseSettings)
   .settings(publishSettings)
-  .settings(excludeTypelevelScalaLibrary)
   .enablePlugins(AutomateHeaderPlugin)
 
 lazy val niflheim = project
@@ -291,7 +270,6 @@ lazy val niflheim = project
   .settings(logBuffered in Test := isTravisBuild.value)
   .settings(headerLicenseSettings)
   .settings(publishSettings)
-  .settings(excludeTypelevelScalaLibrary)
   .enablePlugins(AutomateHeaderPlugin)
 
 lazy val yggdrasil = project
@@ -306,7 +284,6 @@ lazy val yggdrasil = project
   .settings(logBuffered in Test := isTravisBuild.value)
   .settings(headerLicenseSettings)
   .settings(publishSettings)
-  .settings(excludeTypelevelScalaLibrary)
   .enablePlugins(AutomateHeaderPlugin)
 
 lazy val yggdrasilPerf = project
@@ -318,7 +295,6 @@ lazy val yggdrasilPerf = project
   .settings(logBuffered in Test := isTravisBuild.value)
   .settings(headerLicenseSettings)
   .settings(noPublishSettings)
-  .settings(excludeTypelevelScalaLibrary)
   .enablePlugins(AutomateHeaderPlugin)
   .enablePlugins(JmhPlugin)
 
@@ -334,5 +310,4 @@ lazy val mimir = project
   .settings(logBuffered in Test := isTravisBuild.value)
   .settings(headerLicenseSettings)
   .settings(publishSettings)
-  .settings(excludeTypelevelScalaLibrary)
   .enablePlugins(AutomateHeaderPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -1,16 +1,11 @@
-import scala.Predef._
 import quasar.project._
 
-import java.lang.{Integer, String, Throwable}
-import scala.{Boolean, List, Predef, None, Some, StringContext, sys, Unit}, Predef.{any2ArrowAssoc, assert, augmentString}
-import scala.collection.Seq
-import scala.collection.immutable.Map
-import scala.sys.process._
-
-import sbt._, Keys._
-import sbt.std.Transform.DummyTaskMap
 import sbt.TestFrameworks.Specs2
-import sbtrelease._, ReleaseStateTransformations._, Utilities._
+
+import java.lang.{Integer, String}
+import scala.{Boolean, Some, StringContext, sys}
+import scala.Predef._
+import scala.collection.Seq
 
 def exclusiveTasks(tasks: Scoped*) =
   tasks.flatMap(inTask(_)(tags := Seq((ExclusiveTest, 1))))

--- a/foundation/src/test/scala/quasar/QuasarSpecification.scala
+++ b/foundation/src/test/scala/quasar/QuasarSpecification.scala
@@ -86,17 +86,3 @@ trait QuasarSpecification extends AnyRef
       if (isIsolatedEnv) AsResult(t) else Skipped(m)
   }
 }
-
-/** Trait that tags all examples in a spec for exclusive execution. Examples
-  * will be executed sequentially and parallel execution will be disabled.
-  *
-  * Use this when you have tests that muck with global state.
-  */
-trait ExclusiveQuasarSpecification extends QuasarSpecification {
-  import org.specs2.specification.core.Fragments
-  import org.specs2.specification.dsl.FragmentsDsl._
-
-  sequential
-  override def map(fs: => Fragments) =
-    section(exclusiveTestTag) ^ super.map(fs) ^ section(exclusiveTestTag)
-}

--- a/foundation/src/test/scala/quasar/QuasarSpecification.scala
+++ b/foundation/src/test/scala/quasar/QuasarSpecification.scala
@@ -16,8 +16,6 @@
 
 package quasar
 
-import quasar.build.BuildInfo._
-
 import java.lang.String
 import scala._
 
@@ -79,10 +77,5 @@ trait QuasarSpecification extends AnyRef
 
     def pendingUntilFixed(m: String): Result =
       outer.toPendingUntilFixed(t).pendingUntilFixed(m)
-
-    def skippedOnUserEnv: Result= skippedOnUserEnv("")
-
-    def skippedOnUserEnv(m: String): Result =
-      if (isIsolatedEnv) AsResult(t) else Skipped(m)
   }
 }

--- a/it/src/test/scala/quasar/regression/Sql2QueryRegressionSpec.scala
+++ b/it/src/test/scala/quasar/regression/Sql2QueryRegressionSpec.scala
@@ -19,7 +19,6 @@ package quasar.regression
 import slamdata.Predef._
 import quasar._
 import quasar.api.datasource._
-import quasar.build.BuildInfo
 import quasar.common.PhaseResults
 import quasar.common.data.Data
 import quasar.concurrent.BlockingContext
@@ -177,8 +176,6 @@ abstract class Sql2QueryRegressionSpec extends Qspec {
     s"${test.name} [${posixCodec.printPath(loc)}]" >> {
       collectFirstDirective(test.backends, backendName) {
         case TestDirective.Skip    => skipped
-        case TestDirective.SkipCI  =>
-          BuildInfo.isCIBuild.fold(execute.Skipped("(skipped during CI build)"), runTest)
         case TestDirective.Pending | TestDirective.PendingIgnoreFieldOrder =>
           runTest.pendingUntilFixed
       } getOrElse runTest

--- a/it/src/test/scala/quasar/regression/TestDirective.scala
+++ b/it/src/test/scala/quasar/regression/TestDirective.scala
@@ -25,7 +25,6 @@ sealed abstract class TestDirective
 
 object TestDirective {
   final case object Skip extends TestDirective
-  final case object SkipCI extends TestDirective
   final case object Pending extends TestDirective
   final case object PendingIgnoreFieldOrder extends TestDirective
   final case object IgnoreAllOrder extends TestDirective
@@ -37,7 +36,6 @@ object TestDirective {
   implicit val TestDirectiveDecodeJson: DecodeJson[TestDirective] =
     DecodeJson(c => c.as[String].flatMap {
       case "skip" => ok(Skip)
-      case "skipCI" => ok(SkipCI)
       case "pending" => ok(Pending)
       case "pendingIgnoreFieldOrder" => ok(PendingIgnoreFieldOrder)
       case "ignoreAllOrder" => ok(IgnoreAllOrder)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,6 @@
 resolvers += Resolver.sonatypeRepo("releases")
 resolvers += Resolver.bintrayRepo("slamdata-inc", "maven-public")
 
-addSbtPlugin("com.eed3si9n"          % "sbt-assembly"      % "0.14.5")
 addSbtPlugin("com.eed3si9n"          % "sbt-buildinfo"     % "0.7.0")
 addSbtPlugin("io.get-coursier"       % "sbt-coursier"      % "1.1.0-M4")
 addSbtPlugin("com.slamdata"          % "sbt-slamdata"      % "1.4.0")


### PR DESCRIPTION
Depends on #3997 

- Don't exclude typelevel scala dep
- Include `-Ybackend:GenBCode`
- Get rid of `isCIBuild` and `isIsolatedEnv` `BuildInfo`
 