### PR TITLE
more scalar stages tests

### DIFF
--- a/frontend/src/test/scala/quasar/ScalarStageSpec.scala
+++ b/frontend/src/test/scala/quasar/ScalarStageSpec.scala
@@ -1650,6 +1650,131 @@ object ScalarStageSpec {
 
 	input must interpretInto(stages)(expected)
       }
+
+      "foc-21 Pivot . Pivot (IncludeId)" in {
+        val input = ldjson("""
+          { "x": [12], "y": { "z": false } }
+          """)
+
+        val expected = ldjson("""
+	  [0, "x"]
+	  [1, [12]]
+	  [0, "y"]
+          [1, { "z": false}]
+          """)
+
+        val stages = List(
+          Pivot(IdStatus.IncludeId, ColumnType.Object),
+          Pivot(IdStatus.IncludeId, ColumnType.Array))
+
+        input must interpretInto(stages)(expected)
+      }
+
+      "foc-22 Pivot . Wrap (IncludeId)" in {
+        val input = ldjson("""
+          { "x": [12], "y": { "z": false } }
+          """)
+
+        val expected = ldjson("""
+          { "foo": ["x", [12]] }
+          { "foo": ["y", { "z": false}] }
+          """)
+
+        val stages = List(
+          Pivot(IdStatus.IncludeId, ColumnType.Object),
+	  Wrap("foo"))
+
+        input must interpretInto(stages)(expected)
+      }
+
+      "foc-23 Pivot . Mask (IncludeId)" in {
+        val input = ldjson("""
+          { "x": [12], "y": { "z": false } }
+          """)
+
+        val expected = ldjson("""
+          ["x"]
+          ["y", { "z": false}]
+          """)
+
+        val stages = List(
+          Pivot(IdStatus.IncludeId, ColumnType.Object),
+          Mask(Map(
+            CPath.parse("[0]") -> ColumnType.Top,
+            CPath.parse("[1]") -> Set(ColumnType.Object))))
+
+        input must interpretInto(stages)(expected)
+      }
+
+      "foc-24 Pivot . Project (IncludeId)" in {
+        val input = ldjson("""
+          { "x": [12], "y": { "z": false } }
+          """)
+
+        val stages = List(
+          Pivot(IdStatus.IncludeId, ColumnType.Object),
+	  Project(CPath.parse("k")))
+
+        input must interpretInto(stages)(ldjson(""))
+      }
+
+      "foc-25 Pivot . Pivot (IdOnly)" in {
+        val input = ldjson("""
+          { "x": [12], "y": { "z": false } }
+          """)
+
+        val stages = List(
+          Pivot(IdStatus.IdOnly, ColumnType.Object),
+          Pivot(IdStatus.IncludeId, ColumnType.Array))
+
+        input must interpretInto(stages)(ldjson(""))
+      }
+
+      "foc-26 Pivot . Wrap (IdOnly)" in {
+        val input = ldjson("""
+          { "x": [12], "y": { "z": false } }
+          """)
+
+        val expected = ldjson("""
+          { "foo": "x" }
+          { "foo": "y" }
+          """)
+
+        val stages = List(
+          Pivot(IdStatus.IdOnly, ColumnType.Object),
+	  Wrap("foo"))
+
+        input must interpretInto(stages)(expected)
+      }
+
+      "foc-27 Pivot . Mask (IdOnly)" in {
+        val input = ldjson("""
+          { "x": [12], "y": { "z": false } }
+          """)
+
+        val expected = ldjson("""
+          "x"
+          "y"
+          """)
+
+        val stages = List(
+          Pivot(IdStatus.IdOnly, ColumnType.Object),
+          Mask(Map(CPath.parse(".") -> Set(ColumnType.String))))
+
+        input must interpretInto(stages)(expected)
+      }
+
+      "foc-28 Pivot . Project (IdOnly)" in {
+        val input = ldjson("""
+          { "x": [12], "y": { "z": false } }
+          """)
+
+        val stages = List(
+          Pivot(IdStatus.IdOnly, ColumnType.Object),
+	  Project(CPath.parse("k")))
+
+        input must interpretInto(stages)(ldjson(""))
+      }
     }
 
     override def is: SpecStructure =

