### PR TITLE
Introduce destination-related abstractions

### DIFF
--- a/api/src/main/scala/quasar/api/destination/DestinationError.scala
+++ b/api/src/main/scala/quasar/api/destination/DestinationError.scala
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.api.destination
+
+import slamdata.Predef._
+
+import monocle.Prism
+import scalaz.std.string._
+import scalaz.syntax.equal._
+import scalaz.syntax.show._
+import scalaz.{Cord, Equal, ISet, NonEmptyList, Show}
+
+sealed trait DestinationError[+I, +C] extends Product with Serializable
+
+object DestinationError {
+  sealed trait CreateError[+C] extends DestinationError[Nothing, C]
+  final case class DestinationUnsupported(kind: DestinationType, supported: ISet[DestinationType])
+      extends CreateError[Nothing]
+  final case class DestinationNameExists(name: DestinationName)
+      extends CreateError[Nothing]
+
+  sealed trait InitializationError[+C] extends CreateError[C]
+  final case class MalformedConfiguration[C](kind: DestinationType, config: C, reason: String)
+      extends InitializationError[C]
+  final case class InvalidConfiguration[C](kind: DestinationType, config: C, reasons: NonEmptyList[String])
+      extends InitializationError[C]
+  final case class ConnectionFailed[C](kind: DestinationType, config: C, cause: Exception)
+      extends InitializationError[C]
+  final case class AccessDenied[C](kind: DestinationType, config: C, reason: String)
+      extends InitializationError[C]
+
+  sealed trait ExistentialError[+I] extends DestinationError[I, Nothing]
+  final case class DestinationNotFound[I](destinationId: I)
+      extends ExistentialError[I]
+
+  def destinationUnsupported[E >: CreateError[Nothing] <: DestinationError[_, _]]
+      : Prism[E, (DestinationType, ISet[DestinationType])] =
+    Prism.partial[E, (DestinationType, ISet[DestinationType])] {
+      case DestinationUnsupported(k, s) => (k, s)
+    } (DestinationUnsupported.tupled)
+
+  def destinationNameExists[E >: CreateError[Nothing] <: DestinationError[_, _]]
+      : Prism[E, DestinationName] =
+    Prism.partial[E, DestinationName] {
+      case DestinationNameExists(n) => n
+    } (DestinationNameExists(_))
+
+  def malformedConfiguration[C, E >: InitializationError[C] <: DestinationError[_, C]]
+      : Prism[E, (DestinationType, C, String)] =
+    Prism.partial[E, (DestinationType, C, String)] {
+      case MalformedConfiguration(d, c, r) => (d, c, r)
+    } ((MalformedConfiguration[C] _).tupled)
+
+  def invalidConfiguration[C, E >: InitializationError[C] <: DestinationError[_, C]]
+      : Prism[E, (DestinationType, C, NonEmptyList[String])] =
+    Prism.partial[E, (DestinationType, C, NonEmptyList[String])] {
+      case InvalidConfiguration(d, c, rs) => (d, c, rs)
+    } ((InvalidConfiguration[C] _).tupled)
+
+  def connectionFailed[C, E >: InitializationError[C] <: DestinationError[_, C]]
+      : Prism[E, (DestinationType, C, Exception)] =
+    Prism.partial[E, (DestinationType, C, Exception)] {
+      case ConnectionFailed(d, c, e) => (d, c, e)
+    } ((ConnectionFailed[C] _).tupled)
+
+  def accessDenied[C, E >: InitializationError[C] <: DestinationError[_, C]]
+      : Prism[E, (DestinationType, C, String)] =
+    Prism.partial[E, (DestinationType, C, String)] {
+      case AccessDenied(d, c, e) => (d, c, e)
+    } ((AccessDenied[C] _).tupled)
+
+  def destinationNotFound[I, E >: ExistentialError[I] <: DestinationError[I, _]]
+      : Prism[E, I] =
+    Prism.partial[E, I] {
+      case DestinationNotFound(i) => i
+    } (DestinationNotFound[I](_))
+
+  implicit def equalCreateError[C: Equal]: Equal[CreateError[C]] =
+    Equal.equal {
+      case (DestinationUnsupported(k1, s1), DestinationUnsupported(k2, s2)) =>
+        k1 === k2 && s1 === s2
+      case (DestinationNameExists(n1), DestinationNameExists(n2)) =>
+        n1 === n2
+      case _ =>
+        false
+    }
+
+  implicit def equalInitializationError[C: Equal]: Equal[InitializationError[C]] =
+    Equal.equal {
+      case (MalformedConfiguration(k1, c1, r1), MalformedConfiguration(k2, c2, r2)) =>
+        k1 === k2 && c1 === c2 && r1 === r2
+      case (InvalidConfiguration(k1, c1, rs1), InvalidConfiguration(k2, c2, rs2)) =>
+        k1 === k2 && c1 === c2 && rs1 === rs2
+      case (ConnectionFailed(k1, c1, _), ConnectionFailed(k2, c2, _)) =>
+        // ignore exceptions
+        k1 === k2 && c1 === c2
+      case (AccessDenied(k1, c1, r1), AccessDenied(k2, c2, r2)) =>
+        k1 === k2 && c1 === c2 && r1 === r2
+      case _ =>
+        false
+    }
+
+  implicit def equalExistentialError[I: Equal]: Equal[ExistentialError[I]] =
+    Equal.equal {
+      case (DestinationNotFound(i1), DestinationNotFound(i2)) =>
+        i1 === i2
+      case _ =>
+        false
+    }
+
+  implicit def equal[I: Equal, C: Equal]: Equal[DestinationError[I, C]] =
+    Equal.equal {
+      case (e1: CreateError[C], e2: CreateError[C]) =>
+        (e1, e2) match {
+          case (e1: InitializationError[C], e2: InitializationError[C]) =>
+            Equal[InitializationError[C]].equal(e1, e2)
+          case (e1: CreateError[C], e2: CreateError[C]) =>
+            Equal[CreateError[C]].equal(e1, e2)
+        }
+      case (e1: ExistentialError[I], e2: ExistentialError[I]) =>
+        Equal[ExistentialError[I]].equal(e1, e2)
+      case _ => false
+    }
+
+  implicit def showCreateError[C: Show]: Show[CreateError[C]] =
+    Show.show {
+      case e: InitializationError[C] =>
+        Show[InitializationError[C]].show(e)
+
+      case DestinationUnsupported(kind, supported) =>
+        Cord("DestinationUnsupported(") ++ kind.show ++ Cord(", ") ++ supported.show ++ Cord(")")
+
+      case DestinationNameExists(name) =>
+        Cord("DestinationNameExists(") ++ name.show ++ Cord(")")
+    }
+
+  implicit def showInitializationError[C: Show]: Show[InitializationError[C]] =
+    Show.show {
+      case MalformedConfiguration(kind, config, reason) =>
+        Cord("MalformedConfiguration(") ++ kind.show ++ Cord(", ") ++ config.show ++ Cord(", ") ++ Cord(reason) ++ Cord(")")
+
+      case InvalidConfiguration(kind, config, reasons) =>
+        Cord("InvalidConfiguration(") ++ kind.show ++ Cord(", ") ++ config.show ++ Cord(", ") ++ reasons.show ++ Cord(")")
+
+      case ConnectionFailed(kind, config, ex) =>
+        Cord("ConnectionFailed(") ++ kind.show ++ Cord(", ") ++ config.show ++ Cord(s")\n$ex")
+
+      case AccessDenied(kind, config, reason) =>
+        Cord("AccessDenied(") ++ kind.show ++ Cord(", ") ++ config.show ++ Cord(", ") ++ reason.show ++ Cord(")")
+    }
+
+  implicit def showExistentialError[I: Show]: Show[ExistentialError[I]] =
+    Show.show {
+      case DestinationNotFound(id) =>
+        Cord("DestinationNotFound(") ++ id.show ++ Cord(")")
+    }
+
+  implicit def show[I: Show, C: Show]: Show[DestinationError[I, C]] =
+    Show.show {
+      case e: CreateError[C] => e match {
+        case e: InitializationError[C] =>
+          Show[InitializationError[C]].show(e)
+        case e =>
+          Show[CreateError[C]].show(e)
+      }
+      case e: ExistentialError[I] => e match {
+        case DestinationNotFound(id) =>
+          Cord("DestinationNotFound(") ++ id.show ++ Cord(")")
+      }
+    }
+}

