### PR TITLE
Change Uop repr to a SortedSet

### DIFF
--- a/foundation/src/main/scala/quasar/contrib/cats/boolean.scala
+++ b/foundation/src/main/scala/quasar/contrib/cats/boolean.scala
@@ -14,27 +14,22 @@
  * limitations under the License.
  */
 
-package quasar.qsu.mra
+package quasar.contrib.cats
 
-import slamdata.Predef.Set
+import slamdata.Predef.Boolean
 
-import quasar.pkg.tests._
+import cats.kernel.BoundedSemilattice
 
-import cats.Order
+import scalaz.@@
+import scalaz.Tags.Disjunction
+import scalaz.syntax.tag._
 
-import org.scalacheck.Cogen
+object boolean {
+  implicit def catsBooleanDisjBoundedSemilattice: BoundedSemilattice[Boolean @@ Disjunction] =
+    new BoundedSemilattice[Boolean @@ Disjunction] {
+      def combine(x: Boolean @@ Disjunction, y: Boolean @@ Disjunction) =
+        Disjunction(x.unwrap || y.unwrap)
 
-trait UopGenerator {
-  implicit def arbitraryUop[A: Arbitrary: Order]: Arbitrary[Uop[A]] =
-    Arbitrary(for {
-      sz <- Gen.frequency((32, 1), (16, 2), (8, 3), (4, 4), (2, 5), (1, 0))
-      as <- Gen.listOfN(sz, arbitrary[A])
-    } yield Uop.of(as: _*))
-
-  implicit def cogenUop[A: Cogen: Order]: Cogen[Uop[A]] = {
-    implicit val ording = Order[A].toOrdering
-    Cogen[Set[A]].contramap(_.toSortedSet)
-  }
+      val empty = Disjunction(false)
+    }
 }
-
-object UopGenerator extends UopGenerator

--- a/foundation/src/main/scala/quasar/contrib/cats/data/nonEmptySet.scala
+++ b/foundation/src/main/scala/quasar/contrib/cats/data/nonEmptySet.scala
@@ -14,27 +14,13 @@
  * limitations under the License.
  */
 
-package quasar.qsu.mra
-
-import slamdata.Predef.Set
-
-import quasar.pkg.tests._
+package quasar.contrib.cats.data
 
 import cats.Order
+import cats.data.NonEmptySet
+import cats.instances.sortedSet._
 
-import org.scalacheck.Cogen
-
-trait UopGenerator {
-  implicit def arbitraryUop[A: Arbitrary: Order]: Arbitrary[Uop[A]] =
-    Arbitrary(for {
-      sz <- Gen.frequency((32, 1), (16, 2), (8, 3), (4, 4), (2, 5), (1, 0))
-      as <- Gen.listOfN(sz, arbitrary[A])
-    } yield Uop.of(as: _*))
-
-  implicit def cogenUop[A: Cogen: Order]: Cogen[Uop[A]] = {
-    implicit val ording = Order[A].toOrdering
-    Cogen[Set[A]].contramap(_.toSortedSet)
-  }
+object nonEmptySet {
+  implicit def catsNonEmptySetOrder[A: Order]: Order[NonEmptySet[A]] =
+    Order.by(_.toSortedSet)
 }
-
-object UopGenerator extends UopGenerator

--- a/qsu/src/main/scala/quasar/qsu/ReifyIdentities.scala
+++ b/qsu/src/main/scala/quasar/qsu/ReifyIdentities.scala
@@ -141,7 +141,7 @@ final class ReifyIdentities[T[_[_]]: BirecursiveT: ShowT] private () extends QSU
 
       case QSU.QSAutoJoin(left, right, autojoin, combiner) =>
         val keysAccess = for {
-          conj <- autojoin.keys.toList
+          conj <- autojoin.keys.toSortedSet
           key <- conj.toNonEmptyList.toList
           keyAccess <- joinKeyAccess(g.root, key)
         } yield keyAccess

--- a/qsu/src/test/scala/quasar/qsu/mra/IdentitiesSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/mra/IdentitiesSpec.scala
@@ -25,7 +25,7 @@ import scala.Predef.$conforms
 import cats.data.NonEmptyList
 import cats.instances.int._
 import cats.instances.option._
-import cats.kernel.laws.discipline.{SemilatticeTests, EqTests}
+import cats.kernel.laws.discipline.{OrderTests, SemilatticeTests}
 import cats.syntax.eq._
 import cats.syntax.foldable._
 import cats.syntax.list._
@@ -389,6 +389,6 @@ object IdentitiesSpec extends Qspec
     }
   }
 
