### PR TITLE
handle QueryResult.Stateful in ssts

### DIFF
--- a/impl/src/test/scala/quasar/impl/datasource/CountBoolPlate.scala
+++ b/impl/src/test/scala/quasar/impl/datasource/CountBoolPlate.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014–2019 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.impl.datasources
+
+import slamdata.Predef._
+
+import java.lang.CharSequence
+
+import tectonic.{Plate, Signal}
+
+final class CountBoolPlate() extends Plate[Unit] {
+
+  private var state: Int = 0
+
+  def getState(): Int = state
+
+  def arr(): Signal = Signal.Continue
+  def map(): Signal = Signal.Continue
+  def nul(): Signal = Signal.Continue
+  def str(s: CharSequence): Signal = Signal.Continue
+  def num(s: CharSequence, decIdx: Int, expIdx: Int): Signal = Signal.Continue
+
+  def fls(): Signal = {
+    state += 1
+    Signal.Continue
+  }
+
+  def tru(): Signal = {
+    state += 1
+    Signal.Continue
+  }
+
+  def nestArr(): Signal = Signal.Continue
+  def nestMap(pathComponent: CharSequence): Signal = Signal.Continue
+  def nestMeta(pathComponent: CharSequence): Signal = Signal.Continue
+  def unnest(): Signal = Signal.Continue
+
+  def finishRow(): Unit = ()
+  def skipped(bytes: Int): Unit = ()
+  def finishBatch(terminal: Boolean): Unit = ()
+}

--- a/impl/src/test/scala/quasar/impl/datasources/SimpleCompositeResourceSchemaSpec.scala
+++ b/impl/src/test/scala/quasar/impl/datasources/SimpleCompositeResourceSchemaSpec.scala
@@ -93,6 +93,25 @@ object SimpleCompositeResourceSchemaSpec extends quasar.EffectfulQSpec[IO] {
       Stream.emits(BoolsData.mkString("\n").getBytes(Charset.forName("UTF-8"))),
       ScalarStages.Id)
 
+  val statefulResult: QueryResult.Stateful[IO, CountBoolPlate, Unit] = {
+    val plate = new CountBoolPlate()
+
+    QueryResult.Stateful[IO, CountBoolPlate, Unit](
+      DataFormat.ldjson,
+      IO(plate),
+      (p: CountBoolPlate) => {
+        val cur = p.getState
+        if (cur > 3) IO(None) else IO(Some(()))
+      },
+      {
+        case Some(_) =>
+          Stream.emits("true".getBytes(Charset.forName("UTF-8"))).covary[IO]
+        case None =>
+          Stream.emits("false".getBytes(Charset.forName("UTF-8"))).covary[IO]
+      },
+      ScalarStages.Id)
+  }
+
   val resourceSchema: ResourceSchema[IO, SstConfig[Fix[EJson], Double], (ResourcePath, CompositeResult[IO, QueryResult[IO]])] =
     SimpleCompositeResourceSchema[IO, Fix[EJson], Double](SstEvalConfig(20L, 1L, 100L))
 
@@ -105,6 +124,18 @@ object SimpleCompositeResourceSchemaSpec extends quasar.EffectfulQSpec[IO] {
   "computes an SST of unparsed data" >>* {
     resourceSchema(defaultCfg, (path, Left(unparsedResult)), 1.hour) map { qsst =>
       qsst must_= Some(schema)
+    }
+  }
+
+  "computes an SST of stateful data" >>* {
+    val sst = envT(
+      TypeStat.bool(3.0, 1.0),
+      TypeST(TypeF.simple[Fix[EJson], SST[Fix[EJson], Double]](SimpleType.Bool))).embed
+
+    val expected = SstSchema.fromSampled(100.0, sst)
+
+    resourceSchema(defaultCfg, (path, Left(statefulResult)), 1.hour) map { qsst =>
+      qsst must_= Some(expected)
     }
   }
 


### PR DESCRIPTION
[ch9430]

These additions will be deleted when new schema go into production, but in case data-based pagination lands before new schema, we include support for `Stateful` in old ssts.

This implementation is nearly identical to https://github.com/slamdata/scion/pull/200