--- a/api/src/main/scala/quasar/api/destination/DestinationMeta.scala
+++ b/api/src/main/scala/quasar/api/destination/DestinationMeta.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.api.destination
+
+import slamdata.Predef.{Exception, Option}
+import quasar.Condition
+
+import monocle.macros.Lenses
+import scalaz.{Cord, Show}
+import scalaz.syntax.show._
+
+@Lenses
+final case class DestinationMeta(
+    kind: DestinationType,
+    name: DestinationName,
+    status: Condition[Exception])
+
+object DestinationMeta extends DestinationMetaInstances {
+  def fromOption(
+      kind: DestinationType,
+      name: DestinationName,
+      optErr: Option[Exception])
+      : DestinationMeta =
+    DestinationMeta(kind, name, Condition.optionIso.reverseGet(optErr))
+}
+
+sealed abstract class DestinationMetaInstances {
+  implicit val show: Show[DestinationMeta] = {
+    implicit val exShow: Show[Exception] =
+      Show.shows(_.getMessage)
+
+    Show.show {
+      case DestinationMeta(n, k, s) =>
+        Cord("DestinationMeta(") ++ k.show ++ Cord(", ") ++ n.show ++ Cord(", ") ++ s.show ++ Cord(")")
+    }
+  }
+}

--- a/api/src/main/scala/quasar/api/destination/DestinationName.scala
+++ b/api/src/main/scala/quasar/api/destination/DestinationName.scala
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package quasar.api.datasource
+package quasar.api.destination
 
 import slamdata.Predef.String
 