--- a/frontend/src/test/scala/quasar/ScalarStageSpec.scala
+++ b/frontend/src/test/scala/quasar/ScalarStageSpec.scala
@@ -1132,6 +1132,76 @@ object ScalarStageSpec {
         input must pivotInto(IdStatus.ExcludeId, ColumnType.Array)(ldjson(""))
         input must pivotInto(IdStatus.ExcludeId, ColumnType.Object)(ldjson(""))
       }
+
+      "omit undefined row in object pivot" >> {
+        val input = ldjson("""
+          { "a": 1 }
+          12
+          { "b": 2 }
+          """)
+
+        "pivot-12 ExcludeId" in {
+          val expected = ldjson("""
+            1
+            2
+            """)
+
+          input must pivotInto(IdStatus.ExcludeId, ColumnType.Object)(expected)
+        }
+
+        "pivot-13 IdOnly" in {
+          val expected = ldjson("""
+            "a"
+            "b"
+            """)
+
+          input must pivotInto(IdStatus.IdOnly, ColumnType.Object)(expected)
+        }
+
+        "pivot-14 IncludeId" in {
+          val expected = ldjson("""
+            ["a", 1]
+            ["b", 2]
+            """)
+
+          input must pivotInto(IdStatus.IncludeId, ColumnType.Object)(expected)
+        }
+      }
+
+      "omit undefined row in array pivot" >> {
+        val input = ldjson("""
+          [11]
+          12
+          [13]
+          """)
+
+        "pivot-15 ExcludeId" in {
+          val expected = ldjson("""
+            11
+            13
+            """)
+
+          input must pivotInto(IdStatus.ExcludeId, ColumnType.Array)(expected)
+        }
+
+        "pivot-16 IdOnly" in {
+          val expected = ldjson("""
+            0
+            0
+            """)
+
+          input must pivotInto(IdStatus.IdOnly, ColumnType.Array)(expected)
+        }
+
+        "pivot-17 IncludeId" in {
+          val expected = ldjson("""
+            [0, 11]
+            [0, 13]
+            """)
+
+          input must pivotInto(IdStatus.IncludeId, ColumnType.Array)(expected)
+        }
+      }
     }
 
     override def is: SpecStructure =

--- a/frontend/src/test/scala/quasar/ScalarStageSpec.scala
+++ b/frontend/src/test/scala/quasar/ScalarStageSpec.scala
@@ -2157,6 +2157,28 @@ object ScalarStageSpec {
 
         input must cartesianInto(targets)(expected)
       }
+
+      // a0 as a1, b0 as b1
+      "cart-11 cross fields when some are undefined" in {
+        val input = ldjson("""
+            { "a0": 1 }
+            { "a0": 2, "b0": "foo" }
+            { "b0": "bar" }
+            { "c": 12 }
+            """)
+
+        val expected = ldjson("""
+            { "a1": 1 }
+            { "a1": 2, "b1": "foo" }
+            { "b1": "bar" }
+            """)
+
+        val targets = Map(
+          (CPathField("a1"), (CPathField("a0"), Nil)),
+          (CPathField("b1"), (CPathField("b0"), Nil)))
+
+        input must cartesianInto(targets)(expected)
+      }
     }
 
     override def is: SpecStructure =

--- a/frontend/src/test/scala/quasar/ScalarStageSpec.scala
+++ b/frontend/src/test/scala/quasar/ScalarStageSpec.scala
@@ -1041,57 +1041,6 @@ object ScalarStageSpec {
         }
       }
 
