### PR TITLE
Initialize destinations on first use

### DIFF
--- a/api/src/main/scala/quasar/api/destination/Destination.scala
+++ b/api/src/main/scala/quasar/api/destination/Destination.scala
@@ -14,17 +14,12 @@
  * limitations under the License.
  */
 
-package quasar.connector
+package quasar.api.destination
 
-import slamdata.Predef.{Stream => _, _}
+import scalaz.NonEmptyList
 
-import quasar.api.resource.ResourcePath
-import quasar.api.table.TableColumn
+trait Destination[F[_]] {
+  def destinationType: DestinationType
 
-import fs2.Stream
-
-sealed trait ResultSink[F[_]]
-
-object ResultSink {
-  final case class Csv[F[_]](run: (ResourcePath, List[TableColumn], Stream[F, Byte]) => F[Unit]) extends ResultSink[F]
+  def sinks: NonEmptyList[ResultSink[F]]
 }

--- a/api/src/main/scala/quasar/api/destination/Destinations.scala
+++ b/api/src/main/scala/quasar/api/destination/Destinations.scala
@@ -44,6 +44,9 @@ trait Destinations[F[_], G[_], I, C] {
     */
   def destinationRef(destinationId: I): F[ExistentialError[I] \/ DestinationRef[C]]
 
+  /** Returns the specified destination. Initializes it if necessary */
+  def destinationOf(destinationId: I): F[DestinationError[I, C] \/ Destination[F]]
+
   /** Returns the status of the specified destination or an error if it doesn't
     * exist.
     */

--- a/api/src/main/scala/quasar/api/destination/ResultSink.scala
+++ b/api/src/main/scala/quasar/api/destination/ResultSink.scala
@@ -14,14 +14,17 @@
  * limitations under the License.
  */
 
-package quasar.connector
+package quasar.api.destination
 
-import quasar.api.destination.DestinationType
+import slamdata.Predef.{Stream => _, _}
 
-import scalaz.NonEmptyList
+import quasar.api.resource.ResourcePath
+import quasar.api.table.TableColumn
 
-trait Destination[F[_]] {
-  def destinationType: DestinationType
+import fs2.Stream
 
-  def sinks: NonEmptyList[ResultSink[F]]
+sealed trait ResultSink[F[_]]
+
+object ResultSink {
+  final case class Csv[F[_]](run: (ResourcePath, List[TableColumn], Stream[F, Byte]) => F[Unit]) extends ResultSink[F]
 }

--- a/connector/src/main/scala/quasar/connector/DestinationModule.scala
+++ b/connector/src/main/scala/quasar/connector/DestinationModule.scala
@@ -17,7 +17,7 @@
 package quasar.connector
 
 import quasar.api.destination.DestinationError.InitializationError
-import quasar.api.destination.DestinationType
+import quasar.api.destination.{Destination, DestinationType}
 
 import scala.util.Either
 

--- a/impl/src/main/scala/quasar/impl/datasource/local/LocalDestination.scala
+++ b/impl/src/main/scala/quasar/impl/datasource/local/LocalDestination.scala
@@ -18,8 +18,9 @@ package quasar.impl.datasource.local
 
 import slamdata.Predef.{Stream => _, _}
 
+import quasar.api.destination.{Destination, ResultSink}
 import quasar.concurrent.BlockingContext
-import quasar.connector.{Destination, MonadResourceErr, ResourceError, ResultSink}
+import quasar.connector.{MonadResourceErr, ResourceError}
 
 import cats.effect.{ContextShift, Effect}
 import fs2.io

--- a/impl/src/main/scala/quasar/impl/datasource/local/LocalDestinationModule.scala
+++ b/impl/src/main/scala/quasar/impl/datasource/local/LocalDestinationModule.scala
@@ -16,12 +16,13 @@
 
 package quasar.impl.datasource.local
 
+import quasar.api.destination.Destination
 import quasar.api.destination.DestinationError.{
   InitializationError,
   malformedConfiguration
 }
 import quasar.concurrent.BlockingContext
-import quasar.connector.{Destination, DestinationModule, MonadResourceErr}
+import quasar.connector.{DestinationModule, MonadResourceErr}
 
 import scala.util.Either
 

--- a/impl/src/main/scala/quasar/impl/destinations/DestinationManager.scala
+++ b/impl/src/main/scala/quasar/impl/destinations/DestinationManager.scala
@@ -18,12 +18,10 @@ package quasar.impl.destinations
 
 import slamdata.Predef.{Exception, Option, Unit}
 
-import quasar.Condition
 import quasar.api.destination.DestinationError.CreateError
-import quasar.api.destination.{DestinationRef, DestinationType}
-import quasar.connector.Destination
+import quasar.api.destination.{Destination, DestinationRef, DestinationType}
 
-import scalaz.{IMap, ISet}
+import scalaz.{IMap, ISet, \/}
 
 /** A primitive facility for managing the lifecycle of destinations. */
 trait DestinationManager[I, C, F[_]] {
@@ -31,7 +29,7 @@ trait DestinationManager[I, C, F[_]] {
     * destination exists at `destinationId`, it is shut down.
     */
   def initDestination(destinationId: I, ref: DestinationRef[C])
-      : F[Condition[CreateError[C]]]
+      : F[CreateError[C] \/ Destination[F]]
 
   /** Returns the destination having the given id or `None` if not found. */
   def destinationOf(destinationId: I): F[Option[Destination[F]]]

--- a/impl/src/main/scala/quasar/impl/push/DefaultResultPush.scala
+++ b/impl/src/main/scala/quasar/impl/push/DefaultResultPush.scala
@@ -19,7 +19,7 @@ package quasar.impl.push
 import slamdata.Predef.{Map => _, _}
 
 import quasar.Condition
-import quasar.connector.{Destination, ResultSink}
+import quasar.api.destination.{Destination, ResultSink}
 import quasar.api.QueryEvaluator
 import quasar.api.destination.ResultType
 import quasar.api.push.{ResultPush, ResultPushError, ResultRender, Status}

--- a/impl/src/test/scala/quasar/impl/destinations/DefaultDestinationManagerSpec.scala
+++ b/impl/src/test/scala/quasar/impl/destinations/DefaultDestinationManagerSpec.scala
@@ -18,9 +18,8 @@ package quasar.impl.destinations
 
 import slamdata.Predef._
 
-import quasar.Condition
-import quasar.api.destination.{DestinationError, DestinationName, DestinationRef, DestinationType}
-import quasar.connector.{Destination, DestinationModule, ResourceError}
+import quasar.api.destination.{Destination, DestinationError, DestinationName, DestinationRef, DestinationType}
+import quasar.connector.{DestinationModule, ResourceError}
 import quasar.contrib.scalaz.MonadError_
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -29,7 +28,7 @@ import argonaut.Json
 import cats.effect.IO
 import cats.effect.concurrent.Ref
 import eu.timepit.refined.auto._
-import scalaz.{IMap, ISet}
+import scalaz.{-\/, IMap, ISet}
 import scalaz.std.anyVal._
 import scalaz.syntax.applicative._
 import shims._
@@ -75,7 +74,7 @@ object DefaultDestinationManagerSpec extends quasar.Qspec {
         val ref = DestinationRef(notKnown, DestinationName("notknown"), Json.jEmptyString)
 
         emptyManager.flatMap(_.initDestination(1, ref)).unsafeRunSync must beLike {
-          case Condition.Abnormal(DestinationError.DestinationUnsupported(k, s)) =>
+          case -\/(DestinationError.DestinationUnsupported(k, s)) =>
             k must_== notKnown
             s must_== ISet.singleton(MockDestinationType)
         }

--- a/impl/src/test/scala/quasar/impl/destinations/DefaultDestinationsSpec.scala
+++ b/impl/src/test/scala/quasar/impl/destinations/DefaultDestinationsSpec.scala
@@ -19,8 +19,8 @@ package quasar.impl.destinations
 import slamdata.Predef.{Stream => _, _}
 
 import quasar.{Condition, ConditionMatchers}
-import quasar.api.destination.{DestinationError, DestinationMeta, DestinationName, DestinationRef, DestinationType, Destinations}
-import quasar.connector.{Destination, DestinationModule, ResourceError}
+import quasar.api.destination.{Destination, DestinationError, DestinationMeta, DestinationName, DestinationRef, DestinationType, Destinations}
+import quasar.connector.{DestinationModule, ResourceError}
 import quasar.contrib.scalaz.MonadError_
 import quasar.impl.storage.RefIndexedStore
 

--- a/impl/src/test/scala/quasar/impl/destinations/MockDestination.scala
+++ b/impl/src/test/scala/quasar/impl/destinations/MockDestination.scala
@@ -19,8 +19,8 @@ package quasar.impl.destinations
 import slamdata.Predef._
 
 import quasar.api.destination.DestinationError.InitializationError
-import quasar.api.destination.DestinationType
-import quasar.connector.{Destination, DestinationModule, MonadResourceErr, ResultSink}
+import quasar.api.destination.{Destination, DestinationType, ResultSink}
+import quasar.connector.{DestinationModule, MonadResourceErr}
 
 import argonaut.Json
 import cats.effect.{ConcurrentEffect, ContextShift, Resource, Timer}

--- a/impl/src/test/scala/quasar/impl/destinations/MockDestinations.scala
+++ b/impl/src/test/scala/quasar/impl/destinations/MockDestinations.scala
@@ -19,7 +19,7 @@ package quasar.impl.destinations
 import slamdata.Predef._
 
 import quasar.Condition
-import quasar.api.destination.{DestinationMeta, DestinationRef, DestinationType, Destinations}
+import quasar.api.destination.{Destination, DestinationMeta, DestinationRef, DestinationType, Destinations}
 import quasar.api.destination.DestinationError
 import quasar.api.destination.DestinationError.{CreateError, ExistentialError}
 import quasar.contrib.scalaz.MonadState_
@@ -66,6 +66,10 @@ final class MockDestinations[I: Order, C, F[_]: Monad](freshId: F[I], supported:
   def destinationRef(id: I): F[ExistentialError[I] \/ DestinationRef[C]] =
     R.gets(_.lookup(id))
       .map(_.toRight(DestinationError.destinationNotFound(id)).disjunction)
+
+  def destinationOf(id: I): F[DestinationError[I, C] \/ Destination[F]] =
+    DestinationError.destinationNotFound[I, DestinationError[I, C]](id)
+      .left[Destination[F]].point[F]
 
   def destinationStatus(id: I): F[ExistentialError[I] \/ Condition[Exception]] =
     (R.get |@| E.get) {

--- a/impl/src/test/scala/quasar/impl/push/DefaultResultPushSpec.scala
+++ b/impl/src/test/scala/quasar/impl/push/DefaultResultPushSpec.scala
@@ -19,13 +19,11 @@ package quasar.impl.push
 import slamdata.Predef._
 
 import quasar.api.QueryEvaluator
-import quasar.api.destination.DestinationType
-import quasar.api.destination.ResultType
+import quasar.api.destination.{Destination, DestinationType, ResultSink, ResultType}
 import quasar.api.push.{ResultPush, ResultPushError, ResultRender, Status}
 import quasar.api.resource.ResourcePath
 import quasar.api.resource.{ResourcePath, ResourceName}
 import quasar.api.table.{TableColumn, TableName, TableRef}
-import quasar.connector.{Destination, ResultSink}
 import quasar.{ConditionMatchers, EffectfulQSpec}
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/run/src/main/scala/quasar/run/Quasar.scala
+++ b/run/src/main/scala/quasar/run/Quasar.scala
@@ -58,7 +58,6 @@ import spire.std.double._
 final class Quasar[F[_], R, S, C <: SchemaConfig](
     val datasources: Datasources[F, Stream[F, ?], UUID, Json, SstConfig[Fix[EJson], Double], C],
     val destinations: Destinations[F, Stream[F, ?], UUID, Json],
-    val destManager: DestinationManager[UUID, Json, F],
     val tables: Tables[F, UUID, SqlQuery, R, S],
     val queryEvaluator: QueryEvaluator[F, SqlQuery, R])
 
@@ -127,7 +126,7 @@ object Quasar extends Logging {
       tables =
         DefaultTables(freshUUID, tableRefs, prepManager, lookupTableData, lookupTableSchema)
 
-    } yield new Quasar(datasources, destinations, destManager, tables, sqlEvaluator)
+    } yield new Quasar(datasources, destinations, tables, sqlEvaluator)
   }
 
   ////

--- a/run/src/main/scala/quasar/run/Quasar.scala
+++ b/run/src/main/scala/quasar/run/Quasar.scala
@@ -32,7 +32,7 @@ import quasar.impl.DatasourceModule
 import quasar.impl.datasource.{AggregateResult, CompositeResult}
 import quasar.impl.datasources._
 import quasar.impl.datasources.middleware._
-import quasar.impl.destinations.{DefaultDestinationManager, DefaultDestinations, DestinationManager}
+import quasar.impl.destinations.{DefaultDestinationManager, DefaultDestinations}
 import quasar.impl.schema.{SstConfig, SstEvalConfig}
 import quasar.impl.storage.IndexedStore
 import quasar.impl.table.{DefaultTables, PreparationsManager}

--- a/run/src/main/scala/quasar/run/Quasar.scala
+++ b/run/src/main/scala/quasar/run/Quasar.scala
@@ -32,7 +32,7 @@ import quasar.impl.DatasourceModule
 import quasar.impl.datasource.{AggregateResult, CompositeResult}
 import quasar.impl.datasources._
 import quasar.impl.datasources.middleware._
-import quasar.impl.destinations.{DefaultDestinationManager, DefaultDestinations}
+import quasar.impl.destinations.{DefaultDestinationManager, DefaultDestinations, DestinationManager}
 import quasar.impl.schema.{SstConfig, SstEvalConfig}
 import quasar.impl.storage.IndexedStore
 import quasar.impl.table.{DefaultTables, PreparationsManager}
@@ -58,6 +58,7 @@ import spire.std.double._
 final class Quasar[F[_], R, S, C <: SchemaConfig](
     val datasources: Datasources[F, Stream[F, ?], UUID, Json, SstConfig[Fix[EJson], Double], C],
     val destinations: Destinations[F, Stream[F, ?], UUID, Json],
+    val destManager: DestinationManager[UUID, Json, F],
     val tables: Tables[F, UUID, SqlQuery, R, S],
     val queryEvaluator: QueryEvaluator[F, SqlQuery, R])
 
@@ -126,7 +127,7 @@ object Quasar extends Logging {
       tables =
         DefaultTables(freshUUID, tableRefs, prepManager, lookupTableData, lookupTableSchema)
 
-    } yield new Quasar(datasources, destinations, tables, sqlEvaluator)
+    } yield new Quasar(datasources, destinations, destManager, tables, sqlEvaluator)
   }
 
   ////


### PR DESCRIPTION
[ch8932]

This also moves `ResultSink` and `Destination` from `quasar.connector` to `quasar.api.push`. This was in order to add `destinationOf` in `quasar.api.destination.Destinations`. In a subsequent PR I will use `destinationOf` to wire the result push HTTP API