### PR TITLE
Made PhaseResults lazy (using Eval) to tree logging costs in production

### DIFF
--- a/common/src/main/scala/quasar/common/package.scala
+++ b/common/src/main/scala/quasar/common/package.scala
@@ -19,6 +19,7 @@ package quasar
 import slamdata.Predef._
 import quasar.contrib.scalaz.{MonadListen_, MonadTell_}
 
+import cats.Eval
 import scalaz._
 
 package object common {
@@ -32,11 +33,11 @@ package object common {
       CIString.unapply(name)
   }
 
-  type PhaseResults = Vector[PhaseResult]
+  type PhaseResults = Vector[Eval[PhaseResult]]
 
   object PhaseResults {
     final def logPhase[M[_]]
-      (pr: PhaseResult)
+      (pr: Eval[PhaseResult])
       (implicit MT: PhaseResultTell[M])
         : M[Unit] =
       MT.tell(Vector(pr))
@@ -62,7 +63,7 @@ package object common {
     def apply[F[_]] = new PartiallyApplied[F]
     final class PartiallyApplied[F[_]] {
       def apply[A: RenderTree](label: String, a: A)(implicit F: PhaseResultTell[F]): F[A] =
-        F.writer(Vector(PhaseResult.tree(label, a)), a)
+        F.writer(Vector(Eval.later(PhaseResult.tree(label, a))), a)
     }
   }
 

--- a/qsu/src/main/scala/quasar/qsu/LPtoQS.scala
+++ b/qsu/src/main/scala/quasar/qsu/LPtoQS.scala
@@ -25,6 +25,7 @@ import quasar.qscript.MonadPlannerErr
 
 import matryoshka.{BirecursiveT, EqualT, ShowT}
 import org.slf4s.Logging
+import cats.Eval
 import scalaz.{Cord, Functor, Kleisli => K, Monad, Show}
 import scalaz.syntax.functor._
 import scalaz.syntax.show._
@@ -81,7 +82,7 @@ final class LPtoQS[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT]
 
   private def debug[F[_]: Functor: PhaseResultTell, A: Show](name: String): A => F[A] = { a =>
     log.debug((Cord(name + "\n") ++ a.show).shows)
-    PhaseResultTell[F].tell(Vector(PhaseResult.detail(s"QSU ($name)", a.shows))).as(a)
+    PhaseResultTell[F].tell(Vector(Eval.later(PhaseResult.detail(s"QSU ($name)", a.shows)))).as(a)
   }
 }
 


### PR DESCRIPTION
`WriterT` isn't a logger. It never was. The fact that we're calling `RenderTree` on giant qscripts in production code paths is… very broken.

[ch5234]