### PR TITLE
Increase latchGet timeout

### DIFF
--- a/impl/src/test/scala/quasar/impl/push/DefaultResultPushSpec.scala
+++ b/impl/src/test/scala/quasar/impl/push/DefaultResultPushSpec.scala
@@ -116,7 +116,7 @@ object DefaultResultPushSpec extends EffectfulQSpec[IO] with ConditionMatchers {
   val awaitS = Stream.sleep_(WorkTime)
 
   def latchGet(s: SignallingRef[IO, String], expected: String): IO[Unit] =
-    s.discrete.filter(Equal[String].equal(_, expected)).take(1).compile.drain.timeout(Timeout)
+    s.discrete.filter(Equal[String].equal(_, expected)).take(1).compile.drain.timeout(Timeout * 2)
 
   def waitForUpdate[K, V](s: SignallingRef[IO, Map[K, V]]): IO[Unit] =
     s.discrete.filter(_.nonEmpty).take(1).compile.drain.timeout(Timeout)


### PR DESCRIPTION
Even under high load I'm unable to reproduce the flakiness in `DefaultResultPushSpec` locally. So I'm opening this PR to test with Travis directly. 