### PR TITLE
Remove join-condition related side effects

### DIFF
--- a/qsu/src/main/scala/quasar/qsu/ExpandShifts.scala
+++ b/qsu/src/main/scala/quasar/qsu/ExpandShifts.scala
@@ -22,7 +22,6 @@ import quasar.IdStatus
 import quasar.common.effect.NameGenerator
 import quasar.contrib.scalaz._
 import quasar.ejson.{EJson, Fixed}
-import quasar.fp.ski.κ
 import quasar.qscript.{
   MonadPlannerErr,
   OnUndefined,
@@ -117,16 +116,7 @@ final class ExpandShifts[T[_[_]]: BirecursiveT: EqualT: ShowT] extends QSUTTypes
       QSU.LeftShift[T, Symbol](
         src.root, struct.asRec, status, OnUndefined.Emit, RightTarget, rotation)
 
-    def dimsOf(sym: Symbol): G[QDims] =
-      MonadState_[G, QAuth].get >>= (_.lookupDimsE[G](sym))
-
     for {
-      commonSrcDims <- dimsOf(commonRoot)
-
-      structDim =
-        ApplyProvenance.computeFuncDims(struct)(κ(commonSrcDims))
-          .getOrElse(commonSrcDims)
-
       tempShift <- QSUGraph.withName[T, G](NamePrefix)(tempShiftPat)
       commonShift = tempShift.overwriteAtRoot(tempShiftPat.copy(source = commonRoot))
 


### PR DESCRIPTION
Not sure if we still need the `MonadCI` constraint since we no longer call `get` on it anywhere. Shall I remove that too?