-      "pivot-9 omit results when object pivoting a value of a different kind" in {
-        val input = ldjson("""
-          1
-          "three"
-          false
-          null
-          ["x", true, {}, []]
-          { "a": 1, "b": "two", "c": {}, "d": [] }
-          """)
-
-        val expected = ldjson("""
-          1
-          "two"
-          {}
-          []
-        """)
-
-        input must pivotInto(IdStatus.ExcludeId, ColumnType.Object)(expected)
-      }
-
-      "pivot-10 omit results when array pivoting a value of a different kind" in {
-        val input = ldjson("""
-          1
-          "two"
-          false
-          null
-          ["x", true, {}, []]
-          { "a": 1, "b": "two", "c": {}, "d": [] }
-          """)
-
-        val expected = ldjson("""
-          "x"
-          true
-          {}
-          []
-        """)
-
-        input must pivotInto(IdStatus.ExcludeId, ColumnType.Array)(expected)
-      }
-
-      "pivot-11 omit empty vector from pivot results" in {
-
-        val input = ldjson("""
-          {}
-          []
-        """)
-
-        input must pivotInto(IdStatus.ExcludeId, ColumnType.Array)(ldjson(""))
-        input must pivotInto(IdStatus.ExcludeId, ColumnType.Object)(ldjson(""))
-      }
-
       "omit undefined row in object pivot" >> {
         val input = ldjson("""
           { "a": 1 }
@@ -1259,6 +1208,116 @@ object ScalarStageSpec {
           """)
 
           input must pivotInto(IdStatus.IncludeId, ColumnType.Object)(expected)
+        }
+      }
+
+      "omit results when object pivoting a value of a different kind" >> {
+        val input = ldjson("""
+          1
+          "three"
+          false
+          null
+          ["x", true, {}, []]
+          { "a": 1, "b": "two", "c": {}, "d": [] }
+          """)
+
+        "pivot-24 ExcludeId" in {
+          val expected = ldjson("""
+            1
+            "two"
+            {}
+            []
+          """)
+
+          input must pivotInto(IdStatus.ExcludeId, ColumnType.Object)(expected)
+        }
+
+        "pivot-25 IdOnly" in {
+          val expected = ldjson("""
+            "a"
+            "b"
+            "c"
+            "d"
+          """)
+
+          input must pivotInto(IdStatus.IdOnly, ColumnType.Object)(expected)
+        }
+
+        "pivot-26 IncludeId" in {
+          val expected = ldjson("""
+            ["a", 1]
+            ["b", "two"]
+            ["c", {}]
+            ["d", []]
+          """)
+
+          input must pivotInto(IdStatus.IncludeId, ColumnType.Object)(expected)
+        }
+      }
+
+      "pivot-10 omit results when array pivoting a value of a different kind" >> {
+        val input = ldjson("""
+          1
+          "two"
+          false
+          null
+          ["x", true, {}, []]
+          { "a": 1, "b": "two", "c": {}, "d": [] }
+          """)
+
+        "pivot-27 ExcludeId" in {
+          val expected = ldjson("""
+            "x"
+            true
+            {}
+            []
+          """)
+
+          input must pivotInto(IdStatus.ExcludeId, ColumnType.Array)(expected)
+        }
+
+        "pivot-28 IdOnly" in {
+          val expected = ldjson("""
+            0
+            1
+            2
+            3
+          """)
+
+          input must pivotInto(IdStatus.IdOnly, ColumnType.Array)(expected)
+        }
+
+        "pivot-29 IncludeId" in {
+          val expected = ldjson("""
+            [0, "x"]
+            [1, true]
+            [2, {}]
+            [3, []]
+          """)
+
+          input must pivotInto(IdStatus.IncludeId, ColumnType.Array)(expected)
+        }
+      }
+
+      "omit empty vector from pivot results" >> {
+        val input = ldjson("""
+          {}
+          []
+        """)
+
+        "pivot-30 ExcludeId" in {
+          input must pivotInto(IdStatus.ExcludeId, ColumnType.Array)(ldjson(""))
+          input must pivotInto(IdStatus.ExcludeId, ColumnType.Object)(ldjson(""))
+        }
+
+        "pivot-31 IdOnly" in {
+          input must pivotInto(IdStatus.IdOnly, ColumnType.Array)(ldjson(""))
+          input must pivotInto(IdStatus.IdOnly, ColumnType.Object)(ldjson(""))
+        }
+
+        "pivot-32 IncludeId" in {
+          input must pivotInto(IdStatus.IncludeId, ColumnType.Array)(ldjson(""))
+          input must pivotInto(IdStatus.IncludeId, ColumnType.Object)(ldjson(""))
         }
       }
     }