-import scalaz.{Order, Show}
+import scalaz.{Equal, Order, Show}
 import scalaz.std.string._
 
 final case class DestinationName(value: String)
@@ -26,6 +26,9 @@ final case class DestinationName(value: String)
 object DestinationName extends DestinationNameInstances
 
 sealed abstract class DestinationNameInstances {
+  implicit val equal: Equal[DestinationName] =
+    Equal.equalBy(_.value)
+
   implicit val order: Order[DestinationName] =
     Order.orderBy(_.value)
 

--- a/api/src/main/scala/quasar/api/destination/DestinationRef.scala
+++ b/api/src/main/scala/quasar/api/destination/DestinationRef.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package quasar.api.datasource
+package quasar.api.destination
 
 import monocle.PLens
 import monocle.macros.Lenses

--- a/api/src/main/scala/quasar/api/destination/DestinationType.scala
+++ b/api/src/main/scala/quasar/api/destination/DestinationType.scala
@@ -14,28 +14,42 @@
  * limitations under the License.
  */
 
-package quasar.api.datasource
+package quasar.api.destination
+
+import slamdata.Predef.{None, Some, String}
 
 import quasar.contrib.refined._
 import quasar.fp.numeric.Positive
+import quasar.fp.ski.κ
 
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.refineV
 import eu.timepit.refined.scalaz._
+import eu.timepit.refined.string.MatchesRegex
+import monocle.Prism
 import monocle.macros.Lenses
-import scalaz.{Cord, Order, Show}
 import scalaz.std.anyVal._
 import scalaz.std.string._
 import scalaz.std.tuple._
 import scalaz.syntax.show._
+import scalaz.{Cord, Equal, Order, Show}
+import shapeless.{Witness => W}
 
 @Lenses
 final case class DestinationType(name: DestinationType.Name, version: Positive, minSupportedVersion: Positive)
 
 object DestinationType extends DestinationTypeInstances {
-  type Name = datasource.Name
-  type NameP = datasource.NameP
+  type NameP = MatchesRegex[W.`"[a-zA-Z0-9-]+"`.T]
+  type Name = String Refined NameP
+
+  def stringName = Prism[String, Name](
+    refineV[NameP](_).fold(κ(None), Some(_)))(_.value)
 }
 
 sealed abstract class DestinationTypeInstances {
+  implicit val equal: Equal[DestinationType] =
+    Equal.equalBy(t => (t.name, t.version, t.minSupportedVersion))
+
   implicit val order: Order[DestinationType] =
     Order.orderBy(t => (t.name, t.version, t.minSupportedVersion))
 

--- a/api/src/main/scala/quasar/api/destination/Destinations.scala
+++ b/api/src/main/scala/quasar/api/destination/Destinations.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.api.destination
+
+import slamdata.Predef.Exception
+import quasar.Condition
+
+import scalaz.{\/, ISet}
+
+/** @tparam F effects
+  * @tparam G multiple results
+  * @tparam I identity
+  * @tparam C configuration
+  */
+trait Destinations[F[_], G[_], I, C] {
+  import DestinationError._
+
+  /** Adds the destination described by the given `DestinationRef` to
+    * the set of destinations, returning its identifier or an error if
+    * it could not be added.
+    */
+  def addDestination(ref: DestinationRef[C]): F[CreateError[C] \/ I]
+
+  /** Metadata for all destinations. */
+  def allDestinationMetadata: F[G[(I, DestinationMeta)]]
+
+  /** Returns the reference to the specified destination, or an error if
+    * it doesn't exist.
+    */
+  def destinationRef(destinationId: I): F[ExistentialError[I] \/ DestinationRef[C]]
+
+  /** Returns the status of the specified destination or an error if it doesn't
+    * exist.
+    */
+  def destinationStatus(destinationId: I): F[ExistentialError[I] \/ Condition[Exception]]
+
+  def removeDestination(destinationId: I): F[Condition[ExistentialError[I]]]
+
+  /** Replaces the reference to the specified destination. */
+  def replaceDestination(destinationId: I, ref: DestinationRef[C])
+      : F[Condition[DestinationError[I, C]]]
+
+  /** The set of supported destination types. */
+  def supportedDestinationTypes: F[ISet[DestinationType]]
+}

--- a/connector/src/main/scala/quasar/connector/Destination.scala
+++ b/connector/src/main/scala/quasar/connector/Destination.scala
@@ -16,7 +16,7 @@
 
 package quasar.connector
 
-import quasar.api.datasource.DestinationType
+import quasar.api.destination.DestinationType
 
 import scalaz.NonEmptyList
 

--- a/connector/src/main/scala/quasar/connector/DestinationModule.scala
+++ b/connector/src/main/scala/quasar/connector/DestinationModule.scala
@@ -16,8 +16,8 @@
 
 package quasar.connector
 
-import quasar.api.datasource.DatasourceError.InitializationError
-import quasar.api.datasource.DestinationType
+import quasar.api.destination.DestinationError.InitializationError
+import quasar.api.destination.DestinationType
 
 import argonaut.Json
 import cats.effect.{ConcurrentEffect, ContextShift, Resource, Timer}
@@ -25,6 +25,8 @@ import scalaz.\/
 
 trait DestinationModule {
   def destinationType: DestinationType
+
+  def sanitizeDestinationConfig(config: Json): Json
 
   def destination[F[_]: ConcurrentEffect: ContextShift: MonadResourceErr: Timer](
     config: Json)

--- a/impl/src/main/scala/quasar/impl/IncompatibleDatasourceException.scala
+++ b/impl/src/main/scala/quasar/impl/IncompatibleDatasourceException.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.impl
+
+import slamdata.Predef._
+
+import quasar.api.datasource.DatasourceType
+import quasar.api.destination.DestinationType
+
+import cats.ApplicativeError
+import scalaz.syntax.either._
+import scalaz.{\/, -\/, \/-}
+
+final case class IncompatibleModuleException(kind: DatasourceType \/ DestinationType) extends java.lang.RuntimeException {
+  override def getMessage = kind match {
+    case -\/(k) => s"Loaded datasource implementation with type $k is incompatible with quasar"
+    case \/-(k) => s"Loaded destination implementation with type $k is incompatible with quasar"
+  }
+}
+
+object IncompatibleModuleException {
+  def datasource(kind: DatasourceType): IncompatibleModuleException =
+    IncompatibleModuleException(kind.left)
+
+  def destination(kind: DestinationType): IncompatibleModuleException =
+    IncompatibleModuleException(kind.right)
+
+  def linkDatasource[F[_]: ApplicativeError[?[_], Throwable], A](kind: DatasourceType, fa: => F[A]): F[A] =
+    link(datasource(kind), fa)
+
+  def linkDestination[F[_]: ApplicativeError[?[_], Throwable], A](kind: DestinationType, fa: => F[A]): F[A] =
+    link(destination(kind), fa)
+
+  private def link[F[_]: ApplicativeError[?[_], Throwable], A](ex: IncompatibleModuleException, fa: => F[A]): F[A] =
+    try {
+      fa
+    } catch {
+      case _: java.lang.LinkageError => ApplicativeError[F, Throwable].raiseError(ex)
+    }
+
+}

--- a/impl/src/main/scala/quasar/impl/datasource/local/LocalDatasourceModule.scala
+++ b/impl/src/main/scala/quasar/impl/datasource/local/LocalDatasourceModule.scala
@@ -42,8 +42,9 @@ object LocalDatasourceModule extends LightweightDatasourceModule with LocalDesti
       implicit ec: ExecutionContext)
       : F[InitializationError[Json] \/ Disposable[F, DS[F]]] = {
     val ds = for {
-      lc <- attemptConfig[F, LocalConfig](config, "Failed to decode LocalDatasource config: ")
-      root <- validatePath(lc.rootDir, config, "Invalid path: ")
+      lc <- attemptConfig[F, LocalConfig, InitializationError[Json]](
+        config, "Failed to decode LocalDatasource config: ")((c, d) => malformedConfiguration((LocalType, c, d)))
+      root <- validatePath(lc.rootDir, config, "Invalid path: ")((c, d) => malformedConfiguration((LocalType, c, d)))
     } yield LocalDatasource[F](root, lc.readChunkSizeBytes, blockingPool).point[Disposable[F, ?]]
 
     ds.run

--- a/impl/src/main/scala/quasar/impl/datasource/local/LocalParsedDatasourceModule.scala
+++ b/impl/src/main/scala/quasar/impl/datasource/local/LocalParsedDatasourceModule.scala
@@ -43,8 +43,9 @@ object LocalParsedDatasourceModule extends LightweightDatasourceModule with Loca
       implicit ec: ExecutionContext)
       : F[InitializationError[Json] \/ Disposable[F, DS[F]]] = {
     val ds = for {
-      lc <- attemptConfig[F, LocalConfig](config, "Failed to decode LocalDatasource config: ")
-      root <- validatePath(lc.rootDir, config, "Invalid path: ")
+      lc <- attemptConfig[F, LocalConfig, InitializationError[Json]](
+        config, "Failed to decode LocalDatasource config: ")((c, d) => malformedConfiguration((LocalType, c, d)))
+      root <- validatePath(lc.rootDir, config, "Invalid path: ")((c, d) => malformedConfiguration((LocalType, c, d)))
     } yield LocalParsedDatasource[F, RValue](root, lc.readChunkSizeBytes, blockingPool).point[Disposable[F, ?]]
 
     ds.run

--- a/impl/src/main/scala/quasar/impl/datasource/local/package.scala
+++ b/impl/src/main/scala/quasar/impl/datasource/local/package.scala
@@ -18,11 +18,8 @@ package quasar.impl.datasource
 
 import slamdata.Predef._
 
-import quasar.api.datasource.DatasourceError.{
-  InitializationError,
-  MalformedConfiguration
-}
-import quasar.api.datasource.{DatasourceType, DestinationType}
+import quasar.api.datasource.DatasourceType
+import quasar.api.destination.DestinationType
 import quasar.api.resource.ResourcePath
 import quasar.contrib.scalaz.MonadError_
 import quasar.fp.ski.ι
@@ -50,17 +47,20 @@ package object local {
       else MonadError_[F, Throwable].unattempt_(\/.fromTryCatchNonFatal(p.resolve(n)))
     }
 
-  def attemptConfig[F[_]: Sync, A: DecodeJson](config: Json, errorPrefix: String)
-      : EitherT[F, InitializationError[Json], A] =
+  def attemptConfig[F[_]: Sync, A: DecodeJson, B](
+    config: Json,
+    errorPrefix: String)(onError: (Json, String) => B)
+      : EitherT[F, B, A] =
     EitherT.fromEither(config.as[A].toEither.point[F])
-      .leftMap[InitializationError[Json]] {
-        case (s, _) =>
-          MalformedConfiguration(LocalType, config, errorPrefix + s)
+      .leftMap[B] {
+        case (s, _) => onError(config, errorPrefix + s)
       }
 
-  def validatePath[F[_]: Sync](path: String, config: Json, errorPrefix: String)
-      : EitherT[F, InitializationError[Json], JPath] =
+  def validatePath[F[_]: Sync, B](
+    path: String,
+    config: Json,
+    errorPrefix: String)(onError: (Json, String) => B)
+      : EitherT[F, B, JPath] =
     EitherT.fromEither(Sync[F].attempt(Sync[F].delay(Paths.get(path))))
-      .leftMap[InitializationError[Json]](
-        t => MalformedConfiguration(LocalType, config, errorPrefix + t.getMessage))
+      .leftMap[B](t => onError(config, errorPrefix + t.getMessage))
 }

--- a/impl/src/main/scala/quasar/impl/destinations/DestinationManager.scala
+++ b/impl/src/main/scala/quasar/impl/destinations/DestinationManager.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014–2018 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.impl.destinations
+
+import slamdata.Predef.{Option, Unit}
+
+import quasar.Condition
+import quasar.api.destination.DestinationError.CreateError
+import quasar.api.destination.{DestinationRef, DestinationType}
+import quasar.connector.Destination
+
+import scalaz.ISet
+
+/** A primitive facility for managing the lifecycle of destinations. */
+trait DestinationManager[I, C, F[_]] {
+  /** Initialize a destination as `destinationId` using the provided `ref`. If a
+    * destination exists at `destinationId`, it is shut down.
+    */
+  def initDestination(destinationId: I, ref: DestinationRef[C])
+      : F[Condition[CreateError[C]]]
+
+  /** Returns the destination having the given id or `None` if not found. */
+  def destinationOf(destinationId: I): F[Option[Destination[F]]]
+
+  /** Returns `ref` devoid of any sensitive information (credentials and the like). */
+  def sanitizedRef(ref: DestinationRef[C]): DestinationRef[C]
+
+  /** Stop the destination, discarding it and freeing any resources it may
+    * be using.
+    */
+  def shutdownDestination(destinationId: I): F[Unit]
+
+  /** The types of destinations supported. */
+  def supportedDestinationTypes: F[ISet[DestinationType]]
+}


### PR DESCRIPTION
The main part of this PR are the two interfaces we're going to use to manage destinations:

1. `Destinations`
2. `DestinationManager`

I have implementation of these two traits in the pipeline but I'd like to start reviewing this sooner rather than later. 

You may notice these two traits share many similarities with `Tables`, `Datasources`, `DatasourceManager` and `PreparationsManager`, but I'm not convinced they're similar enough to justify abstraction to eliminate the duplication. Any thoughts are very welcome.

Tagged as `revision` since the changes are purely additive.

[ch6522]