### PR TITLE
create the stateful plate within the effect in the local ds

### DIFF
--- a/impl/src/main/scala/quasar/impl/datasource/local/LocalStatefulDatasource.scala
+++ b/impl/src/main/scala/quasar/impl/datasource/local/LocalStatefulDatasource.scala
@@ -41,7 +41,7 @@ object LocalStatefulDatasource {
 
     EvaluableLocalDatasource[F](LocalType, root) { iRead =>
 
-      val plate = new LocalStatefulPlate()
+      val plate = Effect[F].delay(new LocalStatefulPlate())
 
       def data(more: Option[Long]): Stream[F, Byte] =
         more match {
@@ -66,7 +66,7 @@ object LocalStatefulDatasource {
 
       QueryResult.stateful(
         format,
-        Effect[F].pure(plate),
+        plate,
         state(_),
         data(_),
         iRead.stages)

--- a/impl/src/test/scala/quasar/impl/datasources/CompositeResourceSchemaSpec.scala
+++ b/impl/src/test/scala/quasar/impl/datasources/CompositeResourceSchemaSpec.scala
@@ -108,15 +108,13 @@ object CompositeResourceSchemaSpec extends quasar.EffectfulQSpec[IO] {
       Stream.emits(BoolsData.mkString("\n").getBytes(Charset.forName("UTF-8"))),
       ScalarStages.Id)
 
-  val statefulResult: QueryResult.Stateful[IO, CountBoolPlate, Unit] = {
-    val plate = new CountBoolPlate()
-
+  val statefulResult: QueryResult.Stateful[IO, CountBoolPlate, Unit] =
     QueryResult.Stateful[IO, CountBoolPlate, Unit](
       DataFormat.ldjson,
-      IO(plate),
-      (p: CountBoolPlate) => {
+      IO.delay(new CountBoolPlate()),
+      (p: CountBoolPlate) => IO delay {
         val cur = p.getState
-        if (cur > 3) IO(None) else IO(Some(()))
+        if (cur > 3) None else Some(())
       },
       {
         case Some(_) =>
@@ -125,7 +123,6 @@ object CompositeResourceSchemaSpec extends quasar.EffectfulQSpec[IO] {
           Stream.emits("false".getBytes(Charset.forName("UTF-8"))).covary[IO]
       },
       ScalarStages.Id)
-  }
 
   val resourceSchema: ResourceSchema[IO, SstConfig[Fix[EJson], Double], (ResourcePath, CompositeResult[IO, QueryResult[IO]])] =
     CompositeResourceSchema[IO, Fix[EJson], Double](SstEvalConfig(20L, 1L, 100L))

--- a/impl/src/test/scala/quasar/impl/datasources/SimpleCompositeResourceSchemaSpec.scala
+++ b/impl/src/test/scala/quasar/impl/datasources/SimpleCompositeResourceSchemaSpec.scala
@@ -93,15 +93,13 @@ object SimpleCompositeResourceSchemaSpec extends quasar.EffectfulQSpec[IO] {
       Stream.emits(BoolsData.mkString("\n").getBytes(Charset.forName("UTF-8"))),
       ScalarStages.Id)
 
-  val statefulResult: QueryResult.Stateful[IO, CountBoolPlate, Unit] = {
-    val plate = new CountBoolPlate()
-
+  val statefulResult: QueryResult.Stateful[IO, CountBoolPlate, Unit] =
     QueryResult.Stateful[IO, CountBoolPlate, Unit](
       DataFormat.ldjson,
-      IO(plate),
-      (p: CountBoolPlate) => {
+      IO.delay(new CountBoolPlate()),
+      (p: CountBoolPlate) => IO delay {
         val cur = p.getState
-        if (cur > 3) IO(None) else IO(Some(()))
+        if (cur > 3) None else Some(())
       },
       {
         case Some(_) =>
@@ -110,7 +108,6 @@ object SimpleCompositeResourceSchemaSpec extends quasar.EffectfulQSpec[IO] {
           Stream.emits("false".getBytes(Charset.forName("UTF-8"))).covary[IO]
       },
       ScalarStages.Id)
-  }
 
   val resourceSchema: ResourceSchema[IO, SstConfig[Fix[EJson], Double], (ResourcePath, CompositeResult[IO, QueryResult[IO]])] =
     SimpleCompositeResourceSchema[IO, Fix[EJson], Double](SstEvalConfig(20L, 1L, 100L))


### PR DESCRIPTION
and ensure only one stateful plate is created in the sst stateful impl

**breaking** because the mimir integration tests fail against this patch (the mimir evaluator requires a change analogous to how ssts are changed here)