--- a/frontend/src/test/scala/quasar/ScalarStageSpec.scala
+++ b/frontend/src/test/scala/quasar/ScalarStageSpec.scala
@@ -1041,47 +1041,6 @@ object ScalarStageSpec {
         }
       }
 
-      "pivot-7 preserve empty arrays as values of an array pivot" in {
-        val input = ldjson("""
-          [ 1, "two", [] ]
-          [ [] ]
-          [ [], 3, "four" ]
-          """)
-
-        val expected = ldjson("""
-          1
-          "two"
-          []
-          []
-          []
-          3
-          "four"
-        """)
-
-        input must pivotInto(IdStatus.ExcludeId, ColumnType.Array)(expected)
-      }
-
-      "pivot-8 preserve empty objects as values of an object pivot" in {
-        val input = ldjson("""
-          { "1": 1, "2": "two", "3": {} }
-          { "4": {} }
-          { "5": {}, "6": 3, "7": "four" }
-          """)
-
-        val expected = ldjson("""
-          1
-          "two"
-          {}
-          {}
-          {}
-          3
-          "four"
-        """)
-
-        input must pivotInto(IdStatus.ExcludeId, ColumnType.Object)(expected)
-      }
-
-
       "pivot-9 omit results when object pivoting a value of a different kind" in {
         val input = ldjson("""
           1
@@ -1200,6 +1159,106 @@ object ScalarStageSpec {
             """)
 
           input must pivotInto(IdStatus.IncludeId, ColumnType.Array)(expected)
+        }
+      }
+
+      "preserve empty arrays as values of an array pivot" >> {
+        val input = ldjson("""
+          [ 1, "two", [] ]
+          [ [] ]
+          [ [], 3, "four" ]
+          """)
+
+        "pivot-18 ExludeId" in {
+          val expected = ldjson("""
+            1
+            "two"
+            []
+            []
+            []
+            3
+            "four"
+          """)
+
+          input must pivotInto(IdStatus.ExcludeId, ColumnType.Array)(expected)
+        }
+
+        "pivot-19 IdOnly" in {
+          val expected = ldjson("""
+            0
+            1
+            2
+            0
+            0
+            1
+            2
+          """)
+
+          input must pivotInto(IdStatus.IdOnly, ColumnType.Array)(expected)
+        }
+
+        "pivot-20 IncludeId" in {
+          val expected = ldjson("""
+            [0, 1]
+            [1, "two"]
+            [2, []]
+            [0, []]
+            [0, []]
+            [1, 3]
+            [2, "four"]
+          """)
+
+          input must pivotInto(IdStatus.IncludeId, ColumnType.Array)(expected)
+        }
+      }
+
+      "preserve empty objects as values of an object pivot" >> {
+        val input = ldjson("""
+          { "1": 1, "2": "two", "3": {} }
+          { "4": {} }
+          { "5": {}, "6": 3, "7": "four" }
+          """)
+
+       "pivot-21 ExcludeId" in {
+          val expected = ldjson("""
+            1
+            "two"
+            {}
+            {}
+            {}
+            3
+            "four"
+          """)
+
+          input must pivotInto(IdStatus.ExcludeId, ColumnType.Object)(expected)
+        }
+
+       "pivot-22 IdOnly" in {
+          val expected = ldjson("""
+            "1"
+            "2"
+            "3"
+            "4"
+            "5"
+            "6"
+            "7"
+          """)
+
+          input must pivotInto(IdStatus.IdOnly, ColumnType.Object)(expected)
+        }
+
+       "pivot-23 IncludeId" in {
+          val expected = ldjson("""
+            ["1", 1]
+            ["2", "two"]
+            ["3", {}]
+            ["4", {}]
+            ["5", {}]
+            ["6", 3]
+            ["7", "four"]
+          """)
+
+          input must pivotInto(IdStatus.IncludeId, ColumnType.Object)(expected)
         }
       }
     }


### PR DESCRIPTION
Adds new tests, as well as all three `IdStatus` cases for all the `Pivot`-only tests.