### PR TITLE
Use Typecheck instead of Cond when possible

### DIFF
--- a/qsu/src/main/scala/quasar/qsu/minimizers/FilterToCond.scala
+++ b/qsu/src/main/scala/quasar/qsu/minimizers/FilterToCond.scala
@@ -113,7 +113,7 @@ final class FilterToCond[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] priv
 
   ///
 
-  private def rewriteFilter(predicate: FreeMap, consequent: FreeMap): FreeMap = {
+  private def rewriteFilter(predicate: FreeMap, fm: FreeMap): FreeMap = {
     val nameToType: SMap[String, Type] =
       SMap(
         "number" -> Type.Dec,
@@ -127,9 +127,9 @@ final class FilterToCond[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] priv
           Embed(CoEnv(\/-(MFC(TypeOf(Embed(CoEnv(-\/(_)))))))),
           Embed(CoEnv(\/-(MFC(Constant(Embed(CommonEJson(Str(expectedType))))))))))) =>
         nameToType.get(expectedType)
-          .fold(func.Cond(predicate, consequent, func.Undefined))(func.Typecheck(consequent, _))
+          .fold(func.Cond(predicate.as(fm).join, fm, func.Undefined))(func.Typecheck(fm, _))
       case _ =>
-        func.Cond(predicate, consequent, func.Undefined)
+        func.Cond(predicate.as(fm).join, fm, func.Undefined)
     }
   }
 }


### PR DESCRIPTION
This does not close ch 366 since this doesn't introduce filtering `MapFunc`s. It simply uses `Typecheck` instead of `Cond` in `FilterToCond` when possible. To showcase what this does, consider the following query generated by the frontend:

```sql
SELECT c.c1 AS a, c.c2 AS b, c.c3 AS c, c.c4 AS d FROM ( 
  SELECT p5.g7 AS c1, p5.g8  AS c2, p5.g9 AS c3, p5.g10 AS c4 
  FROM (SELECT
       (SELECT * FROM (SELECT ty.previous_addresses[_]{_} FROM `patients.data` AS ty) AS v WHERE type_of(v) = "string") AS g10, 
       (SELECT * FROM (SELECT ty.previous_addresses[_].city FROM   `patients.data` AS ty) AS v WHERE  type_of(v) = "string") AS g7, 
       (SELECT * FROM (SELECT ty.previous_addresses[_].state FROM   `patients.data` AS ty) AS v WHERE  type_of(v) = "string") AS g8, 
       (SELECT * FROM (SELECT ty.last_visit FROM   `patients.data` AS ty) AS v WHERE  type_of(v) = "string") AS g9 FROM  `patients.data` AS r6) AS p5) AS c
```

[QScript after this patch](https://gist.github.com/jsantos17/69fe7659edea36445a05b6fa3f5630f6).
[QScript before this patch](https://gist.github.com/jsantos17/3b941f5c3001beed4f8ce6be22d2847d)

Work on the filtering `MapFunc`s (and related frontend changes) are still on the pipeline.