### PR TITLE
Better identify compatible shifts

### DIFF
--- a/qsu/src/main/scala/quasar/qsu/minimizers/CollapseShifts.scala
+++ b/qsu/src/main/scala/quasar/qsu/minimizers/CollapseShifts.scala
@@ -460,12 +460,12 @@ final class CollapseShifts[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] pr
 
           val idStatusAdj = idStatusL |+| idStatusR
 
-          val repair = if (repairL === repairR && idStatusL === idStatusR) {
-            repairL
-          } else {
-            val repairLAdj = fixCompatible(repairL, idStatusL, idStatusAdj)
-            val repairRAdj = fixCompatible(repairR, idStatusR, idStatusAdj)
+          val repairLAdj = fixCompatible(repairL, idStatusL, idStatusAdj)
+          val repairRAdj = fixCompatible(repairR, idStatusR, idStatusAdj)
 
+          val repair = if (repairLAdj === repairRAdj) {
+            repairLAdj
+          } else {
             func.StaticMapS(
               LeftField -> repairLAdj,
               RightField -> repairRAdj)

--- a/qsu/src/main/scala/quasar/qsu/minimizers/CollapseShifts.scala
+++ b/qsu/src/main/scala/quasar/qsu/minimizers/CollapseShifts.scala
@@ -475,7 +475,18 @@ final class CollapseShifts[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] pr
               else
                 hole
           }
-          case _ => repair
+
+          case _ => repair flatMap {
+            case access @ ShiftTarget.AccessLeftTarget(_) =>
+              val hole = Free.pure[MapFunc, ShiftTarget](access)
+
+              if (hasParent && requiresDeref)
+                func.ProjectKeyS(hole, name(side))
+              else
+                hole
+
+            case target => target.point[FreeMapA]
+          }
         }
 
       (left, right) match {

--- a/qsu/src/test/scala/quasar/qsu/MinimizeAutoJoinsSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/MinimizeAutoJoinsSpec.scala
@@ -50,7 +50,7 @@ import scalaz.{\/, \/-, EitherT, Free, Need, StateT}
 import scalaz.std.anyVal._
 import scalaz.syntax.applicative._
 import scalaz.syntax.either._
-// import scalaz.syntax.show._
+import scalaz.syntax.show._
 import scalaz.syntax.std.boolean._
 import scalaz.syntax.tag._
 
@@ -1859,7 +1859,13 @@ object MinimizeAutoJoinsSpec
           asese,
           func.ConcatMaps(func.LeftSide, func.RightSide))))
 
-      runOn(qgraph) must haveShiftCount(2)
+      println(s"input: ${qgraph.shows}")
+
+      val results = runOn(qgraph)
+
+      println(s"output: ${results.shows}")
+
+      results must haveShiftCount(2)
     }
   }
 

--- a/qsu/src/test/scala/quasar/qsu/MinimizeAutoJoinsSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/MinimizeAutoJoinsSpec.scala
@@ -50,7 +50,7 @@ import scalaz.{\/, \/-, EitherT, Free, Need, StateT}
 import scalaz.std.anyVal._
 import scalaz.syntax.applicative._
 import scalaz.syntax.either._
-import scalaz.syntax.show._
+// import scalaz.syntax.show._
 import scalaz.syntax.std.boolean._
 import scalaz.syntax.tag._
 
@@ -1859,13 +1859,7 @@ object MinimizeAutoJoinsSpec
           asese,
           func.ConcatMaps(func.LeftSide, func.RightSide))))
 
-      println(s"input: ${qgraph.shows}")
-
-      val results = runOn(qgraph)
-
-      println(s"output: ${results.shows}")
-
-      results must haveShiftCount(2)
+      runOn(qgraph) must haveShiftCount(2)
     }
   }
 

--- a/qsu/src/test/scala/quasar/qsu/MinimizeAutoJoinsSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/MinimizeAutoJoinsSpec.scala
@@ -1859,7 +1859,47 @@ object MinimizeAutoJoinsSpec
           asese,
           func.ConcatMaps(func.LeftSide, func.RightSide))))
 
-      runOn(qgraph) must haveShiftCount(2)
+      val results = runOn(qgraph)
+      results must haveShiftCount(2)
+
+      results must beLike {
+        case Map(
+          LeftShift(
+            LeftShift(
+              Read(`afile`, ExcludeId),
+              _,
+              _,
+              _,
+              repairInner,
+              _),
+            _,
+            _,
+            _,
+            repair,
+            _),
+          _) =>
+
+        repairInner must beTreeEqual(
+          func.StaticMapS(
+            "left" ->
+              func.StaticMapS(
+                "left" -> func.MakeMapS("0", func.ProjectIndexI(RightTarget[Fix], 0)),
+                "right" -> func.ProjectIndexI(RightTarget[Fix], 1)),
+            "right" -> func.ProjectIndexI(RightTarget[Fix], 1)))
+
+        repair must beTreeEqual(
+          func.ConcatMaps(
+            func.ConcatMaps(
+              func.ProjectKeyS(
+                func.ProjectKeyS(AccessLeftTarget[Fix](Access.value(_)), "left"),
+                "left"),
+              func.MakeMapS(
+                "1",
+                func.ProjectIndexI(RightTarget[Fix], 0))),
+            func.MakeMapS(
+              "2",
+              func.ProjectIndexI(RightTarget[Fix], 1))))
+      }
     }
 
     // a{_:}, a{_}{_:}, a{_}{_}

--- a/run/src/test/scala/quasar/QScriptRegressionSpec.scala
+++ b/run/src/test/scala/quasar/QScriptRegressionSpec.scala
@@ -226,6 +226,16 @@ object QScriptRegressionSpec extends Qspec {
         result must countInterpretedReadAs(1)
         result must countLeftShiftAs(1)
       }
+
+      // ch4758
+      val q6 = "select topObj{_:} as k1, topObj{_}{_:} as k2, topObj{_}{_} as v2 from `nested.data`"
+      q6 in {
+        val result = count(q6)
+
+        result must countReadAs(0)
+        result must countInterpretedReadAs(1)
+        result must countLeftShiftAs(1)
+      }
     }
 
     "handle real-world queries" >> {


### PR DESCRIPTION
The two conceptual changes here are:

- Use provenance's structural normalization and compare for compatibility based on `struct >> parent.repair` whenever relevant, rather than just using `struct`
- Account for the structural differences introduced by `IncludeIds` versus `IdOnly`/`ExcludeId` by "faking" a projection in the provenance prior to comparison

Note that both of these adjustments were only applied to `LeftShift`, ignoring `MultiLeftShift` altogether. This is true both for the collapse of zipping `LeftShift`s *and* when those shifts are direct descendants of a `MultiLeftShift`. These fixes are, at least theoretically, compatible with the `MultiLeftShift` structure, but in the interests of time we're ignoring that. Basically, once you get into `Multi`-land, you're hosed.

[ch4758]