### PR TITLE
Use default settings for ProxySearch

### DIFF
--- a/foundation/src/main/scala/quasar/contrib/proxy/Search.scala
+++ b/foundation/src/main/scala/quasar/contrib/proxy/Search.scala
@@ -27,23 +27,5 @@ import java.net.ProxySelector
 object Search {
 
   def apply[F[_]: Sync]: F[ProxySelector] =
-    Sync[F] delay {
-      val builder = new ProxySearch
-
-      if (PlatformUtil.getCurrentPlattform() == Platform.WIN) {
-        builder.addStrategy(ProxySearch.Strategy.BROWSER)
-      } else if (PlatformUtil.getCurrentPlattform() == Platform.LINUX) {
-        builder.addStrategy(ProxySearch.Strategy.GNOME)
-        builder.addStrategy(ProxySearch.Strategy.KDE)
-        builder.addStrategy(ProxySearch.Strategy.BROWSER)
-      } else {
-        // mac and other
-        builder.addStrategy(ProxySearch.Strategy.OS_DEFAULT)    // TODO
-      }
-
-      // Cache 20 hosts for up to 10 minutes. This is the default
-      builder.setPacCacheSettings(20, 1000 * 60 * 10, CacheScope.CACHE_SCOPE_HOST)
-
-      builder.getProxySelector()
-    }
+    Sync[F].delay(ProxySearch.getDefaultProxySearch.getProxySelector)
 }

--- a/foundation/src/main/scala/quasar/contrib/proxy/Search.scala
+++ b/foundation/src/main/scala/quasar/contrib/proxy/Search.scala
@@ -19,8 +19,6 @@ package quasar.contrib.proxy
 import cats.effect.Sync
 
 import com.github.markusbernhardt.proxy.ProxySearch
-import com.github.markusbernhardt.proxy.selector.misc.BufferedProxySelector.CacheScope
-import com.github.markusbernhardt.proxy.util.PlatformUtil, PlatformUtil.Platform
 
 import java.net.ProxySelector
 


### PR DESCRIPTION
I have confirmed this works with the frontend. [Green frontend build here](https://travis-ci.com/slamdata/slamx/builds/131846875).

@djspiewak I have replaced the proxy-vole configuration with the defaults. Would you mind explaining the rationale used to pick the defaults we had before this PR? 