### PR TITLE
Provenance fixes for autojoin

### DIFF
--- a/qscript/src/main/scala/quasar/qscript/provenance/Dimension.scala
+++ b/qscript/src/main/scala/quasar/qscript/provenance/Dimension.scala
@@ -33,8 +33,11 @@ trait Dimension[D, I, P] {
   def autojoinKeys(ls: Dimensions[P], rs: Dimensions[P])(implicit D: Equal[D]): JoinKeys[I] =
     ls.union.tuple(rs.union) foldMap {
       case (l, r) =>
+        val fl = l.flatMap(flattenThen).reverse
+        val fr = r.flatMap(flattenThen).reverse
+
         val joined =
-          l.reverse.alignBoth(r.reverse).foldLeftM(true) { (b, lr) =>
+          fl.alignBoth(fr).foldLeftM(true) { (b, lr) =>
             if (b)
               lr anyM { case (a, b) => autojoined[Writer[JoinKeys[I], ?]](a, b) }
             else

--- a/qscript/src/test/scala/quasar/qscript/provenance/DimensionSpec.scala
+++ b/qscript/src/test/scala/quasar/qscript/provenance/DimensionSpec.scala
@@ -19,14 +19,28 @@ package quasar.qscript.provenance
 import slamdata.Predef.{Char, Int}
 import quasar.Qspec
 
+import scala.util.{Either, Left, Right}
+
 import matryoshka._
 import matryoshka.data.Fix
+
+import monocle.std.either.stdLeft
+
 import scalaz.{IList, NonEmptyList}
 import scalaz.std.anyVal._
+import scalaz.std.either._
 
 object DimensionSpec extends Qspec {
-  val P = Prov[Char, Int, Fix[ProvF[Char, Int, ?]]]
+  type I = Either[Char, Int]
+
+  val P = Prov[Char, I, Fix[ProvF[Char, I, ?]]](stdLeft)
   val D = Dimension(P)
+
+  def i(int: Int): I = Right(int)
+  def c(char: Char): I = Left(char)
+
+  def ikey(l: Int, r: Int): JoinKey[I] =
+    JoinKey(i(l), i(r))
 
   import P.implicits._
 
@@ -39,17 +53,17 @@ object DimensionSpec extends Qspec {
   }
 
   "project static key known not to exist is empty" >> {
-    val d = D.injectStatic('y', D.lshift(1, D.projectStatic('c', D.projectPath('f', D.empty))))
+    val d = D.injectStatic('y', D.lshift(i(1), D.projectStatic('c', D.projectPath('f', D.empty))))
     D.projectStatic('z', d) must_= D.empty
   }
 
   "project static eliminates inject static" >> {
     val init = Dimensions.origin(
       P.both(P.injValue('x'), P.injValue('y')),
-      P.value(3),
+      P.value(i(3)),
       P.prjPath('a'))
 
-    val exp = Dimensions.origin(P.value(3), P.prjPath('a'))
+    val exp = Dimensions.origin(P.value(i(3)), P.prjPath('a'))
 
     D.projectStatic('x', init) must_= exp
   }
@@ -58,10 +72,10 @@ object DimensionSpec extends Qspec {
     val init = Dimensions.origin(
       P.thenn(
         P.both(P.injValue('x'), P.injValue('y')),
-        P.value(3)),
+        P.value(i(3))),
       P.prjPath('a'))
 
-    val exp = Dimensions.origin(P.value(3), P.prjPath('a'))
+    val exp = Dimensions.origin(P.value(i(3)), P.prjPath('a'))
 
     D.projectStatic('x', init) must_= exp
   }
@@ -72,52 +86,76 @@ object DimensionSpec extends Qspec {
 
   "autojoin keys" >> {
     "builds join keys from zipped dimensions" >> {
-      val x = D.lshift(1, D.lshift(2, D.projectPath('a', D.empty)))
-      val y = D.lshift(3, D.lshift(4, D.projectPath('a', D.empty)))
+      val x = D.lshift(i(1), D.lshift(i(2), D.projectPath('a', D.empty)))
+      val y = D.lshift(i(3), D.lshift(i(4), D.projectPath('a', D.empty)))
 
       val jks = JoinKeys(IList(NonEmptyList(
-        NonEmptyList(JoinKey(1, 3)),
-        NonEmptyList(JoinKey(2, 4)))))
+        NonEmptyList(ikey(1, 3)),
+        NonEmptyList(ikey(2, 4)))))
 
       D.autojoinKeys(x, y) must_= jks
     }
 
-    "does not include keys for dimensions after a partial join" >> {
-      val x = D.lshift(3, D.flatten(2, D.lshift(1, D.projectPath('a', D.empty))))
-      val y = D.lshift(9, D.lshift(8, D.lshift(7, D.projectPath('a', D.empty))))
+    "flatten joins with shift" >> {
+      val x = D.lshift(i(3), D.flatten(i(2), D.lshift(i(1), D.projectPath('a', D.empty))))
+      val y = D.lshift(i(9), D.lshift(i(8), D.lshift(i(7), D.projectPath('a', D.empty))))
 
-      val jks = JoinKeys(IList(NonEmptyList(NonEmptyList(JoinKey(1, 7)))))
-
-      D.autojoinKeys(x, y) must_= jks
-    }
-
-    "does not include keys for dimensions after mismatched projection" >> {
-      val x = D.lshift(3, D.projectStatic('k', D.lshift(1, D.projectPath('a', D.empty))))
-      val y = D.lshift(9, D.lshift(7, D.projectPath('a', D.empty)))
-
-      val jks = JoinKeys(IList(NonEmptyList(NonEmptyList(JoinKey(1, 7)))))
+      val jks = JoinKeys(IList(NonEmptyList(
+        NonEmptyList(ikey(1, 7)),
+        NonEmptyList(ikey(2, 8)),
+        NonEmptyList(ikey(3, 9)))))
 
       D.autojoinKeys(x, y) must_= jks
     }
 
-    "does not include keys after a mismatch" >> {
-      val x = D.lshift(2, D.flatten(1, D.projectPath('b', D.projectPath('a', D.empty))))
-      val y = D.lshift(8, D.flatten(7, D.projectPath('c', D.projectPath('a', D.empty))))
+    "flatten joins with project" >> {
+      val x = D.lshift(i(3), D.projectStatic('k', D.lshift(i(1), D.projectPath('a', D.empty))))
+      val y = D.flatten(i(9), D.lshift(i(7), D.projectPath('a', D.empty)))
+
+      val jks = JoinKeys(IList(NonEmptyList(
+        NonEmptyList(ikey(1, 7)),
+        NonEmptyList(JoinKey(c('k'), i(9))))))
+
+      D.autojoinKeys(x, y) must_= jks
+    }
+
+    "shift joins with project" >> {
+      val x = D.lshift(i(3), D.projectStatic('k', D.lshift(i(1), D.projectPath('a', D.empty))))
+      val y = D.lshift(i(9), D.lshift(i(7), D.projectPath('a', D.empty)))
+
+      val jks = JoinKeys(IList(NonEmptyList(
+        NonEmptyList(ikey(1, 7)),
+        NonEmptyList(JoinKey(c('k'), i(9))))))
+
+      D.autojoinKeys(x, y) must_= jks
+    }
+
+    "halts the join on project mismatch" >> {
+      val x = D.lshift(i(2), D.projectStatic('x', D.flatten(i(1), D.projectPath('a', D.empty))))
+      val y = D.lshift(i(8), D.projectStatic('y', D.flatten(i(7), D.projectPath('a', D.empty))))
+
+      val jks = JoinKeys(IList(NonEmptyList(NonEmptyList(ikey(1, 7)))))
+
+      D.autojoinKeys(x, y) must_= jks
+    }
+
+    "halts the join on path mismatch" >> {
+      val x = D.lshift(i(2), D.flatten(i(1), D.projectPath('b', D.projectPath('a', D.empty))))
+      val y = D.lshift(i(8), D.flatten(i(7), D.projectPath('c', D.projectPath('a', D.empty))))
 
       D.autojoinKeys(x, y) must_= JoinKeys.empty
     }
 
     "join with union disjoins keys for each side" >> {
-      val x = D.lshift(2, D.projectPath('a', D.empty))
-      val y = D.lshift(3, D.projectPath('a', D.empty))
-      val z = D.lshift(4, D.projectPath('a', D.empty))
+      val x = D.lshift(i(2), D.projectPath('a', D.empty))
+      val y = D.lshift(i(3), D.projectPath('a', D.empty))
+      val z = D.lshift(i(4), D.projectPath('a', D.empty))
 
       val jks = JoinKeys(IList(
-        NonEmptyList(NonEmptyList(JoinKey(2, 4))),
-        NonEmptyList(NonEmptyList(JoinKey(3, 4)))))
+        NonEmptyList(NonEmptyList(ikey(2, 4))),
+        NonEmptyList(NonEmptyList(ikey(3, 4)))))
 
       D.autojoinKeys(D.union(x, y), z) must_= jks
     }
-
   }
 }

--- a/qsu/src/main/scala/quasar/qsu/Access.scala
+++ b/qsu/src/main/scala/quasar/qsu/Access.scala
@@ -25,64 +25,74 @@ import scalaz.syntax.show._
 import scalaz.std.option._
 import scalaz.std.tuple._
 
-sealed abstract class Access[A] {
-  def symbolic(value: A => Symbol): Access[Symbol] =
+sealed abstract class Access[D, A] {
+  def symbolic(value: A => Symbol): Access[D, Symbol] =
     this match {
       case Access.Id(i, a) =>
-        IdAccess.symbols
+        IdAccess.symbols[D]
           .headOption(i)
-          .fold(Access.id(i, value(a)))(Access.id(i, _))
+          .fold(O.id(i, value(a)))(O.id(i, _))
 
       case Access.Value(a) =>
-        Access.value(value(a))
+        O.value(value(a))
     }
+
+  ////
+
+  private def O = Access.Optics[D]
 }
 
 object Access extends AccessInstances {
 
-  final case class Id[A](idAccess: IdAccess, src: A) extends Access[A]
-  final case class Value[A](src: A) extends Access[A]
+  final case class Id[D, A](idAccess: IdAccess[D], src: A) extends Access[D, A]
+  final case class Value[D, A](src: A) extends Access[D, A]
 
-  def id[A]: Prism[Access[A], (IdAccess, A)] =
-    Prism.partial[Access[A], (IdAccess, A)] {
-      case Id(i, a) => (i, a)
-    } { case (i, a) => Id(i, a) }
+  final class Optics[D] {
+    def id[A]: Prism[Access[D, A], (IdAccess[D], A)] =
+      Prism.partial[Access[D, A], (IdAccess[D], A)] {
+        case Id(i, a) => (i, a)
+      } { case (i, a) => Id(i, a) }
 
-  def value[A]: Prism[Access[A], A] =
-    Prism.partial[Access[A], A] {
-      case Value(a) => a
-    } (Value(_))
+    def value[A]: Prism[Access[D, A], A] =
+      Prism.partial[Access[D, A], A] {
+        case Value(a) => a
+      } (Value(_))
 
-  def src[A]: Lens[Access[A], A] =
-    srcP[A, A]
+    def src[A]: Lens[Access[D, A], A] =
+      srcP[A, A]
 
-  def srcP[A, B]: PLens[Access[A], Access[B], A, B] =
-    PLens[Access[A], Access[B], A, B] {
-      case Id(_, a) => a
-      case Value(a) => a
-    } { b => {
-      case Id(i, _) => id(i, b)
-      case Value(_) => value(b)
-    }}
+    def srcP[A, B]: PLens[Access[D, A], Access[D, B], A, B] =
+      PLens[Access[D, A], Access[D, B], A, B] {
+        case Id(_, a) => a
+        case Value(a) => a
+      } { b => {
+        case Id(i, _) => id(i, b)
+        case Value(_) => value(b)
+      }}
+  }
+
+  object Optics {
+    def apply[D]: Optics[D] = new Optics[D]
+  }
 }
 
 sealed abstract class AccessInstances extends AccessInstances0 {
-  implicit val traverse1: Traverse1[Access] =
-    new Traverse1[Access] {
-      def traverse1Impl[G[_]: Apply, A, B](fa: Access[A])(f: A => G[B]) =
-        Access.srcP[A, B].modifyF(f)(fa)
+  implicit def traverse1[D]: Traverse1[Access[D, ?]] =
+    new Traverse1[Access[D, ?]] {
+      def traverse1Impl[G[_]: Apply, A, B](fa: Access[D, A])(f: A => G[B]) =
+        Access.Optics[D].srcP[A, B].modifyF(f)(fa)
 
-      def foldMapRight1[A, B](fa: Access[A])(z: A => B)(f: (A, => B) => B) =
-        z(Access.src[A] get fa)
+      def foldMapRight1[A, B](fa: Access[D, A])(z: A => B)(f: (A, => B) => B) =
+        z(Access.Optics[D].src[A] get fa)
     }
 
-  implicit def order[A: Order]: Order[Access[A]] =
+  implicit def order[D: Order, A: Order]: Order[Access[D, A]] =
     Order.orderBy(generic)
 
-  implicit def renderTree[A: Show]: RenderTree[Access[A]] =
+  implicit def renderTree[D: Show, A: Show]: RenderTree[Access[D, A]] =
     RenderTree.fromShowAsType("Access")
 
-  implicit def show[A: Show]: Show[Access[A]] =
+  implicit def show[D: Show, A: Show]: Show[Access[D, A]] =
     Show.shows {
       case Access.Id(i, a) => s"Id(${i.shows}, ${a.shows})"
       case Access.Value(a) => s"Value(${a.shows})"
@@ -90,9 +100,11 @@ sealed abstract class AccessInstances extends AccessInstances0 {
 }
 
 sealed abstract class AccessInstances0 {
-  implicit def equal[A: Equal]: Equal[Access[A]] =
+  implicit def equal[D: Equal, A: Equal]: Equal[Access[D, A]] =
     Equal.equalBy(generic)
 
-  protected def generic[A](a: Access[A]) =
-    (Access.id.getOption(a), Access.value.getOption(a))
+  protected def generic[D, A](a: Access[D, A]) = {
+    val O = Access.Optics[D]
+    (O.id.getOption(a), O.value.getOption(a))
+  }
 }

--- a/qsu/src/main/scala/quasar/qsu/ExpandShifts.scala
+++ b/qsu/src/main/scala/quasar/qsu/ExpandShifts.scala
@@ -87,7 +87,7 @@ final class ExpandShifts[T[_[_]]: BirecursiveT: EqualT: ShowT] extends QSUTTypes
 
   private val OriginalKey = "original"
   private val NamePrefix = "esh"
-  private val SrcVal = AccessLeftTarget[T](Access.value(_))
+  private val SrcVal = AccessLeftTarget[T](Access.Optics[T[EJson]].value(_))
   private val PrjOriginal = func.ProjectKeyS(func.Hole, OriginalKey)
 
   private def buildShift[G[_]: Monad: NameGenerator: RevIdxM: MonadPlannerErr: QAuthS](

--- a/qsu/src/main/scala/quasar/qsu/QProv.scala
+++ b/qsu/src/main/scala/quasar/qsu/QProv.scala
@@ -28,17 +28,17 @@ import matryoshka.implicits._
 import scalaz.{Lens => _, _}, Scalaz._, Tags.MaxVal
 
 final class QProv[T[_[_]]: BirecursiveT: EqualT]
-    extends Dimension[T[EJson], IdAccess, QProv.P[T]]
+    extends Dimension[T[EJson], IdAccess[T[EJson]], QProv.P[T]]
     with QSUTTypes[T] {
 
   import QProv.BucketsState
 
   type D     = T[EJson]
-  type I     = IdAccess
+  type I     = IdAccess[D]
   type PF[A] = QProv.PF[T, A]
   type P     = QProv.P[T]
 
-  val prov: Prov[D, I, P] = Prov[D, I, P]
+  val prov: Prov[D, I, P] = Prov[D, I, P](IdAccess.static)
 
   import prov.implicits._
 
@@ -63,7 +63,7 @@ final class QProv[T[_[_]]: BirecursiveT: EqualT]
           )) as s.nextIdx
         }
 
-        b = IdAccess.bucket(src, idx)
+        b = IdAccess.bucket[D](src, idx)
       } yield prov.value(b)
 
     case other =>
@@ -122,7 +122,7 @@ final class QProv[T[_[_]]: BirecursiveT: EqualT]
 }
 
 object QProv {
-  type PF[T[_[_]], A] = ProvF[T[EJson], IdAccess, A]
+  type PF[T[_[_]], A] = ProvF[T[EJson], IdAccess[T[EJson]], A]
   type P[T[_[_]]]     = T[PF[T, ?]]
 
   final case class BucketsState[I](nextIdx: SInt, buckets: I ==>> SInt)

--- a/qsu/src/main/scala/quasar/qsu/QSUGraph.scala
+++ b/qsu/src/main/scala/quasar/qsu/QSUGraph.scala
@@ -22,6 +22,7 @@ import quasar.common.effect.NameGenerator
 import quasar.contrib.iota._
 import quasar.contrib.scalaz._
 import quasar.contrib.scalaz.MonadState_
+import quasar.ejson.EJson
 import quasar.fp._
 import quasar.fp.ski.κ
 import quasar.qscript.{FreeMapA, OnUndefined, RecFreeMap}
@@ -484,14 +485,14 @@ object QSUGraph extends QSUGraphInstances {
     }
 
     object LeftShift {
-      def unapply[T[_[_]]](g: QSUGraph[T]): Option[(QSUGraph[T], RecFreeMap[T], IdStatus, OnUndefined, FreeMapA[T, QSU.ShiftTarget], QSU.Rotation)] = g.unfold match {
+      def unapply[T[_[_]]](g: QSUGraph[T]): Option[(QSUGraph[T], RecFreeMap[T], IdStatus, OnUndefined, FreeMapA[T, QSU.ShiftTarget[T[EJson]]], QSU.Rotation)] = g.unfold match {
         case g: QSU.LeftShift[T, QSUGraph[T]] => QSU.LeftShift.unapply(g)
         case _ => None
       }
     }
 
     object MultiLeftShift {
-      def unapply[T[_[_]]](g: QSUGraph[T]): Option[(QSUGraph[T], List[(FreeMap[T], IdStatus, QSU.Rotation)], OnUndefined, FreeMapA[T, Access[Hole] \/ Int])] = g.unfold match {
+      def unapply[T[_[_]]](g: QSUGraph[T]): Option[(QSUGraph[T], List[(FreeMap[T], IdStatus, QSU.Rotation)], OnUndefined, FreeMapA[T, Access[T[EJson], Hole] \/ Int])] = g.unfold match {
         case g: QSU.MultiLeftShift[T, QSUGraph[T]] => QSU.MultiLeftShift.unapply(g)
         case _ => None
       }

--- a/qsu/src/main/scala/quasar/qsu/QSUTTypes.scala
+++ b/qsu/src/main/scala/quasar/qsu/QSUTTypes.scala
@@ -19,12 +19,13 @@ package quasar.qsu
 import quasar.qscript.TTypes
 
 trait QSUTTypes[T[_[_]]] extends TTypes[T] {
+  type QAccess[A] = quasar.qsu.QAccess[T, A]
   type QAuth = quasar.qsu.QAuth[T]
   type QDims = quasar.qsu.QDims[T]
   type FreeAccess[A] = quasar.qsu.FreeAccess[T, A]
   type QSUGraph = quasar.qsu.QSUGraph[T]
   type RevIdx = quasar.qsu.QSUGraph.RevIdx[T]
   type RevIdxM[F[_]] = quasar.qsu.RevIdxM[T, F]
-  type References = quasar.qsu.References[T]
+  type References[A] = quasar.qsu.References[T, A]
   type QScriptUniform[A] = quasar.qsu.QScriptUniform[T, A]
 }

--- a/qsu/src/main/scala/quasar/qsu/QScriptUniform.scala
+++ b/qsu/src/main/scala/quasar/qsu/QScriptUniform.scala
@@ -234,7 +234,7 @@ object QScriptUniform {
   final case class QSAutoJoin[T[_[_]], A](
     left: A,
     right: A,
-    keys: JoinKeys[IdAccess],
+    keys: JoinKeys[IdAccess[T[EJson]]],
     combiner: JoinFunc[T]) extends QScriptUniform[T, A]
 
   final case class GroupBy[T[_[_]], A](
@@ -384,33 +384,33 @@ object QScriptUniform {
       Show.showFromToString
   }
 
-  sealed trait ShiftTarget extends Product with Serializable
+  sealed trait ShiftTarget[A] extends Product with Serializable
 
   object ShiftTarget {
-    case object LeftTarget extends ShiftTarget
-    case object RightTarget extends ShiftTarget
-    final case class AccessLeftTarget(access: Access[Hole]) extends ShiftTarget
+    final case class LeftTarget[A]() extends ShiftTarget[A]
+    final case class RightTarget[A]() extends ShiftTarget[A]
+    final case class AccessLeftTarget[A](access: Access[A, Hole]) extends ShiftTarget[A]
 
-    implicit val equalShiftTarget: Equal[ShiftTarget] = Equal.equal {
+    implicit def equalShiftTarget[A: Equal]: Equal[ShiftTarget[A]] = Equal.equal[ShiftTarget[A]] {
       case (AccessLeftTarget(access1), AccessLeftTarget(access2)) => access1 ≟ access2
-      case (LeftTarget, LeftTarget) => true
-      case (RightTarget, RightTarget) => true
+      case (LeftTarget(), LeftTarget()) => true
+      case (RightTarget(), RightTarget()) => true
       case _ => false
     }
 
-    implicit val showShiftTarget: Show[ShiftTarget] = Show.shows {
-      case LeftTarget => "LeftTarget"
-      case RightTarget => "RightTarget"
+    implicit def showShiftTarget[A: Show]: Show[ShiftTarget[A]] = Show.shows {
+      case LeftTarget() => "LeftTarget"
+      case RightTarget() => "RightTarget"
       case AccessLeftTarget(access) => s"AccessLeftTarget(${access.shows})"
     }
 
-    implicit val renderShiftTarget: RenderTree[ShiftTarget] = RenderTree.make {
-      case LeftTarget =>
+    implicit def renderShiftTarget[A: Show]: RenderTree[ShiftTarget[A]] = RenderTree.make {
+      case LeftTarget() =>
         RenderedTree("ShiftTarget" :: Nil, "LeftTarget".some, Nil)
-      case RightTarget =>
+      case RightTarget() =>
         RenderedTree("ShiftTarget" :: Nil, "RightTarget".some, Nil)
       case AccessLeftTarget(access) =>
-        RenderedTree("ShiftTarget" :: Nil, "AccessLeftTarget".some, RenderTree[Access[Hole]].render(access) :: Nil)
+        RenderedTree("ShiftTarget" :: Nil, "AccessLeftTarget".some, RenderTree[Access[A, Hole]].render(access) :: Nil)
     }
   }
 
@@ -420,7 +420,7 @@ object QScriptUniform {
       struct: RecFreeMap[T],
       idStatus: IdStatus,
       onUndefined: OnUndefined,
-      repair: FreeMapA[T, ShiftTarget],
+      repair: FreeMapA[T, ShiftTarget[T[EJson]]],
       rot: Rotation) extends QScriptUniform[T, A]
 
   // shifting multiple structs on the same source;
@@ -430,7 +430,7 @@ object QScriptUniform {
       // TODO: NEL
       shifts: List[(FreeMap[T], IdStatus, Rotation)],
       onUndefined: OnUndefined,
-      repair: FreeMapA[T, Access[Hole] \/ Int]) extends QScriptUniform[T, A]
+      repair: FreeMapA[T, QAccess[T, Hole] \/ Int]) extends QScriptUniform[T, A]
 
   // LPish
   final case class LPReduce[T[_[_]], A](
@@ -440,7 +440,7 @@ object QScriptUniform {
   // QScriptish
   final case class QSReduce[T[_[_]], A](
       source: A,
-      buckets: List[FreeMapA[T, Access[Hole]]],
+      buckets: List[FreeMapA[T, QAccess[T, Hole]]],
       // TODO: NEL
       reducers: List[ReduceFunc[FreeMap[T]]],
       repair: FreeMapA[T, ReduceIndex]) extends QScriptUniform[T, A]
@@ -455,7 +455,7 @@ object QScriptUniform {
   // QScriptish
   final case class QSSort[T[_[_]], A](
       source: A,
-      buckets: List[FreeMapA[T, Access[Hole]]],
+      buckets: List[FreeMapA[T, QAccess[T, Hole]]],
       order: NEL[(FreeMap[T], SortDir)]) extends QScriptUniform[T, A]
 
   final case class Union[T[_[_]], A](left: A, right: A) extends QScriptUniform[T, A]
@@ -510,13 +510,13 @@ object QScriptUniform {
         case JoinSideRef(s) => s
       } (JoinSideRef(_))
 
-    def leftShift[A]: Prism[QScriptUniform[A], (A, RecFreeMap, IdStatus, OnUndefined, FreeMapA[ShiftTarget], Rotation)] =
-      Prism.partial[QScriptUniform[A], (A, RecFreeMap, IdStatus, OnUndefined, FreeMapA[ShiftTarget], Rotation)] {
+    def leftShift[A]: Prism[QScriptUniform[A], (A, RecFreeMap, IdStatus, OnUndefined, FreeMapA[ShiftTarget[T[EJson]]], Rotation)] =
+      Prism.partial[QScriptUniform[A], (A, RecFreeMap, IdStatus, OnUndefined, FreeMapA[ShiftTarget[T[EJson]]], Rotation)] {
         case LeftShift(s, fm, ids, ou, jf, rot) => (s, fm, ids, ou, jf, rot)
       } { case (s, fm, ids, ou, jf, rot) => LeftShift(s, fm, ids, ou, jf, rot) }
 
-    def multiLeftShift[A]: Prism[QScriptUniform[A], (A, List[(FreeMap, IdStatus, Rotation)], OnUndefined, FreeMapA[Access[Hole] \/ Int])] =
-      Prism.partial[QScriptUniform[A], (A, List[(FreeMap, IdStatus, Rotation)], OnUndefined, FreeMapA[Access[Hole] \/ Int])] {
+    def multiLeftShift[A]: Prism[QScriptUniform[A], (A, List[(FreeMap, IdStatus, Rotation)], OnUndefined, FreeMapA[QAccess[Hole] \/ Int])] =
+      Prism.partial[QScriptUniform[A], (A, List[(FreeMap, IdStatus, Rotation)], OnUndefined, FreeMapA[QAccess[Hole] \/ Int])] {
         case MultiLeftShift(s, ss, ou, map) => (s, ss, ou, map)
       } { case (s, ss, ou, map) => MultiLeftShift(s, ss, ou, map) }
 
@@ -550,8 +550,8 @@ object QScriptUniform {
         case Map(a, fm) => (a, fm)
       } { case (a, fm) => Map(a, fm) }
 
-    def qsAutoJoin[A]: Prism[QScriptUniform[A], (A, A, JoinKeys[IdAccess], JoinFunc)] =
-      Prism.partial[QScriptUniform[A], (A, A, JoinKeys[IdAccess], JoinFunc)] {
+    def qsAutoJoin[A]: Prism[QScriptUniform[A], (A, A, JoinKeys[IdAccess[T[EJson]]], JoinFunc)] =
+      Prism.partial[QScriptUniform[A], (A, A, JoinKeys[IdAccess[T[EJson]]], JoinFunc)] {
         case QSAutoJoin(l, r, ks, c) => (l, r, ks, c)
       } { case (l, r, ks, c) => QSAutoJoin(l, r, ks, c) }
 
@@ -665,12 +665,12 @@ object QScriptUniform {
       composeLifting[G](O.joinSideRef[A])
     }
 
-    def leftShift: Prism[A, F[(A, RecFreeMap, IdStatus, OnUndefined, FreeMapA[ShiftTarget], Rotation)]] = {
-      composeLifting[(?, RecFreeMap, IdStatus, OnUndefined, FreeMapA[ShiftTarget], Rotation)](O.leftShift[A])
+    def leftShift: Prism[A, F[(A, RecFreeMap, IdStatus, OnUndefined, FreeMapA[ShiftTarget[T[EJson]]], Rotation)]] = {
+      composeLifting[(?, RecFreeMap, IdStatus, OnUndefined, FreeMapA[ShiftTarget[T[EJson]]], Rotation)](O.leftShift[A])
     }
 
-    def multiLeftShift: Prism[A, F[(A, List[(FreeMap, IdStatus, Rotation)], OnUndefined, FreeMapA[Access[Hole] \/ Int])]] = {
-      composeLifting[(?, List[(FreeMap, IdStatus, Rotation)], OnUndefined, FreeMapA[Access[Hole] \/ Int])](O.multiLeftShift[A])
+    def multiLeftShift: Prism[A, F[(A, List[(FreeMap, IdStatus, Rotation)], OnUndefined, FreeMapA[QAccess[Hole] \/ Int])]] = {
+      composeLifting[(?, List[(FreeMap, IdStatus, Rotation)], OnUndefined, FreeMapA[QAccess[Hole] \/ Int])](O.multiLeftShift[A])
     }
 
     def lpFilter: Prism[A, F[(A, A)]] = {
@@ -702,8 +702,8 @@ object QScriptUniform {
         case(src, f) => (src, RecFreeS.roll(mfc(f.as(recFunc.Hole))))
       })
 
-    def qsAutoJoin: Prism[A, F[(A, A, JoinKeys[IdAccess], JoinFunc)]] = {
-      type G[A] = (A, A, JoinKeys[IdAccess], JoinFunc)
+    def qsAutoJoin: Prism[A, F[(A, A, JoinKeys[IdAccess[T[EJson]]], JoinFunc)]] = {
+      type G[A] = (A, A, JoinKeys[IdAccess[T[EJson]]], JoinFunc)
       composeLifting[G](O.qsAutoJoin[A])
     }
 

--- a/qsu/src/main/scala/quasar/qsu/ReifyAutoJoins.scala
+++ b/qsu/src/main/scala/quasar/qsu/ReifyAutoJoins.scala
@@ -19,6 +19,7 @@ package quasar.qsu
 import slamdata.Predef._
 
 import quasar.common.effect.NameGenerator
+import quasar.ejson.EJson
 import quasar.ejson.implicits._
 import quasar.qscript.{
   construction,
@@ -65,7 +66,7 @@ final class ReifyAutoJoins[T[_[_]]: BirecursiveT: EqualT] private () extends QSU
     case g @ AutoJoin2(left, right, combiner) =>
       val (l, r) = (left.root, right.root)
 
-      val keys: F[JoinKeys[IdAccess]] =
+      val keys: F[JoinKeys[IdAccess[T[EJson]]]] =
         (auth.lookupDimsE[F](l) |@| auth.lookupDimsE[F](r))(prov.autojoinKeys(_, _))
 
       keys.map(ks =>
@@ -86,7 +87,7 @@ final class ReifyAutoJoins[T[_[_]]: BirecursiveT: EqualT] private () extends QSU
 
         case (joinName, lName, cName, ldims, cdims, rdims) =>
 
-          val lcKeys: JoinKeys[IdAccess] =
+          val lcKeys: JoinKeys[IdAccess[T[EJson]]] =
             prov.autojoinKeys(ldims, cdims)
 
           def lcCombiner: JoinFunc =
@@ -112,7 +113,7 @@ final class ReifyAutoJoins[T[_[_]]: BirecursiveT: EqualT] private () extends QSU
           val lcDims: QDims =
             prov.join(ldims, cdims)
 
-          val keys: JoinKeys[IdAccess] =
+          val keys: JoinKeys[IdAccess[T[EJson]]] =
             prov.autojoinKeys(lcDims, rdims)
 
           val lcName = Symbol(joinName)

--- a/qsu/src/main/scala/quasar/qsu/minimizers/MergeReductions.scala
+++ b/qsu/src/main/scala/quasar/qsu/minimizers/MergeReductions.scala
@@ -57,9 +57,9 @@ final class MergeReductions[T[_[_]]: BirecursiveT: EqualT: ShowT] private () ext
 
     case qgraph @ QSReduce(src, buckets, reducers, repair) =>
       def rebuild(src: QSUGraph, fm: FreeMap): G[QSUGraph] = {
-        def rewriteBucket(bucket: Access[Hole]): FreeMapA[Access[Hole]] = bucket match {
+        def rewriteBucket(bucket: QAccess[Hole]): FreeAccess[Hole] = bucket match {
           case v @ Access.Value(_) => fm.map(κ(v))
-          case other => Free.pure[MapFunc, Access[Hole]](other)
+          case other => Free.pure[MapFunc, QAccess[Hole]](other)
         }
 
         val buckets2 = buckets.map(_.flatMap(rewriteBucket))

--- a/qsu/src/main/scala/quasar/qsu/package.scala
+++ b/qsu/src/main/scala/quasar/qsu/package.scala
@@ -19,6 +19,7 @@ package quasar
 import slamdata.Predef.{Map => SMap, _}
 import quasar.common.effect.NameGenerator
 import quasar.contrib.scalaz.MonadState_
+import quasar.ejson.EJson
 import quasar.fp._
 import quasar.qscript._, PlannerError.InternalError
 import quasar.qscript.provenance.Dimensions
@@ -31,27 +32,28 @@ import scalaz.syntax.traverse._
 import scalaz.syntax.show._
 
 package object qsu {
-  type FreeAccess[T[_[_]], A] = FreeMapA[T, Access[A]]
+  type QAccess[T[_[_]], A] = Access[T[EJson], A]
+  type FreeAccess[T[_[_]], A] = FreeMapA[T, QAccess[T, A]]
   type QDims[T[_[_]]] = Dimensions[QProv.P[T]]
   type QSUVerts[T[_[_]]] = SMap[Symbol, QScriptUniform[T, Symbol]]
 
   type RevIdxM[T[_[_]], F[_]] = MonadState_[F, QSUGraph.RevIdx[T]]
   def RevIdxM[T[_[_]], F[_]](implicit ev: RevIdxM[T, F]): RevIdxM[T, F] = ev
 
-  def AccessHole[T[_[_]]]: FreeMapA[T, Access[Hole]] =
-    Free.pure(Access.value(SrcHole))
+  def AccessHole[T[_[_]]]: FreeMapA[T, QAccess[T, Hole]] =
+    Free.pure(Access.Optics[T[EJson]].value(SrcHole))
 
-  def LeftTarget[T[_[_]]]: FreeMapA[T, ShiftTarget] =
-    Free.pure(ShiftTarget.LeftTarget)
+  def LeftTarget[T[_[_]]]: FreeMapA[T, ShiftTarget[T[EJson]]] =
+    Free.pure(ShiftTarget.LeftTarget())
 
-  def RightTarget[T[_[_]]]: FreeMapA[T, ShiftTarget] =
-    Free.pure(ShiftTarget.RightTarget)
+  def RightTarget[T[_[_]]]: FreeMapA[T, ShiftTarget[T[EJson]]] =
+    Free.pure(ShiftTarget.RightTarget())
 
-  def AccessLeftTarget[T[_[_]]](f: Hole => Access[Hole]): FreeMapA[T, ShiftTarget] =
+  def AccessLeftTarget[T[_[_]]](f: Hole => QAccess[T, Hole]): FreeMapA[T, ShiftTarget[T[EJson]]] =
     Free.pure(ShiftTarget.AccessLeftTarget(f(SrcHole)))
 
   def AccessValueF[T[_[_]], A](a: A): FreeAccess[T, A] =
-    Free.pure[MapFunc[T, ?], Access[A]](Access.Value(a))
+    Free.pure[MapFunc[T, ?], QAccess[T, A]](Access.Value(a))
 
   def AccessValueHoleF[T[_[_]]]: FreeAccess[T, Hole] =
     AccessValueF[T, Hole](SrcHole)

--- a/qsu/src/test/scala/quasar/qsu/GraduateSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/GraduateSpec.scala
@@ -61,10 +61,12 @@ object GraduateSpec extends Qspec with QSUTTypes[Fix] {
 
   type QSU[A] = QScriptUniform[A]
   type QSE[A] = QScriptEducated[A]
+  type D = Fix[EJson]
 
   val researched = ReifyIdentities[Fix, F] _
   val grad = Graduate[Fix, F] _
 
+  val accO = Access.Optics[D]
   val qsu = QScriptUniform.DslT[Fix]
 
   val defaults = construction.mkDefaults[Fix, QSE]
@@ -107,7 +109,7 @@ object GraduateSpec extends Qspec with QSUTTypes[Fix] {
 
       "convert QSReduce" in {
         val buckets: List[FreeMap] = List(func.Add(HoleF, IntLit(17)))
-        val abuckets: List[FreeAccess[Hole]] = buckets.map(_.map(Access.value[Hole](_)))
+        val abuckets: List[FreeAccess[Hole]] = buckets.map(_.map(accO.value[Hole](_)))
         val reducers: List[ReduceFunc[FreeMap]] = List(ReduceFuncs.Count(HoleF))
         val repair: FreeMapA[ReduceIndex] = ReduceIndexF(\/-(0))
 
@@ -120,8 +122,8 @@ object GraduateSpec extends Qspec with QSUTTypes[Fix] {
       "convert LeftShift" in {
         val struct: RecFreeMap = recFunc.Add(recFunc.Hole, recFunc.Constant(Fixed[Fix[EJson]].int(17)))
 
-        val arepair: FreeMapA[QScriptUniform.ShiftTarget] = func.ConcatArrays(
-          func.MakeArray(AccessLeftTarget[Fix](Access.value(_))),
+        val arepair: FreeMapA[QScriptUniform.ShiftTarget[D]] = func.ConcatArrays(
+          func.MakeArray(AccessLeftTarget[Fix](accO.value(_))),
           func.ConcatArrays(
             LeftTarget[Fix],
             func.MakeArray(RightTarget[Fix])))
@@ -139,7 +141,7 @@ object GraduateSpec extends Qspec with QSUTTypes[Fix] {
 
       "convert QSSort" in {
         val buckets: List[FreeMap] = List(func.Add(HoleF, IntLit(17)))
-        val abuckets: List[FreeAccess[Hole]] = buckets.map(_.map(Access.value[Hole](_)))
+        val abuckets: List[FreeAccess[Hole]] = buckets.map(_.map(accO.value[Hole](_)))
         val order: NEL[(FreeMap, SortDir)] = NEL(HoleF -> SortDir.Descending)
 
         val qgraph: Fix[QSU] = qsu.qsSort(qsu.read(afile, ExcludeId), abuckets, order)
@@ -180,7 +182,7 @@ object GraduateSpec extends Qspec with QSUTTypes[Fix] {
     "graduate naive `select * from zips`" in {
       val aconcatArr =
         func.ConcatArrays(
-          func.MakeArray(AccessLeftTarget[Fix](Access.value(_))),
+          func.MakeArray(AccessLeftTarget[Fix](accO.value(_))),
           func.MakeArray(RightTarget[Fix]))
       val concatArr =
         func.ConcatArrays(

--- a/qsu/src/test/scala/quasar/qsu/MinimizeAutoJoinsSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/MinimizeAutoJoinsSpec.scala
@@ -72,7 +72,9 @@ object MinimizeAutoJoinsSpec
   val qprov = QProv[Fix]
 
   type J = Fix[EJson]
-  val J = Fixed[Fix[EJson]]
+  val J = Fixed[J]
+
+  val accO = Access.Optics[J]
 
   val afile = Path.rootDir[Sandboxed] </> Path.file("afile")
   val afile2 = Path.rootDir[Sandboxed] </> Path.file("afile2")
@@ -621,7 +623,7 @@ object MinimizeAutoJoinsSpec
           repair must beTreeEqual(
             func.StaticMapS(
               "0" -> RightTarget[Fix],
-              "1" -> AccessLeftTarget[Fix](Access.value(_))))
+              "1" -> AccessLeftTarget[Fix](accO.value(_))))
 
           fm must beTreeEqual(
             recFunc.Add(
@@ -660,7 +662,7 @@ object MinimizeAutoJoinsSpec
           repair must beTreeEqual(
             func.StaticMapS(
               "1" -> RightTarget[Fix],
-              "0" -> AccessLeftTarget[Fix](Access.value(_))))
+              "0" -> AccessLeftTarget[Fix](accO.value(_))))
 
           fm must beTreeEqual(
             recFunc.Add(
@@ -711,7 +713,7 @@ object MinimizeAutoJoinsSpec
         repairInner must beTreeEqual(
           func.StaticMapS(
             "0" -> RightTarget[Fix],
-            "1" -> AccessLeftTarget[Fix](Access.value(_))))
+            "1" -> AccessLeftTarget[Fix](accO.value(_))))
 
         h1 must beTreeEqual(func.ProjectKeyS(func.Hole, "0"))
         h2 must beTreeEqual(func.ProjectKeyS(func.Hole, "1"))
@@ -770,7 +772,7 @@ object MinimizeAutoJoinsSpec
         repairInner must beTreeEqual(
           func.StaticMapS(
             "0" -> RightTarget[Fix],
-            "1" -> AccessLeftTarget[Fix](Access.value(_))))
+            "1" -> AccessLeftTarget[Fix](accO.value(_))))
 
         h1 must beTreeEqual(func.ProjectKeyS(func.Hole, "0"))
         h2 must beTreeEqual(func.ProjectKeyS(func.Hole, "1"))
@@ -829,7 +831,7 @@ object MinimizeAutoJoinsSpec
 
           repairInner must beTreeEqual(
             func.StaticMapS(
-              "original" -> AccessLeftTarget[Fix](Access.value(_)),
+              "original" -> AccessLeftTarget[Fix](accO.value(_)),
               "results" -> RightTarget[Fix]))
 
           structOuter must beTreeEqual(
@@ -841,7 +843,7 @@ object MinimizeAutoJoinsSpec
                 RightTarget[Fix],
               "1" ->
                 func.ProjectKeyS(
-                  AccessLeftTarget[Fix](Access.value(_)),
+                  AccessLeftTarget[Fix](accO.value(_)),
                   "original")))
 
           fm must beTreeEqual(
@@ -905,7 +907,7 @@ object MinimizeAutoJoinsSpec
 
           repairInnerInner must beTreeEqual(
             func.StaticMapS(
-              "original" -> AccessLeftTarget[Fix](Access.value(_)),
+              "original" -> AccessLeftTarget[Fix](accO.value(_)),
               "results" -> RightTarget[Fix]))
 
           structInner must beTreeEqual(
@@ -913,7 +915,7 @@ object MinimizeAutoJoinsSpec
 
           repairInner must beTreeEqual(
             func.StaticMapS(
-              "original" -> func.ProjectKeyS(AccessLeftTarget[Fix](Access.value(_)), "original"),
+              "original" -> func.ProjectKeyS(AccessLeftTarget[Fix](accO.value(_)), "original"),
               "results" -> RightTarget[Fix]))
 
           structOuter must beTreeEqual(recFunc.ProjectKeyS(recFunc.Hole, "results"))
@@ -924,7 +926,7 @@ object MinimizeAutoJoinsSpec
                 RightTarget[Fix],
               "1" ->
                 func.ProjectKeyS(
-                  AccessLeftTarget[Fix](Access.value(_)),
+                  AccessLeftTarget[Fix](accO.value(_)),
                   "original")))
 
           fm must beTreeEqual(
@@ -986,9 +988,9 @@ object MinimizeAutoJoinsSpec
           innerRepair must beTreeEqual(
             func.StaticMapS(
               "left" ->
-                Free.pure[MapFunc, Access[Hole] \/ Int](0.right),
+                Free.pure[MapFunc, QAccess[Hole] \/ Int](0.right),
               "right" ->
-                func.MakeMapS("0", Free.pure[MapFunc, Access[Hole] \/ Int](1.right))))
+                func.MakeMapS("0", Free.pure[MapFunc, QAccess[Hole] \/ Int](1.right))))
 
           outerStruct must beTreeEqual(recFunc.ProjectKeyS(recFunc.Hole, "left"))
 
@@ -996,7 +998,7 @@ object MinimizeAutoJoinsSpec
             func.ConcatMaps(
               func.MakeMapS("1", RightTarget[Fix]),
               func.ProjectKeyS(
-                AccessLeftTarget[Fix](Access.value(_)),
+                AccessLeftTarget[Fix](accO.value(_)),
                 "right")))
 
           fm must beTreeEqual(
@@ -1097,11 +1099,11 @@ object MinimizeAutoJoinsSpec
             "results" -> func.StaticMapS(
               "left" -> func.StaticMapS(
                 "left" ->
-                  Free.pure[MapFunc, Access[Hole] \/ Int](0.right),
+                  Free.pure[MapFunc, QAccess[Hole] \/ Int](0.right),
                 "right" ->
-                  func.MakeMapS("2", Free.pure[MapFunc, Access[Hole] \/ Int](1.right))),
+                  func.MakeMapS("2", Free.pure[MapFunc, QAccess[Hole] \/ Int](1.right))),
               "right" ->
-                Free.pure[MapFunc, Access[Hole] \/ Int](2.right))))
+                Free.pure[MapFunc, QAccess[Hole] \/ Int](2.right))))
 
         outerastruct must beTreeEqual(
           func.ProjectKeyS(
@@ -1122,7 +1124,7 @@ object MinimizeAutoJoinsSpec
                 "left" -> func.ConcatMaps(
                   func.MakeMapS(
                     "3",
-                    Free.pure[MapFunc, Access[Hole] \/ Int](0.right)),
+                    Free.pure[MapFunc, QAccess[Hole] \/ Int](0.right)),
                   func.ProjectKeyS(
                     func.ProjectKeyS(
                       func.ProjectKeyS(
@@ -1130,14 +1132,14 @@ object MinimizeAutoJoinsSpec
                         "results"),
                       "left"),
                     "right")),
-                "right" -> Free.pure[MapFunc, Access[Hole] \/ Int](1.right))))
+                "right" -> Free.pure[MapFunc, QAccess[Hole] \/ Int](1.right))))
 
         singleRepair must beTreeEqual(
           func.ConcatMaps(
             func.ConcatMaps(
               func.ProjectKeyS(
                 func.ProjectKeyS(
-                  AccessLeftTarget[Fix](Access.value(_)),
+                  AccessLeftTarget[Fix](accO.value(_)),
                   "results"),
                 "left"),
               func.MakeMapS(
@@ -1146,7 +1148,7 @@ object MinimizeAutoJoinsSpec
             func.MakeMapS(
               "1",
               func.ProjectKeyS(
-                AccessLeftTarget[Fix](Access.value(_)),
+                AccessLeftTarget[Fix](accO.value(_)),
                 "original"))))
 
         singleStruct must beTreeEqual(
@@ -1231,7 +1233,7 @@ object MinimizeAutoJoinsSpec
           innerRepair must beTreeEqual(
             func.StaticMapS(
               "original" ->
-                AccessLeftTarget[Fix](Access.value(_)),
+                AccessLeftTarget[Fix](accO.value(_)),
               "results" ->
                 RightTarget[Fix]))
 
@@ -1243,7 +1245,7 @@ object MinimizeAutoJoinsSpec
                 RightTarget[Fix],
               "0" ->
                 func.ProjectKeyS(
-                  AccessLeftTarget[Fix](Access.value(_)),
+                  AccessLeftTarget[Fix](accO.value(_)),
                   "original")))
 
           fm must beTreeEqual(
@@ -1382,7 +1384,7 @@ object MinimizeAutoJoinsSpec
           innerRepair must beTreeEqual(
             func.StaticMapS(
               "original" ->
-                AccessLeftTarget[Fix](Access.value(_)),
+                AccessLeftTarget[Fix](accO.value(_)),
               "results" ->
                 RightTarget[Fix]))
 
@@ -1394,7 +1396,7 @@ object MinimizeAutoJoinsSpec
               "1" ->
                 RightTarget[Fix],
               "0" ->
-                func.ProjectKeyS(AccessLeftTarget[Fix](Access.value(_)), "original")))
+                func.ProjectKeyS(AccessLeftTarget[Fix](accO.value(_)), "original")))
 
           fm must beTreeEqual(
             recFunc.Add(
@@ -1457,11 +1459,11 @@ object MinimizeAutoJoinsSpec
           innerRepair must beTreeEqual(
             func.StaticMapS(
               "left" ->
-                Free.pure[MapFunc, Access[Hole] \/ Int](0.right),
+                Free.pure[MapFunc, QAccess[Hole] \/ Int](0.right),
               "right" ->
                 func.StaticMapS(
                   "0" ->
-                    Free.pure[MapFunc, Access[Hole] \/ Int](1.right))))
+                    Free.pure[MapFunc, QAccess[Hole] \/ Int](1.right))))
 
           outerStruct must beTreeEqual(
             recFunc.ProjectKeyS(recFunc.ProjectKeyS(recFunc.Hole, "left"), "c"))
@@ -1470,7 +1472,7 @@ object MinimizeAutoJoinsSpec
             func.ConcatMaps(
               func.MakeMapS("1", RightTarget[Fix]),
               func.ProjectKeyS(
-                AccessLeftTarget[Fix](Access.value(_)),
+                AccessLeftTarget[Fix](accO.value(_)),
                 "right")))
 
           fm must beTreeEqual(
@@ -1662,10 +1664,10 @@ object MinimizeAutoJoinsSpec
 
           repair must beTreeEqual(
             func.ConcatMaps(
-              func.StaticMapS("1" -> 0.right[Access[Hole]].pure[FreeMapA]),
+              func.StaticMapS("1" -> 0.right[QAccess[Hole]].pure[FreeMapA]),
               func.StaticMapS(
-                "0" -> func.ProjectIndexI(1.right[Access[Hole]].pure[FreeMapA], 0),
-                "2" -> func.ProjectIndexI(1.right[Access[Hole]].pure[FreeMapA], 1))))
+                "0" -> func.ProjectIndexI(1.right[QAccess[Hole]].pure[FreeMapA], 0),
+                "2" -> func.ProjectIndexI(1.right[QAccess[Hole]].pure[FreeMapA], 1))))
 
           outerMap must beTreeEqual(
             recFunc.StaticMapS(
@@ -1709,7 +1711,7 @@ object MinimizeAutoJoinsSpec
           repair must beTreeEqual(
             func.StaticMapS(
               "0" -> RightTarget[Fix],
-              "1" -> AccessLeftTarget[Fix](Access.value(_))))
+              "1" -> AccessLeftTarget[Fix](accO.value(_))))
           outerMap must beTreeEqual(
             recFunc.StaticMapS(
               "left" -> recFunc.Typecheck(
@@ -1888,7 +1890,7 @@ object MinimizeAutoJoinsSpec
           func.ConcatMaps(
             func.ConcatMaps(
               func.ProjectKeyS(
-                func.ProjectKeyS(AccessLeftTarget[Fix](Access.value(_)), "left"),
+                func.ProjectKeyS(AccessLeftTarget[Fix](accO.value(_)), "left"),
                 "left"),
               func.MakeMapS(
                 "1",

--- a/qsu/src/test/scala/quasar/qsu/ReifyBucketsSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/ReifyBucketsSpec.scala
@@ -22,10 +22,10 @@ import quasar.{Qspec, TreeMatchers}
 import quasar.IdStatus.ExcludeId
 import quasar.ejson.{EJson, Fixed}
 import quasar.ejson.implicits._
-import quasar.contrib.iota.{copkEqual, copkTraverse}
+import quasar.contrib.iota.{copkEqual, copkShow, copkTraverse}
 import quasar.qscript.{construction, Hole, MapFuncsCore, PlannerError, ReduceFuncs, SrcHole}
 
-import matryoshka.{delayEqual, Embed}
+import matryoshka.{delayEqual, showTShow, Embed}
 import matryoshka.data.Fix
 import matryoshka.data.{freeEqual, freeRecursive}
 import matryoshka.patterns.CoEnv
@@ -36,6 +36,7 @@ object ReifyBucketsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
   import QScriptUniform.{DTrans, Retain, Rotation}
 
   val J = Fixed[Fix[EJson]]
+  val accO = Access.Optics[Fix[EJson]]
   val qsu = QScriptUniform.DslT[Fix]
   val func = construction.Func[Fix]
   val recFunc = construction.RecFunc[Fix]
@@ -60,7 +61,7 @@ object ReifyBucketsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
           ReduceFuncs.Sum(()))
 
       val expBucket =
-        func.ProjectKeyS(func.Hole, "state") map (Access.value[Hole](_))
+        func.ProjectKeyS(func.Hole, "state") map (accO.value[Hole](_))
 
       val expReducer =
         func.ProjectKeyS(func.Hole, "pop")
@@ -89,7 +90,7 @@ object ReifyBucketsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
           ReduceFuncs.Sum(()))
 
       val expB =
-        func.Constant[Access[Hole]](J.int(7))
+        func.Constant[QAccess[Hole]](J.int(7))
 
       val expReducer =
         func.ProjectKeyS(func.Hole, "pop")
@@ -165,13 +166,13 @@ object ReifyBucketsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
           _(MapFuncsCore.ConcatMaps(_, _))))
 
       val expArbBucket =
-        func.ProjectKeyS(func.Hole, "city") map (Access.value[Hole](_))
+        func.ProjectKeyS(func.Hole, "city") map (accO.value[Hole](_))
 
       val expArbExpr =
         func.ProjectKeyS(func.Hole, "city")
 
       val expSumBucket =
-        func.ProjectKeyS(func.ProjectKeyS(func.Hole, "grouped"), "city") map (Access.value[Hole](_))
+        func.ProjectKeyS(func.ProjectKeyS(func.Hole, "grouped"), "city") map (accO.value[Hole](_))
 
       val expSumExpr =
         func.ProjectKeyS(func.Hole, "reduce_expr_0")
@@ -251,13 +252,13 @@ object ReifyBucketsSpec extends Qspec with QSUTTypes[Fix] with TreeMatchers {
           _(MapFuncsCore.ConcatMaps(_, _))))
 
       val expArbBucket =
-        func.ProjectKeyS(func.Hole, "city") map (Access.value[Hole](_))
+        func.ProjectKeyS(func.Hole, "city") map (accO.value[Hole](_))
 
       val expArbExpr =
         func.ProjectKeyS(func.Hole, "city")
 
       val expSumBucket =
-        func.ProjectKeyS(func.ProjectKeyS(func.Hole, "grouped"), "city") map (Access.value[Hole](_))
+        func.ProjectKeyS(func.ProjectKeyS(func.Hole, "grouped"), "city") map (accO.value[Hole](_))
 
       val expSumExpr =
         func.ProjectKeyS(func.ProjectKeyS(func.Hole, "reduce_expr_0"), "quux")

--- a/qsu/src/test/scala/quasar/qsu/ResolveOwnIdentitiesSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/ResolveOwnIdentitiesSpec.scala
@@ -23,7 +23,7 @@ import quasar.IdStatus.{ExcludeId, IdOnly, IncludeId}
 import quasar.contrib.pathy.AFile
 import quasar.ejson.EJson
 import quasar.ejson.implicits._
-import quasar.contrib.iota.{copkEqual, copkTraverse}
+import quasar.contrib.iota.{copkEqual, copkShow, copkTraverse}
 import quasar.fp.ski.κ
 import quasar.qscript.{construction, Hole, OnUndefined, SrcHole}
 
@@ -39,6 +39,7 @@ object ResolveOwnIdentitiesSpec extends Qspec with QSUTTypes[Fix] with TreeMatch
 
   type J = Fix[EJson]
 
+  val accO = Access.Optics[J]
   val qsu = QScriptUniform.AnnotatedDsl[Fix, Symbol]
   val func = construction.Func[Fix]
   val recFunc = construction.RecFunc[Fix]
@@ -53,7 +54,7 @@ object ResolveOwnIdentitiesSpec extends Qspec with QSUTTypes[Fix] with TreeMatch
         val renamedRep = rep map {
           case ShiftTarget.AccessLeftTarget(access) =>
             val renamedAccess =
-              Access.id[Hole]
+              accO.id[Hole]
                 .composeLens(_1)
                 .composePrism(IdAccess.identity)
                 .modify(rns)
@@ -67,8 +68,8 @@ object ResolveOwnIdentitiesSpec extends Qspec with QSUTTypes[Fix] with TreeMatch
     }
 
   "resolving own left shift identity" should {
-    val ownAccess: Access[Hole] =
-      Access.id[Hole](IdAccess.identity('ls), SrcHole)
+    val ownAccess: QAccess[Hole] =
+      accO.id[Hole](IdAccess.identity[J]('ls), SrcHole)
 
     val initialRepair =
       func.ConcatArrays(


### PR DESCRIPTION
* Flattens sequences prior to computing autojoin conditions so that flatten and shift are treated identically
* Introduces static identities to be able to represent autojoining an inflation with a projection in the join conditions