### PR TITLE
Fixes for datagen

### DIFF
--- a/datagen/src/main/scala/quasar/datagen/Main.scala
+++ b/datagen/src/main/scala/quasar/datagen/Main.scala
@@ -105,7 +105,7 @@ object Main extends IOApp {
       printError(s"SST file not found: ${notFound.getFile}.")
 
     case other =>
-      printError(other.getMessage)
+      IO(other.printStackTrace(Console.err)).as(ExitCode.Error)
   }
 
   def printError(msg: String): IO[ExitCode] =

--- a/datagen/src/main/scala/quasar/datagen/generate.scala
+++ b/datagen/src/main/scala/quasar/datagen/generate.scala
@@ -24,7 +24,6 @@ import cats.effect.Sync
 import fs2.Stream
 import matryoshka.{Corecursive, Recursive}
 import scalaz.{\/, Equal, Order}
-import scalaz.Scalaz._
 import spire.algebra.{Field, IsReal, NRoot}
 import spire.math.ConvertableFrom
 import spire.random.{Gaussian, Generator}


### PR DESCRIPTION
Fixes for a couple issues in `datagen` uncovered by attempting to generate data from a real-world SST.

Also adds some rudimentary parallelism to help reduce generation time for large datasets.

[ch6234]