### PR TITLE
Prepare for aggregated resource querying

### DIFF
--- a/impl/src/main/scala/quasar/impl/datasources/SimpleCompositeResourceSchema.scala
+++ b/impl/src/main/scala/quasar/impl/datasources/SimpleCompositeResourceSchema.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.impl.datasources
+
+import slamdata.Predef._
+
+import quasar.api.resource.ResourcePath
+import quasar.connector.{MonadResourceErr, QueryResult}
+import quasar.ejson.EJson
+import quasar.impl.datasource.CompositeResult
+import quasar.impl.parsing.ResourceParser
+import quasar.impl.schema._
+import quasar.sst.SST
+
+import scala.concurrent.duration.FiniteDuration
+import scala.util.{Left, Right}
+
+import cats.effect.{Concurrent, Timer}
+
+import matryoshka.{Corecursive, Recursive}
+
+import qdata.QDataEncode
+
+import scalaz.Order
+
+import spire.algebra.Field
+import spire.math.ConvertableTo
+
+// Adapted from CompositeResourceSchema. The difference is that SimpleCompositeSchema
+// does not return a schema of form { "source": String, "value": <child component> } but simply
+// returns the schema as obtained from child component
+final class SimpleCompositeResourceSchema[
+    F[_]: Concurrent: MonadResourceErr,
+    J: Order,
+    N: ConvertableTo: Field: Order] private (
+    evalConfig: SstEvalConfig)(
+    implicit
+    timer: Timer[F],
+    JC: Corecursive.Aux[J, EJson],
+    JR: Recursive.Aux[J, EJson])
+  extends ResourceSchema[F, SstConfig[J, N], (ResourcePath, CompositeResult[F, QueryResult[F]])] {
+
+  import SimpleCompositeResourceSchema.ComponentSampleFactor
+
+  private val sstResourceSchema = SstResourceSchema[F, J, N](evalConfig)
+
+  def apply(
+      sstConfig: SstConfig[J, N],
+      resource: (ResourcePath, CompositeResult[F, QueryResult[F]]),
+      timeLimit: FiniteDuration)
+      : F[Option[sstConfig.Schema]] = {
+
+    type S = SST[J, N]
+
+    implicit val sstQDataEncode: QDataEncode[S] =
+      QDataCompressedSst.encode[J, N](sstConfig)
+
+    // Max number of rows to sample from each component of the aggregate
+    val componentSampleSize =
+      (evalConfig.sampleSize.value * ComponentSampleFactor).toLong
+
+    // Number of component streams to open concurrently, assumed not to be
+    // compute bound
+    val readParallelism = evalConfig.parallelism.value.toInt * 2
+
+    val ssts = resource match {
+      case (rp, Left(qr)) =>
+        ResourceParser[F, S](rp, qr)
+
+      case (_, Right(components)) =>
+        val compSsts =
+          components map { case (rp, qr) =>
+            ResourceParser[F, S](rp, qr)
+              .take(componentSampleSize)
+          }
+
+        compSsts.parJoin(readParallelism)
+    }
+
+    sstResourceSchema(sstConfig, ssts, timeLimit)
+  }
+}
+
+object SimpleCompositeResourceSchema {
+  // Each component of the aggregate will be sampled this factor of the total
+  // sample size.
+  val ComponentSampleFactor: Double = 0.1
+
+  def apply[
+      F[_]: Concurrent: MonadResourceErr,
+      J: Order,
+      N: ConvertableTo: Field: Order](
+      evalConfig: SstEvalConfig)(
+      implicit
+      timer: Timer[F],
+      JC: Corecursive.Aux[J, EJson],
+      JR: Recursive.Aux[J, EJson])
+      : ResourceSchema[F, SstConfig[J, N], (ResourcePath, CompositeResult[F, QueryResult[F]])] =
+    new SimpleCompositeResourceSchema[F, J, N](evalConfig)
+}

