### PR TITLE
Added BOM configuration parameter to RenderConfig.Csv

### DIFF
--- a/api/src/main/scala/quasar/api/push/RenderConfig.scala
+++ b/api/src/main/scala/quasar/api/push/RenderConfig.scala
@@ -24,7 +24,7 @@ object RenderConfig {
   import DateTimeFormatter._
 
   // please note that binary compatibility is *only* guaranteed on this if you
-  // construct instances named arguments
+  // construct instances based on named arguments
   final case class Csv(
       includeHeader: Boolean = true,
       includeBom: Boolean = true,

--- a/api/src/main/scala/quasar/api/push/RenderConfig.scala
+++ b/api/src/main/scala/quasar/api/push/RenderConfig.scala
@@ -23,8 +23,11 @@ import java.time.format.DateTimeFormatter
 object RenderConfig {
   import DateTimeFormatter._
 
+  // please note that binary compatibility is *only* guaranteed on this if you
+  // construct instances named arguments
   final case class Csv(
       includeHeader: Boolean = true,
+      includeBom: Boolean = true,
       offsetDateTimeFormat: DateTimeFormatter = ISO_DATE_TIME,
       offsetDateFormat: DateTimeFormatter = ISO_OFFSET_DATE,
       offsetTimeFormat: DateTimeFormatter = ISO_OFFSET_TIME,


### PR DESCRIPTION
Some destinations don't correctly handle the utf-8 byte order mark, so we need the ability to remove it.