### PR TITLE
Clustering/optimization

### DIFF
--- a/impl/src/main/scala/quasar/impl/storage/AntiEntropyStore.scala
+++ b/impl/src/main/scala/quasar/impl/storage/AntiEntropyStore.scala
@@ -83,7 +83,7 @@ final class AntiEntropyStore[F[_]: ConcurrentEffect: ContextShift: Timer, K: Cod
     // They are handled when this node sends its advertisement instead.
     // for every key in advertisement having the most recent modification timestamp map
     def result(init: Accum, timestamps: Map[K, Long])  = ad.toList.foldM[F, Accum](init){
-      case (acc@(requesting, returning), (k, incoming)) => for {
+      case (acc @ (requesting, returning), (k, incoming)) => for {
         // when this key was modified last time
         current <- timestamps.get(k).getOrElse(0L).pure[F]
         res <- if (current < incoming) {

--- a/impl/src/main/scala/quasar/impl/storage/AntiEntropyStoreConfig.scala
+++ b/impl/src/main/scala/quasar/impl/storage/AntiEntropyStoreConfig.scala
@@ -28,7 +28,7 @@ final case class AntiEntropyStoreConfig(
 
 object AntiEntropyStoreConfig {
   val default: AntiEntropyStoreConfig = AntiEntropyStoreConfig(
-    adTimeoutMillis = 30L,
+    adTimeoutMillis = 300L,
     purgeTimeoutMillis = 1000L,
     tombstoneLiveForMillis = 300000L,
     updateRequestLimit = 128,

--- a/impl/src/main/scala/quasar/impl/storage/AntiEntropyStoreConfig.scala
+++ b/impl/src/main/scala/quasar/impl/storage/AntiEntropyStoreConfig.scala
@@ -21,6 +21,8 @@ import slamdata.Predef._
 final case class AntiEntropyStoreConfig(
   adTimeoutMillis: Long,
   purgeTimeoutMillis: Long,
+  updateBroadcastMillis: Long,
+  updateBroadcastBatch: Int,
   tombstoneLiveForMillis: Long,
   updateRequestLimit: Int,
   updateLimit: Int,
@@ -30,6 +32,8 @@ object AntiEntropyStoreConfig {
   val default: AntiEntropyStoreConfig = AntiEntropyStoreConfig(
     adTimeoutMillis = 300L,
     purgeTimeoutMillis = 1000L,
+    updateBroadcastMillis = 100L,
+    updateBroadcastBatch = 100,
     tombstoneLiveForMillis = 300000L,
     updateRequestLimit = 128,
     updateLimit = 128,

--- a/impl/src/main/scala/quasar/impl/storage/TimestampedStore.scala
+++ b/impl/src/main/scala/quasar/impl/storage/TimestampedStore.scala
@@ -18,60 +18,51 @@ package quasar.impl.storage
 
 import slamdata.Predef._
 
-import quasar.concurrent.BlockingContext
 import quasar.impl.cluster.Timestamped, Timestamped._
 
-import cats.~>
-import cats.effect.{Timer, Concurrent, Sync, Resource, ContextShift}
+import cats.effect.{Timer, Concurrent, Sync, Resource}
 import cats.effect.concurrent.Ref
 import cats.syntax.functor._
 import cats.syntax.flatMap._
 
-import fs2.{Stream, Pipe}
+import fs2.Stream
 import fs2.concurrent.{Queue, NoneTerminatedQueue}
 
-import scalaz.syntax.tag._
-
-final class TimestampedStore[F[_]: Sync: ContextShift: Timer, K, V](
+final class TimestampedStore[F[_]: Sync: Timer, K, V](
     val underlying: IndexedStore[F, K, Timestamped[V]],
     ref: Ref[F, Map[K, Long]],
-    private val queue: NoneTerminatedQueue[F, (K, Timestamped[V])],
-    pool: BlockingContext)
+    private val queue: NoneTerminatedQueue[F, (K, Timestamped[V])])
     extends IndexedStore[F, K, V] {
 
-  private def evalOn[A](fa: F[A]): F[A] = ContextShift[F].evalOn(pool.unwrap)(fa)
-  private def evalOnStream[A]: Pipe[F, A, A] = _.translate(λ[F ~> F](evalOn(_)))
-
   def entries: Stream[F, (K, V)] =
-    underlying.entries.map({ case (k, v) => raw(v).map((k, _))}).unNone.through(evalOnStream)
+    underlying.entries.map({ case (k, v) => raw(v).map((k, _))}).unNone
 
   def lookup(k: K): F[Option[V]] =
-    evalOn(underlying.lookup(k).map(_.flatMap(raw(_))))
+    underlying.lookup(k).map(_.flatMap(raw(_)))
 
-  def insert(k: K, v: V): F[Unit] = evalOn(for {
+  def insert(k: K, v: V): F[Unit] = for {
     toInsert <- tagged[F, V](v)
     _ <- underlying.insert(k, toInsert)
     _ <- ref.modify((mp: Map[K, Long]) => (mp.updated(k, timestamp(toInsert)), ()))
     _ <- queue.enqueue1(Some((k, toInsert)))
-  } yield ())
+  } yield ()
 
-  def delete(k: K): F[Boolean] = evalOn(for {
+  def delete(k: K): F[Boolean] = for {
     was <- underlying.lookup(k)
     tmb <- tombstone[F, V]
     res <- underlying.insert(k, tmb)
     _ <- ref.modify((mp: Map[K, Long]) => (mp.updated(k, timestamp(tmb)), ()))
     _ <- queue.enqueue1(Some((k, tmb)))
-  } yield was.flatMap(raw(_)).nonEmpty)
+  } yield was.flatMap(raw(_)).nonEmpty
 
-  def timestamps: F[Map[K, Long]] = evalOn(ref.get)
-  def updates: Stream[F, (K, Timestamped[V])] = queue.dequeue.through(evalOnStream)
+  def timestamps: F[Map[K, Long]] = ref.get
+  def updates: Stream[F, (K, Timestamped[V])] = queue.dequeue
 }
 
 object TimestampedStore {
   val QueueSize: Int = 4096
-  def apply[F[_]: Concurrent: Timer: ContextShift, K, V](
-      underlying: IndexedStore[F, K, Timestamped[V]],
-      pool: BlockingContext)
+  def apply[F[_]: Concurrent: Timer, K, V](
+      underlying: IndexedStore[F, K, Timestamped[V]])
       : Resource[F, TimestampedStore[F, K, V]] = {
     val make: F[TimestampedStore[F, K, V]] = for {
       entries <- underlying.entries.compile.toList.map(_.toMap)
@@ -79,7 +70,7 @@ object TimestampedStore {
       r <- Ref.of[F, Map[K, Long]](entries.map {
         case (k, v) => (k, timestamp(v))
       })
-    } yield new TimestampedStore(underlying, r, q, pool)
+    } yield new TimestampedStore(underlying, r, q)
     val release: TimestampedStore[F, K, V] => F[Unit] = { ts =>
       ts.queue.enqueue1(None)
     }

--- a/impl/src/test/scala/quasar/impl/storage/AntiEntropyStoreSpec.scala
+++ b/impl/src/test/scala/quasar/impl/storage/AntiEntropyStoreSpec.scala
@@ -67,7 +67,7 @@ final class AntiEntropyStoreSpec extends IndexedStoreSpec[IO, String, String] {
       : Resource[IO, Store] = for {
     atomix <- Atomix.resource[IO](me, seeds.map(_.address))
     storage <- Resource.liftF(IO(new ConcurrentHashMap[String, Timestamped[String]]()))
-    timestamped <- TimestampedStore[IO, String, String](underlying, pool)
+    timestamped <- TimestampedStore[IO, String, String](underlying)
     cluster = Atomix.cluster[IO](atomix, pool).contramap(printMessage(_))
     store <- AntiEntropyStore.default[IO, String, String]("default", cluster, timestamped, pool)
   } yield store

--- a/impl/src/test/scala/quasar/impl/storage/AntiEntropyStoreSpec.scala
+++ b/impl/src/test/scala/quasar/impl/storage/AntiEntropyStoreSpec.scala
@@ -54,7 +54,7 @@ final class AntiEntropyStoreSpec extends IndexedStoreSpec[IO, String, String] {
   } yield NodeInfo(id, "localhost", port)
 
   val pool = BlockingContext.cached("antientropy-spec-pool")
-  val sleep: IO[Unit] = timer.sleep(new FiniteDuration(2000, MILLISECONDS))
+  val sleep: IO[Unit] = timer.sleep(new FiniteDuration(4000, MILLISECONDS))
 
   type Persistence = ConcurrentHashMap[String, Timestamped[String]]
   type UnderlyingStore = IndexedStore[IO, String, Timestamped[String]]
@@ -67,7 +67,7 @@ final class AntiEntropyStoreSpec extends IndexedStoreSpec[IO, String, String] {
       : Resource[IO, Store] = for {
     atomix <- Atomix.resource[IO](me, seeds.map(_.address))
     storage <- Resource.liftF(IO(new ConcurrentHashMap[String, Timestamped[String]]()))
-    timestamped <- Resource.liftF(TimestampedStore[IO, String, String](underlying))
+    timestamped <- TimestampedStore[IO, String, String](underlying, pool)
     cluster = Atomix.cluster[IO](atomix, pool).contramap(printMessage(_))
     store <- AntiEntropyStore.default[IO, String, String]("default", cluster, timestamped, pool)
   } yield store

--- a/impl/src/test/scala/quasar/impl/storage/AntiEntropyStoreSpec.scala
+++ b/impl/src/test/scala/quasar/impl/storage/AntiEntropyStoreSpec.scala
@@ -67,7 +67,7 @@ final class AntiEntropyStoreSpec extends IndexedStoreSpec[IO, String, String] {
       : Resource[IO, Store] = for {
     atomix <- Atomix.resource[IO](me, seeds.map(_.address))
     storage <- Resource.liftF(IO(new ConcurrentHashMap[String, Timestamped[String]]()))
-    timestamped = TimestampedStore[IO, String, String](underlying)
+    timestamped <- Resource.liftF(TimestampedStore[IO, String, String](underlying))
     cluster = Atomix.cluster[IO](atomix, pool).contramap(printMessage(_))
     store <- AntiEntropyStore.default[IO, String, String]("default", cluster, timestamped, pool)
   } yield store

--- a/impl/src/test/scala/quasar/impl/storage/TimestampedStoreSpec.scala
+++ b/impl/src/test/scala/quasar/impl/storage/TimestampedStoreSpec.scala
@@ -49,7 +49,7 @@ final class TimestampedStoreSpec extends IndexedStoreSpec[IO, String, String] {
 
   val emptyStore: Resource[IO, IndexedStore[IO, String, String]] = for {
     u <- underlying
-    res <- TimestampedStore(u, pool)
+    res <- TimestampedStore(u)
   } yield res
 
   val valueA = "A"
@@ -62,7 +62,7 @@ final class TimestampedStoreSpec extends IndexedStoreSpec[IO, String, String] {
         us <- underlying
         bar <- Resource.liftF(Timestamped.tagged[IO, String]("bar"))
         _ <- Resource.liftF(us.insert("foo", bar))
-        ts <- TimestampedStore(us, pool)
+        ts <- TimestampedStore(us)
         res <- Resource.liftF(ts.lookup("foo"))
       } yield {
         res mustEqual Some("bar")
@@ -72,7 +72,7 @@ final class TimestampedStoreSpec extends IndexedStoreSpec[IO, String, String] {
     "inserted values are timestamps" >>* {
       val resource = for {
         us <- underlying
-        ts <- TimestampedStore(us, pool)
+        ts <- TimestampedStore(us)
         _ <- Resource.liftF(ts.insert("foo", "bar"))
         bar <- Resource.liftF(us.lookup("foo"))
       } yield {
@@ -84,7 +84,7 @@ final class TimestampedStoreSpec extends IndexedStoreSpec[IO, String, String] {
       val resource = for {
         us <- underlying
         start <- Resource.liftF(timer.clock.realTime(MILLISECONDS))
-        ts <- TimestampedStore(us, pool)
+        ts <- TimestampedStore(us)
         _ <- Resource.liftF(ts.insert("foo", "bar"))
         _ <- Resource.liftF(ts.delete("foo"))
         t <- Resource.liftF(us.lookup("foo"))
@@ -101,7 +101,7 @@ final class TimestampedStoreSpec extends IndexedStoreSpec[IO, String, String] {
     "timestamps works" >>* {
       val resource = for {
         us <- underlying
-        ts <- TimestampedStore(us, pool)
+        ts <- TimestampedStore(us)
         _ <- Resource.liftF(for {
           _ <- ts.insert("foo", "bar")
           _ <- ts.delete("foo")

--- a/impl/src/test/scala/quasar/impl/storage/TimestampedStoreSpec.scala
+++ b/impl/src/test/scala/quasar/impl/storage/TimestampedStoreSpec.scala
@@ -21,10 +21,7 @@ import slamdata.Predef._
 import quasar.concurrent.BlockingContext
 import quasar.impl.cluster.Timestamped
 
-import cats.effect.{IO, Resource, Timer, ContextShift, Concurrent}
-import cats.effect.concurrent.Ref
-
-import fs2.Stream
+import cats.effect.{IO, Resource, Timer}
 
 import scalaz.std.string._
 


### PR DESCRIPTION
Basically there are two things: 
+ Timestamps are cached, so, advertisement doesn't requre traversing through whole mapdb
+ Updates are cached and broadcasted separately, this in theory should make advertsements handling less talkative and make cluster more consistent. 

I didn't come up with testing update stream from `TimestampedStore` since it's finished when resource is freed, but it's part of the store under resource 🤔 