-  checkAll("Eq[Identities[Int]]", EqTests[Identities[Int]].eqv)
+  checkAll("Order[Identities[Int]]", OrderTests[Identities[Int]].order)
   checkAll("Semilattice[Identities[Int]]", SemilatticeTests[Identities[Int]].semilattice)
 }

--- a/qsu/src/test/scala/quasar/qsu/mra/JoinKeysGenerator.scala
+++ b/qsu/src/test/scala/quasar/qsu/mra/JoinKeysGenerator.scala
@@ -16,7 +16,7 @@
 
 package quasar.qsu.mra
 
-import slamdata.Predef.List
+import slamdata.Predef.Set
 
 import quasar.pkg.tests._
 
@@ -42,8 +42,10 @@ trait JoinKeysGenerator {
     } yield cs.foldMap(c => Disjunction(JoinKeys.conj(c.head, c.tail: _*))).unwrap)
   }
 
-  implicit def cogenJoinKeys[S: Cogen, V: Cogen]: Cogen[JoinKeys[S, V]] =
-    Cogen[List[NonEmptyList[JoinKey[S, V]]]].contramap(_.toList.map(_.toNonEmptyList))
+  implicit def cogenJoinKeys[S: Cogen: Order, V: Cogen: Order]: Cogen[JoinKeys[S, V]] = {
+    implicit val ording = Order[NonEmptyList[JoinKey[S, V]]].toOrdering
+    Cogen[Set[NonEmptyList[JoinKey[S, V]]]].contramap(_.toSortedSet.map(_.toNonEmptyList))
+  }
 }
 
 object JoinKeysGenerator extends JoinKeyGenerator

--- a/qsu/src/test/scala/quasar/qsu/mra/ProvImplSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/mra/ProvImplSpec.scala
@@ -34,7 +34,7 @@ object ProvImplSpec extends {
   val prov: Provenance.Aux[Char, Int, Boolean, Uop[Identities[Dim[Char, Int, Boolean]]]] =
     ProvImpl[Char, Int, Boolean]
 
-  val params = Parameters(maxSize = 6, workers = 2)
+  val params = Parameters(maxSize = 8, workers = 2)
 
 }   with ProvenanceSpec[Char, Int, Boolean]
     with UopGenerator

--- a/qsu/src/test/scala/quasar/qsu/mra/UopSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/mra/UopSpec.scala
@@ -24,7 +24,8 @@ import scala.Predef.implicitly
 
 import cats.Eq
 import cats.instances.int._
-import cats.kernel.laws.discipline.{BoundedSemilatticeTests, CommutativeMonoidTests, EqTests}
+import cats.instances.option._
+import cats.kernel.laws.discipline.{BoundedSemilatticeTests, CommutativeMonoidTests, OrderTests}
 
 import org.scalacheck.Arbitrary
 
@@ -57,7 +58,7 @@ object UopSpec extends Qspec
   implicit def DisjEq: Eq[Uop[Int] @@ Disjunction] =
     Disjunction.subst(Eq[Uop[Int]])
 
-  checkAll("Eq[Uop[Int]]", EqTests[Uop[Int]].eqv)
+  checkAll("Order[Uop[Int]]", OrderTests[Uop[Int]].order)
   checkAll("CommutativeMonoid[Uop[Int] @@ Conjunction]", CommutativeMonoidTests[Uop[Int] @@ Conjunction].commutativeMonoid)
   checkAll("BoundedSemilattice[Uop[Int] @@ Disjunction]", BoundedSemilatticeTests[Uop[Int] @@ Disjunction].boundedSemilattice)
 }


### PR DESCRIPTION
We were representing `Uop` with a `List` to try and avoid needing an `Order` instance for `Identities`, however it turned out to be straightforward to implement the latter, so we can now use a `SortedSet` for `Uop` which results in better performance and fixing the issue with `Cogen`.

[ch7021]