### PR TITLE
Simplify parse instructions

### DIFF
--- a/frontend/src/main/scala/quasar/ParseInstruction.scala
+++ b/frontend/src/main/scala/quasar/ParseInstruction.scala
@@ -35,13 +35,6 @@ sealed trait FocusedParseInstruction extends ParseInstruction
 object ParseInstruction {
 
   /**
-   * Generates one unique identity per row. Creates a top-level array with
-   * the identities in the first component, the original values in the second.
-   * Just like `Pivot` with `IdStatus.IncludeId`.
-   */
-  case object Ids extends FocusedParseInstruction
-
-  /**
    * Wraps the provided `path` into an object with key `name`, thus adding
    * another layer of structure. All other paths are retained.
    */
@@ -55,13 +48,11 @@ object ParseInstruction {
   final case class Mask(masks: Map[CPath, Set[ParseType]]) extends FocusedParseInstruction
 
   /**
-   * Pivots the indices and keys out of arrays and objects, respectively,
-   * according to the provided structure, performing a full cross of all pivoted
-   * values.
+   * Pivots the indices and keys out of arrays and objects, respectively.
    *
-   * `idStatus` determines how the values is returned:
-   *   - `IncludeId` wraps the key/value pair in a two element array.
-   *   - `IdOnly` returns the value unwrapped.
+   * `idStatus` determines how values are returned:
+   *   - `IncludeId` wraps the id/value pair in a two element array.
+   *   - `IdOnly` returns the id unwrapped.
    *   - `ExcludeId` returns the value unwrapped.
    *
    * No values outside of the pivot locus should be retained.
@@ -86,7 +77,6 @@ object ParseInstruction {
 
   implicit val focusedParseInstructionEqual: Equal[FocusedParseInstruction] =
     Equal.equal {
-      case (Ids, Ids) => true
       case (Wrap(p1, n1), Wrap(p2, n2)) => p1 === p2 && n1 === n2
       case (Mask(m1), Mask(m2)) => m1 === m2
       case (Pivot(p1, s1, t1), Pivot(p2, s2, t2)) => p1 === p2 && s1 === s2 && t1 === t2
@@ -104,7 +94,6 @@ object ParseInstruction {
 
   implicit val focusedParseInstructionShow: Show[FocusedParseInstruction] =
     Show.show {
-      case Ids => Cord("Ids")
       case Wrap(p, n) => Cord("Wrap(") ++ p.show ++ Cord(", ") ++ n.show ++ Cord(")")
       case Mask(m) => Cord("Mask(") ++ m.show ++ Cord(")")
       case Pivot(p, s, t) =>

--- a/frontend/src/main/scala/quasar/ParseInstruction.scala
+++ b/frontend/src/main/scala/quasar/ParseInstruction.scala
@@ -57,7 +57,7 @@ object ParseInstruction {
    *
    * No values outside of the pivot locus should be retained.
    */
-  final case class Pivot(path: CPath, status: IdStatus, structure: CompositeParseType)
+  final case class Pivot(status: IdStatus, structure: CompositeParseType)
       extends FocusedParseInstruction
 
   /**
@@ -79,7 +79,7 @@ object ParseInstruction {
     Equal.equal {
       case (Wrap(p1, n1), Wrap(p2, n2)) => p1 === p2 && n1 === n2
       case (Mask(m1), Mask(m2)) => m1 === m2
-      case (Pivot(p1, s1, t1), Pivot(p2, s2, t2)) => p1 === p2 && s1 === s2 && t1 === t2
+      case (Pivot(s1, t1), Pivot(s2, t2)) => s1 === s2 && t1 === t2
       case (Project(p1), Project(p2)) => p1 === p2
       case (_, _) => false
     }
@@ -96,8 +96,7 @@ object ParseInstruction {
     Show.show {
       case Wrap(p, n) => Cord("Wrap(") ++ p.show ++ Cord(", ") ++ n.show ++ Cord(")")
       case Mask(m) => Cord("Mask(") ++ m.show ++ Cord(")")
-      case Pivot(p, s, t) =>
-        Cord("Pivot(") ++ p.show ++ Cord(", ") ++ s.show ++ Cord(", ") ++ t.show  ++ Cord(")")
+      case Pivot(s, t) => Cord("Pivot(") ++ s.show ++ Cord(", ") ++ t.show  ++ Cord(")")
       case Project(p) => Cord("Project(") ++ p.show ++ Cord(")")
     }
 

--- a/frontend/src/test/scala/quasar/ParseInstructionSpec.scala
+++ b/frontend/src/test/scala/quasar/ParseInstructionSpec.scala
@@ -880,7 +880,7 @@ object ParseInstructionSpec {
     protected final val Pivot = ParseInstruction.Pivot
 
     "pivot" should {
-      "shift an array at identity" >> {
+      "shift an array" >> {
         val input = ldjson("""
           [1, 2, 3]
           [4, 5, 6]
@@ -907,7 +907,7 @@ object ParseInstructionSpec {
             13
             """)
 
-          input must pivotInto(".", IdStatus.ExcludeId, ParseType.Array)(expected)
+          input must pivotInto(IdStatus.ExcludeId, ParseType.Array)(expected)
         }
 
         "IdOnly" >> {
@@ -927,7 +927,7 @@ object ParseInstructionSpec {
             1
             """)
 
-          input must pivotInto(".", IdStatus.IdOnly, ParseType.Array)(expected)
+          input must pivotInto(IdStatus.IdOnly, ParseType.Array)(expected)
         }
 
         "IncludeId" >> {
@@ -947,154 +947,11 @@ object ParseInstructionSpec {
             [1, 13]
             """)
 
-          input must pivotInto(".", IdStatus.IncludeId, ParseType.Array)(expected)
+          input must pivotInto(IdStatus.IncludeId, ParseType.Array)(expected)
         }
       }
 
-      "shift an array at .a.b (with no surrounding structure)" >> {
-        val input = ldjson("""
-          { "a": { "b": [1, 2, 3] } }
-          { "a": { "b": [4, 5, 6] } }
-          { "a": { "b": [7, 8, 9, 10] } }
-          { "a": { "b": [11] } }
-          { "a": { "b": [] } }
-          { "a": { "b": [12, 13] } }
-          """)
-
-        "ExcludeId" >> {
-          val expected = ldjson("""
-            { "a": { "b": 1 } }
-            { "a": { "b": 2 } }
-            { "a": { "b": 3 } }
-            { "a": { "b": 4 } }
-            { "a": { "b": 5 } }
-            { "a": { "b": 6 } }
-            { "a": { "b": 7 } }
-            { "a": { "b": 8 } }
-            { "a": { "b": 9 } }
-            { "a": { "b": 10 } }
-            { "a": { "b": 11 } }
-            { "a": { "b": 12 } }
-            { "a": { "b": 13 } }
-            """)
-
-          input must pivotInto(".a.b", IdStatus.ExcludeId, ParseType.Array)(expected)
-        }
-
-        "IdOnly" >> {
-          val expected = ldjson("""
-            { "a": { "b": 0 } }
-            { "a": { "b": 1 } }
-            { "a": { "b": 2 } }
-            { "a": { "b": 0 } }
-            { "a": { "b": 1 } }
-            { "a": { "b": 2 } }
-            { "a": { "b": 0 } }
-            { "a": { "b": 1 } }
-            { "a": { "b": 2 } }
-            { "a": { "b": 3 } }
-            { "a": { "b": 0 } }
-            { "a": { "b": 0 } }
-            { "a": { "b": 1 } }
-            """)
-
-          input must pivotInto(".a.b", IdStatus.IdOnly, ParseType.Array)(expected)
-        }
-
-        "IncludeId" >> {
-          val expected = ldjson("""
-            { "a": { "b": [0, 1] } }
-            { "a": { "b": [1, 2] } }
-            { "a": { "b": [2, 3] } }
-            { "a": { "b": [0, 4] } }
-            { "a": { "b": [1, 5] } }
-            { "a": { "b": [2, 6] } }
-            { "a": { "b": [0, 7] } }
-            { "a": { "b": [1, 8] } }
-            { "a": { "b": [2, 9] } }
-            { "a": { "b": [3, 10] } }
-            { "a": { "b": [0, 11] } }
-            { "a": { "b": [0, 12] } }
-            { "a": { "b": [1, 13] } }
-            """)
-
-          input must pivotInto(".a.b", IdStatus.IncludeId, ParseType.Array)(expected)
-        }
-      }
-
-     "shift an array at .a[0] (with no surrounding structure)" >> {
-        val input = ldjson("""
-          { "a": [ [1, 2, 3] ] }
-          { "a": [ [4, 5, 6] ] }
-          { "a": [ [7, 8, 9, 10] ] }
-          { "a": [ [11] ] }
-          { "a": [ [] ] }
-          { "a": [ [12, 13] ] }
-          """)
-
-        "ExcludeId" >> {
-          val expected = ldjson("""
-            { "a": [ 1 ] }
-            { "a": [ 2 ] }
-            { "a": [ 3 ] }
-            { "a": [ 4 ] }
-            { "a": [ 5 ] }
-            { "a": [ 6 ] }
-            { "a": [ 7 ] }
-            { "a": [ 8 ] }
-            { "a": [ 9 ] }
-            { "a": [ 10 ] }
-            { "a": [ 11 ] }
-            { "a": [ 12 ] }
-            { "a": [ 13 ] }
-            """)
-
-          input must pivotInto(".a[0]", IdStatus.ExcludeId, ParseType.Array)(expected)
-        }
-
-        "IdOnly" >> {
-          val expected = ldjson("""
-            { "a": [ 0 ] }
-            { "a": [ 1 ] }
-            { "a": [ 2 ] }
-            { "a": [ 0 ] }
-            { "a": [ 1 ] }
-            { "a": [ 2 ] }
-            { "a": [ 0 ] }
-            { "a": [ 1 ] }
-            { "a": [ 2 ] }
-            { "a": [ 3 ] }
-            { "a": [ 0 ] }
-            { "a": [ 0 ] }
-            { "a": [ 1 ] }
-            """)
-
-          input must pivotInto(".a[0]", IdStatus.IdOnly, ParseType.Array)(expected)
-        }
-
-        "IncludeId" >> {
-          val expected = ldjson("""
-            { "a": [ [0, 1] ] }
-            { "a": [ [1, 2] ] }
-            { "a": [ [2, 3] ] }
-            { "a": [ [0, 4] ] }
-            { "a": [ [1, 5] ] }
-            { "a": [ [2, 6] ] }
-            { "a": [ [0, 7] ] }
-            { "a": [ [1, 8] ] }
-            { "a": [ [2, 9] ] }
-            { "a": [ [3, 10] ] }
-            { "a": [ [0, 11] ] }
-            { "a": [ [0, 12] ] }
-            { "a": [ [1, 13] ] }
-            """)
-
-          input must pivotInto(".a[0]", IdStatus.IncludeId, ParseType.Array)(expected)
-        }
-      }
-
-
-      "shift an object at identity" >> {
+      "shift an object" >> {
         val input = ldjson("""
           { "a": 1, "b": 2, "c": 3 }
           { "d": 4, "e": 5, "f": 6 }
@@ -1121,7 +978,7 @@ object ParseInstructionSpec {
             13
             """)
 
-          input must pivotInto(".", IdStatus.ExcludeId, ParseType.Object)(expected)
+          input must pivotInto(IdStatus.ExcludeId, ParseType.Object)(expected)
         }
 
         "IdOnly" >> {
@@ -1141,7 +998,7 @@ object ParseInstructionSpec {
             "m"
             """)
 
-          input must pivotInto(".", IdStatus.IdOnly, ParseType.Object)(expected)
+          input must pivotInto(IdStatus.IdOnly, ParseType.Object)(expected)
         }
 
         "IncludeId" >> {
@@ -1161,162 +1018,8 @@ object ParseInstructionSpec {
             ["m", 13]
             """)
 
-          input must pivotInto(".", IdStatus.IncludeId, ParseType.Object)(expected)
+          input must pivotInto(IdStatus.IncludeId, ParseType.Object)(expected)
         }
-      }
-
-      "shift an object at .a.b (no surrounding structure)" >> {
-        val input = ldjson("""
-          { "a": { "b": { "a": 1, "b": 2, "c": 3 } } }
-          { "a": { "b": { "d": 4, "e": 5, "f": 6 } } }
-          { "a": { "b": { "g": 7, "h": 8, "i": 9, "j": 10 } } }
-          { "a": { "b": { "k": 11 } } }
-          { "a": { "b": {} } }
-          { "a": { "b": { "l": 12, "m": 13 } } }
-          """)
-
-        "ExcludeId" >> {
-          val expected = ldjson("""
-            { "a": { "b": 1 } }
-            { "a": { "b": 2 } }
-            { "a": { "b": 3 } }
-            { "a": { "b": 4 } }
-            { "a": { "b": 5 } }
-            { "a": { "b": 6 } }
-            { "a": { "b": 7 } }
-            { "a": { "b": 8 } }
-            { "a": { "b": 9 } }
-            { "a": { "b": 10 } }
-            { "a": { "b": 11 } }
-            { "a": { "b": 12 } }
-            { "a": { "b": 13 } }
-            """)
-
-          input must pivotInto(".a.b", IdStatus.ExcludeId, ParseType.Object)(expected)
-        }
-
-        "IdOnly" >> {
-          val expected = ldjson("""
-            { "a": { "b": "a" } }
-            { "a": { "b": "b" } }
-            { "a": { "b": "c" } }
-            { "a": { "b": "d" } }
-            { "a": { "b": "e" } }
-            { "a": { "b": "f" } }
-            { "a": { "b": "g" } }
-            { "a": { "b": "h" } }
-            { "a": { "b": "i" } }
-            { "a": { "b": "j" } }
-            { "a": { "b": "k" } }
-            { "a": { "b": "l" } }
-            { "a": { "b": "m" } }
-            """)
-
-          input must pivotInto(".a.b", IdStatus.IdOnly, ParseType.Object)(expected)
-        }
-
-        "IncludeId" >> {
-          val expected = ldjson("""
-            { "a": { "b": ["a", 1] } }
-            { "a": { "b": ["b", 2] } }
-            { "a": { "b": ["c", 3] } }
-            { "a": { "b": ["d", 4] } }
-            { "a": { "b": ["e", 5] } }
-            { "a": { "b": ["f", 6] } }
-            { "a": { "b": ["g", 7] } }
-            { "a": { "b": ["h", 8] } }
-            { "a": { "b": ["i", 9] } }
-            { "a": { "b": ["j", 10] } }
-            { "a": { "b": ["k", 11] } }
-            { "a": { "b": ["l", 12] } }
-            { "a": { "b": ["m", 13] } }
-            """)
-
-          input must pivotInto(".a.b", IdStatus.IncludeId, ParseType.Object)(expected)
-        }
-      }
-
-      "shift an object at .a[0] (no surrounding structure)" >> {
-        val input = ldjson("""
-          { "a": [ { "a": 1, "b": 2, "c": 3 } ] }
-          { "a": [ { "d": 4, "e": 5, "f": 6 } ] }
-          { "a": [ { "g": 7, "h": 8, "i": 9, "j": 10 } ] }
-          { "a": [ { "k": 11 } ] }
-          { "a": [ {} ] }
-          { "a": [ { "l": 12, "m": 13 } ] }
-          """)
-
-        "ExcludeId" >> {
-          val expected = ldjson("""
-            { "a": [ 1 ] }
-            { "a": [ 2 ] }
-            { "a": [ 3 ] }
-            { "a": [ 4 ] }
-            { "a": [ 5 ] }
-            { "a": [ 6 ] }
-            { "a": [ 7 ] }
-            { "a": [ 8 ] }
-            { "a": [ 9 ] }
-            { "a": [ 10 ] }
-            { "a": [ 11 ] }
-            { "a": [ 12 ] }
-            { "a": [ 13 ] }
-            """)
-
-          input must pivotInto(".a[0]", IdStatus.ExcludeId, ParseType.Object)(expected)
-        }
-
-        "IdOnly" >> {
-          val expected = ldjson("""
-            { "a": [ "a" ] }
-            { "a": [ "b" ] }
-            { "a": [ "c" ] }
-            { "a": [ "d" ] }
-            { "a": [ "e" ] }
-            { "a": [ "f" ] }
-            { "a": [ "g" ] }
-            { "a": [ "h" ] }
-            { "a": [ "i" ] }
-            { "a": [ "j" ] }
-            { "a": [ "k" ] }
-            { "a": [ "l" ] }
-            { "a": [ "m" ] }
-            """)
-
-          input must pivotInto(".a[0]", IdStatus.IdOnly, ParseType.Object)(expected)
-        }
-
-        "IncludeId" >> {
-          val expected = ldjson("""
-            { "a": [ ["a", 1] ] }
-            { "a": [ ["b", 2] ] }
-            { "a": [ ["c", 3] ] }
-            { "a": [ ["d", 4] ] }
-            { "a": [ ["e", 5] ] }
-            { "a": [ ["f", 6] ] }
-            { "a": [ ["g", 7] ] }
-            { "a": [ ["h", 8] ] }
-            { "a": [ ["i", 9] ] }
-            { "a": [ ["j", 10] ] }
-            { "a": [ ["k", 11] ] }
-            { "a": [ ["l", 12] ] }
-            { "a": [ ["m", 13] ] }
-            """)
-
-          input must pivotInto(".a[0]", IdStatus.IncludeId, ParseType.Object)(expected)
-        }
-      }
-
-      "shift an object under .shifted with IncludeId and only one field" in {
-        val input = ldjson("""
-          { "shifted": { "shifted1": { "foo": "bar" } } }
-          """)
-
-        val expected = ldjson("""
-          { "shifted": ["shifted1", { "foo": "bar" }] }
-          """)
-
-        input must pivotInto(".shifted", IdStatus.IncludeId, ParseType.Object)(expected)
       }
 
       "preserve empty arrays as values of an array pivot" in {
@@ -1336,7 +1039,7 @@ object ParseInstructionSpec {
           "four"
         """)
 
-        input must pivotInto(".", IdStatus.ExcludeId, ParseType.Array)(expected)
+        input must pivotInto(IdStatus.ExcludeId, ParseType.Array)(expected)
       }
 
       "preserve empty objects as values of an object pivot" in {
@@ -1356,20 +1059,19 @@ object ParseInstructionSpec {
           "four"
         """)
 
-        input must pivotInto(".", IdStatus.ExcludeId, ParseType.Object)(expected)
+        input must pivotInto(IdStatus.ExcludeId, ParseType.Object)(expected)
       }
     }
 
     def evalPivot(pivot: Pivot, stream: JsonStream): JsonStream
 
     def pivotInto(
-        path: String,
         idStatus: IdStatus,
         structure: CompositeParseType)(
         expected: JsonStream)
         : Matcher[JsonStream] =
       bestSemanticEqual(expected) ^^ { str: JsonStream =>
-        evalPivot(Pivot(CPath.parse(path), idStatus, structure), str)
+        evalPivot(Pivot(idStatus, structure), str)
       }
   }
 
@@ -1452,11 +1154,11 @@ object ParseInstructionSpec {
 
         val targets = Map(
           (CPathField("a1"),
-            (CPathField("a0"), List(Pivot(CPath.Identity, IdStatus.ExcludeId, ParseType.Array)))),
+            (CPathField("a0"), List(Pivot(IdStatus.ExcludeId, ParseType.Array)))),
           (CPathField("b1"),
             (CPathField("b0"), Nil)),
           (CPathField("c1"),
-            (CPathField("c0"), List(Pivot(CPath.Identity, IdStatus.ExcludeId, ParseType.Object)))))
+            (CPathField("c0"), List(Pivot(IdStatus.ExcludeId, ParseType.Object)))))
 
         input must cartesianInto(targets)(expected)
       }
@@ -1491,18 +1193,18 @@ object ParseInstructionSpec {
         val targets = Map(
           (CPathField("y"),
             (CPathField("a"), List(
-              Pivot(CPath.Identity, IdStatus.ExcludeId, ParseType.Array),
+              Pivot(IdStatus.ExcludeId, ParseType.Array),
               Project(CPath.parse("x0")),
               Project(CPath.parse("y0")),
-              Pivot(CPath.Identity, IdStatus.ExcludeId, ParseType.Object)))),
+              Pivot(IdStatus.ExcludeId, ParseType.Object)))),
           (CPathField("z"),
             (CPathField("a"), List(
-              Pivot(CPath.Identity, IdStatus.ExcludeId, ParseType.Array),
+              Pivot(IdStatus.ExcludeId, ParseType.Array),
               Project(CPath.parse("x1")),
-              Pivot(CPath.Identity, IdStatus.ExcludeId, ParseType.Array)))),
+              Pivot(IdStatus.ExcludeId, ParseType.Array)))),
           (CPathField("b"),
             (CPathField("b"), List(
-              Pivot(CPath.Identity, IdStatus.IdOnly, ParseType.Object)))),
+              Pivot(IdStatus.IdOnly, ParseType.Object)))),
           (CPathField("c"),
             (CPathField("c"), Nil)))
 
@@ -1531,11 +1233,11 @@ object ParseInstructionSpec {
 
           (CPathField("ba"), (CPathField("b"), List(
             Mask(Map(CPath.Identity -> Set(ParseType.Array))),
-            Pivot(CPath.Identity, IdStatus.ExcludeId, ParseType.Array)))),
+            Pivot(IdStatus.ExcludeId, ParseType.Array)))),
 
           (CPathField("bm"), (CPathField("b"), List(
             Mask(Map(CPath.Identity -> Set(ParseType.Object))),
-            Pivot(CPath.Identity, IdStatus.ExcludeId, ParseType.Object)))))
+            Pivot(IdStatus.ExcludeId, ParseType.Object)))))
 
         input must cartesianInto(targets)(expected)
       }

--- a/impl/src/main/scala/quasar/impl/datasource/local/EvaluableLocalDatasource.scala
+++ b/impl/src/main/scala/quasar/impl/datasource/local/EvaluableLocalDatasource.scala
@@ -60,7 +60,7 @@ final class EvaluableLocalDatasource[F[_]: ContextShift: Timer] private (
     for {
       (jp, attrs) <- attributesOf(ir.path).getOrElseF(RE.raiseError(pathNotFound(ir.path)))
       _ <- attrs.isRegularFile.unlessM(RE.raiseError(notAResource(ir.path)))
-    } yield queryResult(InterpretedRead(jp, ir.instructions))
+    } yield queryResult(InterpretedRead(jp, ir.idStatus, ir.instructions))
 
   def pathIsResource(path: ResourcePath): F[Boolean] =
     toNio[F](path) >>= (jp => F.delay(Files.isRegularFile(jp)))

--- a/impl/src/main/scala/quasar/impl/datasources/DefaultDatasources.scala
+++ b/impl/src/main/scala/quasar/impl/datasources/DefaultDatasources.scala
@@ -114,7 +114,7 @@ final class DefaultDatasources[
     withDatasource[DiscoveryError[I], Option[schemaConfig.Schema]](datasourceId) { mds =>
       val fr = mds match {
         case ManagedDatasource.ManagedLightweight(lw) =>
-          lw.evaluate(InterpretedRead(path, Nil))
+          lw.evaluate(InterpretedRead(path, IdStatus.ExcludeId, Nil))
 
         case ManagedDatasource.ManagedHeavyweight(hw) =>
           hw.evaluate(dsl.Read(path, IdStatus.ExcludeId))

--- a/impl/src/test/scala/quasar/impl/datasource/local/LocalDatasourceSpec.scala
+++ b/impl/src/test/scala/quasar/impl/datasource/local/LocalDatasourceSpec.scala
@@ -26,6 +26,7 @@ import java.nio.file.Paths
 
 import scala.concurrent.ExecutionContext
 
+import quasar.IdStatus
 import quasar.api.resource.{ResourceName, ResourcePath}
 import quasar.common.data.RValue
 import quasar.concurrent.BlockingContext
@@ -53,7 +54,7 @@ abstract class LocalDatasourceSpec
 
   "returns data from a nonempty file" >>* {
     datasource
-      .evaluate(InterpretedRead(ResourcePath.root() / ResourceName("smallZips.data"), List()))
+      .evaluate(InterpretedRead(ResourcePath.root() / ResourceName("smallZips.data"), IdStatus.ExcludeId, List()))
       .flatMap(_.data.compile.fold(0)((c, _) => c + 1))
       .map(_ must be_>(0))
   }

--- a/impl/src/test/scala/quasar/impl/datasources/CompositeResourceSchemaSpec.scala
+++ b/impl/src/test/scala/quasar/impl/datasources/CompositeResourceSchemaSpec.scala
@@ -20,6 +20,7 @@ import slamdata.Predef._
 
 import quasar.ParseInstruction
 import quasar.api.resource.{ResourceName, ResourcePath}
+import quasar.common.CPath
 import quasar.common.data.RValue
 import quasar.connector.{CompressionScheme, ParsableType, QueryResult, ResourceError}
 import quasar.connector.ParsableType.JsonVariant
@@ -176,7 +177,7 @@ object CompositeResourceSchemaSpec extends quasar.EffectfulQSpec[IO] {
 
   "error when any parse instructions" >>* {
     val withInstrs =
-      QueryResult.instructions.set(List(ParseInstruction.Ids))(parsedResult)
+      QueryResult.instructions.set(List(ParseInstruction.Project(CPath.Identity)))(parsedResult)
 
     resourceSchema(defaultCfg, (path, Left(withInstrs)), 1.hour)
       .attempt

--- a/impl/src/test/scala/quasar/impl/datasources/middleware/ConditionReportingMiddlewareSpec.scala
+++ b/impl/src/test/scala/quasar/impl/datasources/middleware/ConditionReportingMiddlewareSpec.scala
@@ -18,7 +18,7 @@ package quasar.impl.datasources.middleware
 
 import slamdata.Predef.{Boolean, List, None, Option, Unit}
 
-import quasar.{Condition, ConditionMatchers}
+import quasar.{Condition, ConditionMatchers, IdStatus}
 import quasar.api.datasource.DatasourceType
 import quasar.api.resource._
 import quasar.connector.Datasource
@@ -87,7 +87,7 @@ object ConditionReportingMiddlewareSpec extends quasar.EffectfulQSpec[IO] with C
       r <- Ref[IO].of(List[Condition[Exception]]())
       ds <- ConditionReportingMiddleware[IO, Unit]((_, c) => r.update(c :: _))((), managedTester)
       res = ds match {
-        case ManagedDatasource.ManagedLightweight(lw) => lw.evaluate(InterpretedRead(ResourcePath.root(), List()))
+        case ManagedDatasource.ManagedLightweight(lw) => lw.evaluate(InterpretedRead(ResourcePath.root(), IdStatus.ExcludeId, List()))
         case _ => IO.pure(())
       }
       _ <- res.attempt

--- a/impl/src/test/scala/quasar/impl/evaluate/RValueParseInstructionSpec.scala
+++ b/impl/src/test/scala/quasar/impl/evaluate/RValueParseInstructionSpec.scala
@@ -39,9 +39,9 @@ object RValueParseInstructionSpec extends ParseInstructionSpec {
 
   type JsonElement = RValue
 
-  def evalIds(stream: JsonStream): JsonStream =
+  def evalIds(idStatus: IdStatus, stream: JsonStream): JsonStream =
     Stream.emits(stream)
-      .through(Interpreter.interpretIdStatus(IdStatus.IncludeId))
+      .through(Interpreter.interpretIdStatus(idStatus))
       .compile.toList
 
   def evalMask(mask: Mask, stream: JsonStream): JsonStream =

--- a/qscript/src/main/scala/quasar/qscript/InterpretedRead.scala
+++ b/qscript/src/main/scala/quasar/qscript/InterpretedRead.scala
@@ -16,24 +16,25 @@
 
 package quasar.qscript
 
-import slamdata.Predef.List
-import quasar.{ParseInstruction, RenderTree}
+import slamdata.Predef.{List, StringContext}
+import quasar.{IdStatus, ParseInstruction, RenderTree}
 
 import monocle.macros.Lenses
 import scalaz.{Equal, Show}
 import scalaz.std.list._
+import scalaz.std.option._
 import scalaz.std.tuple._
 import scalaz.syntax.show._
-import scalaz.syntax.std.option._
 
 @Lenses final case class InterpretedRead[A](
   path: A,
+  idStatus: IdStatus,
   instructions: List[ParseInstruction])
 
 object InterpretedRead {
 
   implicit def equal[A: Equal]: Equal[InterpretedRead[A]] =
-    Equal.equalBy(r => (r.path, r.instructions))
+    Equal.equalBy(r => (r.path, r.idStatus, r.instructions))
 
   implicit def show[A: Show]: Show[InterpretedRead[A]] =
     RenderTree.toShow
@@ -41,5 +42,5 @@ object InterpretedRead {
   implicit def renderTree[A: Show]: RenderTree[InterpretedRead[A]] =
     RenderTree.simple(
       List("InterpretedRead"),
-      r => (r.path.shows + ", " + r.instructions.shows).some)
+      r => some(s"${r.path.shows},  ${r.idStatus.shows}, ${r.instructions.shows}"))
 }

--- a/qscript/src/main/scala/quasar/qscript/construction.scala
+++ b/qscript/src/main/scala/quasar/qscript/construction.scala
@@ -780,10 +780,12 @@ object construction {
         f,
         combine)))
 
-    def InterpretedRead[A](path: A,
-                           instructions: List[ParseInstruction])
-                           (implicit F: Injectable[Const[InterpretedRead[A], ?], F]): R =
-      embed(F.inject(Const(qscript.InterpretedRead(path, instructions))))
+    def InterpretedRead[A](
+        path: A,
+        idStatus: IdStatus,
+        instructions: List[ParseInstruction])
+        (implicit F: Injectable[Const[InterpretedRead[A], ?], F]): R =
+      embed(F.inject(Const(qscript.InterpretedRead(path, idStatus, instructions))))
 
     def Read[A](path: A,
                 idStatus: IdStatus)

--- a/qscript/src/main/scala/quasar/qscript/rewrites/FocusedPushdown.scala
+++ b/qscript/src/main/scala/quasar/qscript/rewrites/FocusedPushdown.scala
@@ -62,7 +62,7 @@ final class FocusedPushdown[T[_[_]]: BirecursiveT: EqualT] private () extends TT
           FocusedRepair(repair)) =>
 
         val pivotInstr =
-          Pivot(CPath.Identity, shiftStatus, ShiftType.toParseType(shiftType))
+          Pivot(shiftStatus, ShiftType.toParseType(shiftType))
 
         val iread =
           IR[T[F]](Const(InterpretedRead(a, readStatus, instrs :+ pivotInstr)))

--- a/qscript/src/main/scala/quasar/qscript/rewrites/FocusedResource.scala
+++ b/qscript/src/main/scala/quasar/qscript/rewrites/FocusedResource.scala
@@ -18,13 +18,12 @@ package quasar.qscript.rewrites
 
 import slamdata.Predef.{List, Option}
 
-import quasar.FocusedParseInstruction
+import quasar.{FocusedParseInstruction, IdStatus}
 import quasar.contrib.iota._
 import quasar.qscript.{InterpretedRead, Read}
 
 import scalaz._, Scalaz._
 
-// TODO: Unnecessary once we have `ParseInstructions` class
 object FocusedResource {
   def apply[A] = new PartiallyApplied[A]
 
@@ -33,14 +32,14 @@ object FocusedResource {
         implicit
         IR: Const[InterpretedRead[A], ?] :<<: F,
         R: Const[Read[A], ?] :<<: F)
-        : Option[(A, List[FocusedParseInstruction])] =
+        : Option[(A, IdStatus, List[FocusedParseInstruction])] =
       Resource[A].unapply(fb) flatMap {
-        case (a, instrs) =>
+        case (a, idStatus, instrs) =>
           val r = instrs traverse {
             case fpi: FocusedParseInstruction => some(fpi)
             case _ => none
           }
-          r.strengthL(a)
+          r.map((a, idStatus, _))
       }
   }
 }

--- a/qscript/src/main/scala/quasar/qscript/rewrites/Resource.scala
+++ b/qscript/src/main/scala/quasar/qscript/rewrites/Resource.scala
@@ -19,7 +19,6 @@ package quasar.qscript.rewrites
 import slamdata.Predef.{List, Nil, Option}
 
 import quasar.{IdStatus, ParseInstruction}
-import quasar.common.CPath
 import quasar.contrib.iota._
 import quasar.qscript.{InterpretedRead, Read}
 
@@ -33,28 +32,14 @@ object Resource {
         implicit
         IR: Const[InterpretedRead[A], ?] :<<: F,
         R: Const[Read[A], ?] :<<: F)
-        : Option[(A, List[ParseInstruction])] = {
+        : Option[(A, IdStatus, List[ParseInstruction])] = {
 
       def isIR = IR.prj(fb) map {
-        case Const(InterpretedRead(a, instrs)) => (a, instrs)
+        case Const(InterpretedRead(a, idStatus, instrs)) => (a, idStatus, instrs)
       }
 
       def isR = R.prj(fb) map {
-        case Const(Read(a, idStatus)) =>
-          val instrs = idStatus match {
-            case IdStatus.IdOnly =>
-              List(
-                ParseInstruction.Ids,
-                ParseInstruction.Project(CPath.Identity \ 0))
-
-            case IdStatus.IncludeId =>
-              List(ParseInstruction.Ids)
-
-            case IdStatus.ExcludeId =>
-              Nil
-          }
-
-          (a, instrs)
+        case Const(Read(a, idStatus)) => (a, idStatus, Nil)
       }
 
       isIR orElse isR

--- a/qscript/src/test/scala/quasar/qscript/rewrites/FocusedPushdownSpec.scala
+++ b/qscript/src/test/scala/quasar/qscript/rewrites/FocusedPushdownSpec.scala
@@ -95,7 +95,7 @@ object FocusedPushdownSpec extends Qspec {
               ExcludeId,
               List(
                 Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
-                Pivot(CPath.Identity, IncludeId, ParseType.Object),
+                Pivot(IncludeId, ParseType.Object),
                 Mask(SMap((CPath.Identity \ 0) -> ParseType.Top, (CPath.Identity \ 1) -> ParseType.Top)))),
             recFuncE.ConcatMaps(
               recFuncE.MakeMapS("k1", recFuncE.ProjectIndexI(recFuncE.Hole, 0)),
@@ -120,7 +120,7 @@ object FocusedPushdownSpec extends Qspec {
             ExcludeId,
             List(
               Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
-              Pivot(CPath.Identity, IdOnly, ParseType.Object),
+              Pivot(IdOnly, ParseType.Object),
               Wrap(CPath.Identity, "k1")))
 
         focusedPushdown(initial) must equal(expected)
@@ -142,7 +142,7 @@ object FocusedPushdownSpec extends Qspec {
             ExcludeId,
             List(
               Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
-              Pivot(CPath.Identity, ExcludeId, ParseType.Object),
+              Pivot(ExcludeId, ParseType.Object),
               Wrap(CPath.Identity, "v1")))
 
         focusedPushdown(initial) must equal(expected)
@@ -168,7 +168,7 @@ object FocusedPushdownSpec extends Qspec {
             ExcludeId,
             List(
               Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
-              Pivot(CPath.Identity, ExcludeId, ParseType.Object),
+              Pivot(ExcludeId, ParseType.Object),
               Wrap(CPath.Identity, "v1"))),
           recFuncE.Constant(ejs.bool(true)))
 
@@ -195,7 +195,7 @@ object FocusedPushdownSpec extends Qspec {
               List(
                 Project(CPath.Identity \ "xyz"),
                 Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
-                Pivot(CPath.Identity, IncludeId, ParseType.Object),
+                Pivot(IncludeId, ParseType.Object),
                 Mask(SMap((CPath.Identity \ 0) -> ParseType.Top, (CPath.Identity \ 1) -> ParseType.Top)))),
             recFuncE.ConcatMaps(
               recFuncE.MakeMapS("k1", recFuncE.ProjectIndexI(recFuncE.Hole, 0)),
@@ -229,7 +229,7 @@ object FocusedPushdownSpec extends Qspec {
               List(
                 Project(CPath.parse(".aaa.bbb.ccc")),
                 Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
-                Pivot(CPath.Identity, IncludeId, ParseType.Object),
+                Pivot(IncludeId, ParseType.Object),
                 Mask(SMap((CPath.Identity \ 0) -> ParseType.Top, (CPath.Identity \ 1) -> ParseType.Top)))),
             recFuncE.ConcatMaps(
               recFuncE.MakeMapS("k1", recFuncE.ProjectIndexI(recFuncE.Hole, 0)),
@@ -264,7 +264,7 @@ object FocusedPushdownSpec extends Qspec {
               List(
                 Project(CPath.parse(".aaa[42].ccc")),
                 Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
-                Pivot(CPath.Identity, IncludeId, ParseType.Object),
+                Pivot(IncludeId, ParseType.Object),
                 Mask(SMap((CPath.Identity \ 0) -> ParseType.Top, (CPath.Identity \ 1) -> ParseType.Top)))),
             recFuncE.ConcatMaps(
               recFuncE.MakeMapS("k1", recFuncE.ProjectIndexI(recFuncE.Hole, 0)),
@@ -298,7 +298,7 @@ object FocusedPushdownSpec extends Qspec {
               List(
                 Project(CPath.parse(".[17][42].ccc")),
                 Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
-                Pivot(CPath.Identity, IncludeId, ParseType.Object),
+                Pivot(IncludeId, ParseType.Object),
                 Mask(SMap((CPath.Identity \ 0) -> ParseType.Top, (CPath.Identity \ 1) -> ParseType.Top)))),
             recFuncE.ConcatMaps(
               recFuncE.MakeMapS("k1", recFuncE.ProjectIndexI(recFuncE.Hole, 0)),
@@ -323,7 +323,7 @@ object FocusedPushdownSpec extends Qspec {
           IncludeId,
           List(
             Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
-            Pivot(CPath.Identity, IncludeId, ParseType.Object)))
+            Pivot(IncludeId, ParseType.Object)))
 
       focusedPushdown(initial) must_= expected
     }
@@ -344,7 +344,7 @@ object FocusedPushdownSpec extends Qspec {
           IdOnly,
           List(
             Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
-            Pivot(CPath.Identity, IncludeId, ParseType.Object)))
+            Pivot(IncludeId, ParseType.Object)))
 
       focusedPushdown(initial) must_= expected
     }
@@ -430,10 +430,10 @@ object FocusedPushdownSpec extends Qspec {
           List(
             Project(CPath.parse(".aaa.bbb.ccc")),
             Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
-            Pivot(CPath.Identity, IncludeId, ParseType.Object),
+            Pivot(IncludeId, ParseType.Object),
             Project(CPath.parse(".[1].ddd")),
             Mask(SMap(CPath.Identity -> Set(ParseType.Array))),
-            Pivot(CPath.Identity, ExcludeId, ParseType.Array),
+            Pivot(ExcludeId, ParseType.Array),
             Wrap(CPath.Identity, "result")))
 
       focusedPushdown(initial) must_= expected

--- a/qscript/src/test/scala/quasar/qscript/rewrites/FocusedPushdownSpec.scala
+++ b/qscript/src/test/scala/quasar/qscript/rewrites/FocusedPushdownSpec.scala
@@ -20,7 +20,7 @@ import slamdata.Predef.{Map => SMap, _}
 
 import quasar.{ParseType, Qspec}
 import quasar.IdStatus.{ExcludeId, IdOnly, IncludeId}
-import quasar.ParseInstruction.{Ids, Mask, Pivot, Project, Wrap}
+import quasar.ParseInstruction.{Mask, Pivot, Project, Wrap}
 import quasar.api.resource.ResourcePath
 import quasar.common.CPath
 import quasar.contrib.iota._
@@ -92,6 +92,7 @@ object FocusedPushdownSpec extends Qspec {
           fixE.Map(
             fixE.InterpretedRead[ResourcePath](
               path,
+              ExcludeId,
               List(
                 Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
                 Pivot(CPath.Identity, IncludeId, ParseType.Object),
@@ -116,6 +117,7 @@ object FocusedPushdownSpec extends Qspec {
         val expected: Fix[QSExtra] =
           fixE.InterpretedRead[ResourcePath](
             path,
+            ExcludeId,
             List(
               Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
               Pivot(CPath.Identity, IdOnly, ParseType.Object),
@@ -137,6 +139,7 @@ object FocusedPushdownSpec extends Qspec {
         val expected: Fix[QSExtra] =
           fixE.InterpretedRead[ResourcePath](
             path,
+            ExcludeId,
             List(
               Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
               Pivot(CPath.Identity, ExcludeId, ParseType.Object),
@@ -162,6 +165,7 @@ object FocusedPushdownSpec extends Qspec {
         fixE.Filter(
           fixE.InterpretedRead[ResourcePath](
             path,
+            ExcludeId,
             List(
               Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
               Pivot(CPath.Identity, ExcludeId, ParseType.Object),
@@ -187,6 +191,7 @@ object FocusedPushdownSpec extends Qspec {
           fixE.Map(
             fixE.InterpretedRead[ResourcePath](
               path,
+              ExcludeId,
               List(
                 Project(CPath.Identity \ "xyz"),
                 Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
@@ -220,6 +225,7 @@ object FocusedPushdownSpec extends Qspec {
           fixE.Map(
             fixE.InterpretedRead[ResourcePath](
               path,
+              ExcludeId,
               List(
                 Project(CPath.parse(".aaa.bbb.ccc")),
                 Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
@@ -254,6 +260,7 @@ object FocusedPushdownSpec extends Qspec {
           fixE.Map(
             fixE.InterpretedRead[ResourcePath](
               path,
+              ExcludeId,
               List(
                 Project(CPath.parse(".aaa[42].ccc")),
                 Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
@@ -287,6 +294,7 @@ object FocusedPushdownSpec extends Qspec {
           fixE.Map(
             fixE.InterpretedRead[ResourcePath](
               path,
+              ExcludeId,
               List(
                 Project(CPath.parse(".[17][42].ccc")),
                 Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
@@ -312,8 +320,8 @@ object FocusedPushdownSpec extends Qspec {
       val expected: Fix[QSExtra] =
         fixE.InterpretedRead[ResourcePath](
           path,
+          IncludeId,
           List(
-            Ids,
             Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
             Pivot(CPath.Identity, IncludeId, ParseType.Object)))
 
@@ -333,9 +341,8 @@ object FocusedPushdownSpec extends Qspec {
       val expected: Fix[QSExtra] =
         fixE.InterpretedRead[ResourcePath](
           path,
+          IdOnly,
           List(
-            Ids,
-            Project(CPath.Identity \ 0),
             Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
             Pivot(CPath.Identity, IncludeId, ParseType.Object)))
 
@@ -419,6 +426,7 @@ object FocusedPushdownSpec extends Qspec {
       val expected: Fix[QSExtra] =
         fixE.InterpretedRead[ResourcePath](
           path,
+          ExcludeId,
           List(
             Project(CPath.parse(".aaa.bbb.ccc")),
             Mask(SMap(CPath.Identity -> Set(ParseType.Object))),
@@ -453,6 +461,7 @@ object FocusedPushdownSpec extends Qspec {
         fixE.Map(
           fixE.InterpretedRead[ResourcePath](
             path,
+            ExcludeId,
             List(
               Project(CPath.parse(".[3].order")),
               Mask(SMap(
@@ -502,6 +511,7 @@ object FocusedPushdownSpec extends Qspec {
         fixE.Map(
           fixE.InterpretedRead[ResourcePath](
             path,
+            ExcludeId,
             List(Mask(SMap(
               CPath.parse(".orderA.tax") -> ParseType.Top,
               CPath.parse(".orderB.total") -> ParseType.Top)))),
@@ -540,6 +550,7 @@ object FocusedPushdownSpec extends Qspec {
         fixE.Map(
           fixE.InterpretedRead[ResourcePath](
             path,
+            ExcludeId,
             List(Mask(SMap(
               CPath.parse(".a.aa") -> ParseType.Top,
               CPath.parse(".b[4]") -> ParseType.Top)))),
@@ -582,6 +593,7 @@ object FocusedPushdownSpec extends Qspec {
         fixE.Map(
           fixE.InterpretedRead[ResourcePath](
             path,
+            ExcludeId,
             List(Mask(SMap(
               CPath.parse(".[3].a") -> ParseType.Top,
               CPath.parse(".[9].b[6]") -> ParseType.Top,


### PR DESCRIPTION
* Add an `IdStatus` property to `InterpretedRead`
* Remove `ParseInstruction.Ids`
* Remove the `CPath` property from `Pivot`.

[ch4489]
[ch5100]