### PR TITLE
Fix handling of DimEdit in ApplyProvenance to account for branching

### DIFF
--- a/qsu/src/main/scala/quasar/qsu/QAuth.scala
+++ b/qsu/src/main/scala/quasar/qsu/QAuth.scala
@@ -72,21 +72,6 @@ final case class QAuth[T[_[_]]](
       InternalError(s"GroupKey[$idx] for $vertex not found.", None)
     }
 
-  /** Supplants `target` with `replacement`, removing the former and replacing
-    * any references to it with the latter.
-    */
-  def supplant
-      (target: Symbol, replacement: Symbol)
-      (implicit T0: BirecursiveT[T], T1: EqualT[T])
-      : QAuth[T] = {
-
-    val qp = QProv[T]
-    val supDims = (dims - target).mapValues(qp.rename(target, replacement, _))
-    val supKeys = groupKeys filterKeys { case (s, _) => s =/= target }
-
-    QAuth(supDims, supKeys)
-  }
-
   def renameRefs
       (target: Symbol, replacement: Symbol)
       (implicit T0: BirecursiveT[T], T1: EqualT[T])

--- a/qsu/src/test/scala/quasar/qsu/ApplyProvenanceSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/ApplyProvenanceSpec.scala
@@ -118,6 +118,13 @@ object ApplyProvenanceSpec extends Qspec with QSUTTypes[Fix] {
           P.value(IdAccess.identity('n2)),
           P.value(IdAccess.groupKey('n2, 1)),
           P.value(IdAccess.groupKey('n2, 0)),
+          P.prjPath(J.str("foobar"))),
+        'n1 -> Dimensions.origin(
+          P.value(IdAccess.identity('n1)),
+          P.value(IdAccess.groupKey('n1, 0)),
+          P.prjPath(J.str("foobar"))),
+        'n0 -> Dimensions.origin(
+          P.value(IdAccess.identity('n0)),
           P.prjPath(J.str("foobar")))
       ))
     }
@@ -137,6 +144,9 @@ object ApplyProvenanceSpec extends Qspec with QSUTTypes[Fix] {
           P.thenn(
             P.value(IdAccess.identity('n2)),
             P.prjPath(J.str("foobar")))),
+        'n1 -> Dimensions.origin(
+          P.value(IdAccess.identity('n2)),
+          P.prjPath(J.str("foobar"))),
         'n2 -> Dimensions.origin(
           P.value(IdAccess.identity('n2)),
           P.prjPath(J.str("foobar")))
@@ -519,8 +529,9 @@ object ApplyProvenanceSpec extends Qspec with QSUTTypes[Fix] {
           result(
             qauth.dims ≟ expectedDims,
             s"received expected authenticated QSU:\n${aqsu.shows}",
-            s"received unexpected authenticated QSU:\n${aqsu.shows}\n" +
-            s"expected:\n[\n${printMultiline(expected.toList)}\n]",
+            s"received unexpected dims:\n${printMultiline(qauth.dims.toList)}\n" + // `aqsu.shows` prunes orphan dims
+            s"wth graph:\n${resultGraph.shows}\n" +
+            s"expected:\n[\n${printMultiline(expectedDims.toList)}\n]",
             s)
         }).merge
       }


### PR DESCRIPTION
[ch2068]
[ch3691]
[ch3999]
[ch3553]
[ch672]

When rewriting a qsu graph with `rewriteM`, we begin at the `Read` (the parent) and then recurse into its children. If a node has multiple immediate children and one of those children is a `DimEdit`, in `ApplyProvenance` we rename the parent to have the name of the `DimEdit`. The bug was that we'd then delete the parent's dimensions since the parent had become orphaned (by its old name). This was a problem because when we'd recurse into the _other_ branch, we'd lookup the dimensions of the parent and find they were not there. This produced the `"Dependent dimensions not found"` error.