### PR TITLE
Don't ask...

### DIFF
--- a/common/src/main/scala/quasar/common/data/RValue.scala
+++ b/common/src/main/scala/quasar/common/data/RValue.scala
@@ -708,7 +708,7 @@ final case class CNum(value: BigDecimal) extends CNumericValue[BigDecimal] {
 }
 
 final case object CNum extends CNumericType[BigDecimal] {
-  val bigDecimalOrder: scalaz.Order[BigDecimal] =
+  def bigDecimalOrder: scalaz.Order[BigDecimal] =
     scalaz.Order.order((x, y) => Ordering.fromInt(x compare y))
 
   val classTag: ClassTag[BigDecimal] = implicitly[ClassTag[BigDecimal]]


### PR DESCRIPTION
I'm actually not even certain how the JDBM3 stuff in mimir was working *at all* on `CNum` columns without this change. `scalaz.Order` is not `Serializable`, and `CNum` can appear in `ColumnRef`, which in turn appears in `RowFormat`, which in turn appears in `SortingKeyComparator`, which is set as the comparator on a JDBM3 `TreeMap`, which in turn serializes its comparator, key, and value serializer instances.