### PR TITLE
Use the correct parent for determining struct provenance

### DIFF
--- a/qsu/src/main/scala/quasar/qsu/minimizers/CollapseShifts.scala
+++ b/qsu/src/main/scala/quasar/qsu/minimizers/CollapseShifts.scala
@@ -356,9 +356,6 @@ final class CollapseShifts[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] pr
 
         val realParent = parent.getOrElse(fakeParent)
         val cont = updateGraph[T, G](pat(realParent.root)) map { rewritten =>
-          // println("")
-          // println(s">>> continuing with ${pat(realParent.root).shows}")
-          // println("")
           Some(rewritten :++ realParent)
         }
 
@@ -503,7 +500,7 @@ final class CollapseShifts[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] pr
             (
               (lshift @ ShiftGraph.Single(QSU.LeftShift(fakeParent, structL, idStatusL, onUndefinedL, repairL, rotL), dimsL)) :: tailL,
               (rshift @ ShiftGraph.Single(QSU.LeftShift(_, _, idStatusR, onUndefinedR, repairR, rotR), dimsR)) :: tailR)
-            if {/*println(s"dimsL = $dimsL, dimsR = $dimsR; === = ${dimsL === dimsR}");*/ dimsL === dimsR && rotL === rotR } =>
+            if dimsL === dimsR && rotL === rotR =>
 
           val idStatusAdj = idStatusL |+| idStatusR
 
@@ -804,11 +801,6 @@ final class CollapseShifts[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] pr
     def coalesceWrapped(wrapped: List[(QSUGraph, Set[Int])]): G[(QSUGraph, Set[Int])] = {
       wrapped.tail.foldLeftM[G, (QSUGraph, Set[Int])](wrapped.head) {
         case ((graphL @ ConsecutiveBounded(_, shifts1), leftIndices), (graphR @ ConsecutiveBounded(_, shifts2), rightIndices)) =>
-          // println(s"coalesceWrapping:")
-          // println(graphL.shows)
-          // println(graphR.shows)
-          // println("")
-
           val back = coalesceZip(shifts1.toList.reverse, leftIndices, shifts2.toList.reverse, rightIndices, None, false)
 
           back.map(g => (inlineMap(g).getOrElse(g), leftIndices ++ rightIndices))
@@ -836,12 +828,8 @@ final class CollapseShifts[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] pr
 
     @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
     def coalesceTier(tier: ShiftAssoc): G[(QSUGraph, Set[Int])] = tier match {
-      case ShiftAssoc.Leaves(shifts) => {
-        // println(s"single tier ${shifts.shows}")
-        // println("")
-
+      case ShiftAssoc.Leaves(shifts) =>
         coalesceWrapped(shifts)
-      }
 
       case ShiftAssoc.Branches(shifts) =>
         shifts.traverse(coalesceTier).flatMap(coalesceWrapped)
@@ -932,8 +920,6 @@ final class CollapseShifts[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] pr
           repair,
           rot) =>
 
-        // println(s"!!! inners! ${inners.shows}")
-
         val struct2 = struct >> fm.asRec
 
         val from = inners.head match {
@@ -1014,10 +1000,6 @@ final class CollapseShifts[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] pr
             case other => other.point[FreeMapA]
           }
         } getOrElse repair
-
-        // println(s"from = $from")
-        // println(s"struct = ${struct.shows}")
-        // println(s"repair2 = ${repair2.shows}")
 
         ApplyProvenance.computeFuncDims(struct >> repair2)(κ(from)).getOrElse(from)
 

--- a/qsu/src/test/scala/quasar/qsu/MinimizeAutoJoinsSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/MinimizeAutoJoinsSpec.scala
@@ -50,7 +50,7 @@ import scalaz.{\/, \/-, EitherT, Free, Need, StateT}
 import scalaz.std.anyVal._
 import scalaz.syntax.applicative._
 import scalaz.syntax.either._
-import scalaz.syntax.show._
+// import scalaz.syntax.show._
 import scalaz.syntax.std.boolean._
 import scalaz.syntax.tag._
 
@@ -916,9 +916,9 @@ object MinimizeAutoJoinsSpec
             recFunc.ProjectKeyS(recFunc.Hole, "results"))
 
           repairInner must beTreeEqual(
-            func.ConcatMaps(
-              AccessLeftTarget[Fix](Access.value(_)),
-              func.MakeMapS("results", RightTarget[Fix])))
+            func.StaticMapS(
+              "original" -> func.ProjectKeyS(AccessLeftTarget[Fix](Access.value(_)), "original"),
+              "results" -> RightTarget[Fix]))
 
           structOuter must beTreeEqual(recFunc.ProjectKeyS(recFunc.Hole, "results"))
 
@@ -1117,10 +1117,11 @@ object MinimizeAutoJoinsSpec
         outerdstruct must beTreeEqual(func.ProjectKeyS(func.ProjectKeyS(func.Hole, "results"), "right"))
 
         outerMultiRepair must beTreeEqual(
-          func.ConcatMaps(
-            AccessHole[Fix].map(_.left[Int]),
-            func.MakeMapS(
-              "results",
+          func.StaticMapS(
+            "original" ->
+              func.ProjectKeyS(AccessHole[Fix].map(_.left[Int]), "original"),
+
+            "results" ->
               func.StaticMapS(
                 "left" -> func.ConcatMaps(
                   func.MakeMapS(
@@ -1133,7 +1134,7 @@ object MinimizeAutoJoinsSpec
                         "results"),
                       "left"),
                     "right")),
-                "right" -> Free.pure[MapFunc, Access[Hole] \/ Int](1.right)))))
+                "right" -> Free.pure[MapFunc, Access[Hole] \/ Int](1.right))))
 
         singleRepair must beTreeEqual(
           func.ConcatMaps(
@@ -2202,8 +2203,8 @@ object MinimizeAutoJoinsSpec
           Map(
             LeftShift(
               LeftShift(
-                MultiLeftShift(
-                  MultiLeftShift(
+                LeftShift(
+                  LeftShift(
                     LeftShift(
                       LeftShift(
                         Read(`afile`, ExcludeId),
@@ -2219,7 +2220,11 @@ object MinimizeAutoJoinsSpec
                       _),
                     _,
                     _,
+                    _,
+                    _,
                     _),
+                  _,
+                  _,
                   _,
                   _,
                   _),
@@ -2309,10 +2314,7 @@ object MinimizeAutoJoinsSpec
             func.LeftSide,
             func.MakeMapS("3", func.RightSide)))))
 
-      val results = runOn(qgraph)
-      println(results.shows)
-
-      results must haveShiftCount(4)
+      runOn(qgraph) must haveShiftCount(4)
     }
   }
 


### PR DESCRIPTION
It's kind of distressing that we didn't identify this bug before.

[ch5156]
[ch5152]