### PR TITLE
Fixed collapsing compatible shifts below the top tier

### DIFF
--- a/qsu/src/main/scala/quasar/qsu/QScriptUniform.scala
+++ b/qsu/src/main/scala/quasar/qsu/QScriptUniform.scala
@@ -132,12 +132,11 @@ object QScriptUniform {
     }
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
   implicit def show[T[_[_]]: ShowT]: Delay[Show, QScriptUniform[T, ?]] =
     new Delay[Show, QScriptUniform[T, ?]] {
       def apply[A](a: Show[A]) = {
         implicit val showA = a
-        Show.shows {
+        Show shows {
           case AutoJoin2(left, right, combiner) =>
             s"AutoJoin2(${left.shows}, ${right.shows}, ${combiner.shows})"
 

--- a/qsu/src/main/scala/quasar/qsu/minimizers/CollapseShifts.scala
+++ b/qsu/src/main/scala/quasar/qsu/minimizers/CollapseShifts.scala
@@ -438,13 +438,17 @@ final class CollapseShifts[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] pr
           if compatibleShifts(lshift, rshift) =>
 
           val idStatusAdj = idStatusL |+| idStatusR
-          val repairLAdj = fixCompatible(repairL, idStatusL, idStatusAdj)
-          val repairRAdj = fixCompatible(repairR, idStatusR, idStatusAdj)
 
-          val repair =
+          val repair = if (repairL === repairR && idStatusL === idStatusR) {
+            repairL
+          } else {
+            val repairLAdj = fixCompatible(repairL, idStatusL, idStatusAdj)
+            val repairRAdj = fixCompatible(repairR, idStatusR, idStatusAdj)
+
             func.StaticMapS(
               LeftField -> repairLAdj,
               RightField -> repairRAdj)
+          }
 
           continue(fakeParent, tailL, tailR) { sym =>
             QSU.LeftShift[T, Symbol](
@@ -725,9 +729,7 @@ final class CollapseShifts[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] pr
     def compatibleShifts(l: ShiftGraph, r: ShiftGraph): Boolean = {
       (l, r) match {
         case (-\/(QSU.LeftShift(srcL, structL, _, _, _, rotL)), -\/(QSU.LeftShift(srcR, structR, _, _, _, rotR))) =>
-          srcL.root === srcR.root &&
-            elideGuards(structL.linearize) === elideGuards(structR.linearize) &&
-            rotL === rotR
+          elideGuards(structL.linearize) === elideGuards(structR.linearize) && rotL === rotR
 
         case _ => false
       }

--- a/run/src/test/scala/quasar/QScriptRegressionSpec.scala
+++ b/run/src/test/scala/quasar/QScriptRegressionSpec.scala
@@ -214,7 +214,17 @@ object QScriptRegressionSpec extends Qspec {
 
         result must countReadAs(0)
         result must countInterpretedReadAs(1)
-        result must countLeftShiftAs(2)
+        result must countLeftShiftAs(0)
+      }
+
+      // ch4703
+      val q5 = "select a[*][*], a[*][*].b[*] from zips"
+      q5 in {
+        val result = count(q5)
+
+        result must countReadAs(0)
+        result must countInterpretedReadAs(1)
+        result must countLeftShiftAs(1)
       }
     }
 


### PR DESCRIPTION
Also note the extra change to the `QScriptRegressionSpec`: even before @wemrysi's rewrite lands, there are several queries which we can now push into tectonic which we previously could not.

[ch4703]