--- a/impl/src/test/scala/quasar/impl/datasources/SimpleCompositeResourceSchemaSpec.scala
+++ b/impl/src/test/scala/quasar/impl/datasources/SimpleCompositeResourceSchemaSpec.scala
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.impl.datasources
+
+import slamdata.Predef._
+
+import quasar.{IdStatus, ScalarStages}
+import quasar.api.resource.{ResourceName, ResourcePath}
+import quasar.common.data.RValue
+import quasar.connector.{CompressionScheme, ParsableType, QueryResult, ResourceError}
+import quasar.connector.ParsableType.JsonVariant
+import quasar.contrib.iota._
+import quasar.contrib.matryoshka.envT
+import quasar.contrib.scalaz.MonadError_
+import quasar.ejson.EJson
+import quasar.ejson.implicits._
+import quasar.impl.datasource.CompositeResult
+import quasar.impl.schema._
+import quasar.sst._
+import quasar.sst.StructuralType.TypeST
+import quasar.tpe._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.util.Left
+
+import java.lang.IllegalArgumentException
+import java.nio.charset.Charset
+
+import cats.effect.{IO, Timer}
+
+import eu.timepit.refined.auto._
+
+import fs2.{gzip, Pure, Stream}
+
+import matryoshka._
+import matryoshka.data.Fix
+import matryoshka.implicits._
+
+import qdata.QDataDecode
+
+import scalaz.std.anyVal._
+import scalaz.std.option._
+
+import shims.{eqToScalaz => _, orderToScalaz => _, _}
+
+import spire.std.double._
+
+object SimpleCompositeResourceSchemaSpec extends quasar.EffectfulQSpec[IO] {
+
+  implicit val ioResourceErrorME: MonadError_[IO, ResourceError] =
+    MonadError_.facet[IO](ResourceError.throwableP)
+
+  implicit val ioTimer: Timer[IO] =
+    IO.timer(global)
+
+  val defaultCfg = SstConfig.Default[Fix[EJson], Double]
+
+  val path: ResourcePath =
+    ResourcePath.root() / ResourceName("data")
+
+  val BoolsData: List[Boolean] =
+    List(true, true, false, true, false)
+
+  val sst = envT(
+    TypeStat.bool(3.0, 2.0),
+    TypeST(TypeF.simple[Fix[EJson], SST[Fix[EJson], Double]](SimpleType.Bool))).embed
+
+  val schema = SstSchema.fromSampled(100.0, sst)
+
+  val parsedResult: QueryResult[IO] =
+    QueryResult.parsed(
+      QDataDecode[RValue],
+      Stream.emits(BoolsData.map(RValue.rBoolean(_))),
+      ScalarStages.Id)
+
+  val unparsedResult: QueryResult.Unparsed[IO] =
+    QueryResult.typed(
+      ParsableType.Json(JsonVariant.LineDelimited, false),
+      Stream.emits(BoolsData.mkString("\n").getBytes(Charset.forName("UTF-8"))),
+      ScalarStages.Id)
+
+  val resourceSchema: ResourceSchema[IO, SstConfig[Fix[EJson], Double], (ResourcePath, CompositeResult[IO, QueryResult[IO]])] =
+    SimpleCompositeResourceSchema[IO, Fix[EJson], Double](SstEvalConfig(20L, 1L, 100L))
+
+  "computes an SST of parsed data" >>* {
+    resourceSchema(defaultCfg, (path, Left(parsedResult)), 1.hour) map { qsst =>
+      qsst must_= Some(schema)
+    }
+  }
+
+  "computes an SST of unparsed data" >>* {
+    resourceSchema(defaultCfg, (path, Left(unparsedResult)), 1.hour) map { qsst =>
+      qsst must_= Some(schema)
+    }
+  }
+
+  "computes an SST of gzipped data" >>* {
+    val gzippedResult =
+      QueryResult.compressed(
+        CompressionScheme.Gzip,
+        unparsedResult.modifyBytes(_ through gzip.compress(50)))
+
+    resourceSchema(defaultCfg, (path, Left(gzippedResult)), 1.hour) map { qsst =>
+      qsst must_= Some(schema)
+    }
+  }
+
+  "computes an SST from aggregated results" >>* {
+    val as = Stream(true, true).repeat
+    val bs = Stream(true, false).repeat
+    val cs = Stream(false)
+
+    def boolResult(bs: Stream[Pure, Boolean]) =
+      QueryResult.parsed(
+        QDataDecode[RValue],
+        bs.map(RValue.rBoolean(_)).covary[IO],
+        ScalarStages.Id)
+
+    val agg = Stream(
+      (ResourcePath.root() / ResourceName("a")) -> boolResult(as),
+      (ResourcePath.root() / ResourceName("b")) -> boolResult(bs),
+      (ResourcePath.root() / ResourceName("c")) -> boolResult(cs))
+
+    resourceSchema(defaultCfg, (path, Right(agg.covary[IO])), 1.hour) map { qsst =>
+      qsst must_= Some(SstSchema.fromSampled(100, sst))
+    }
+  }
+
+  "emits parser errors as ResourceError" >>* {
+    val badResult =
+      QueryResult.typed[IO](
+        ParsableType.Json(JsonVariant.LineDelimited, false),
+        Stream.emits("""{ "foo": sdlfkj""".getBytes(Charset.forName("UTF-8"))),
+        ScalarStages.Id)
+
+    val qsst = resourceSchema(defaultCfg, (path, Left(badResult)), 1.hour)
+
+    MonadError_[IO, ResourceError].attempt(qsst) map { r =>
+      r must be_-\/.like {
+        case ResourceError.MalformedResource(p, expect, _, _) =>
+          p must_= path
+          expect must_=== "ldjson"
+      }
+    }
+  }
+
+  "error when stages modifies input" >>* {
+    val withInstrs =
+      QueryResult.stages.set(ScalarStages(IdStatus.IncludeId, List()))(parsedResult)
+
+    resourceSchema(defaultCfg, (path, Left(withInstrs)), 1.hour)
+      .attempt
+      .map(_ must beLeft(beAnInstanceOf[IllegalArgumentException]))
+  }
+
+  "halts computation after time limit" >> todo
+}


### PR DESCRIPTION
Support for aggregated resource querying that does not return `source`. The child query results are simply concatenated.

Local datasource now excludes hidden files as resources. Otherwise .DS_Store prevents local datasource from working with aggregated resource querying.

[ch4298]