### PR TITLE
Make all shims imports explicit

### DIFF
--- a/api/src/main/scala/quasar/api/datasource/DatasourceError.scala
+++ b/api/src/main/scala/quasar/api/datasource/DatasourceError.scala
@@ -31,7 +31,7 @@ import quasar.api.resource.ResourcePath
 
 import scalaz.{ISet, NonEmptyList}
 
-import shims._
+import shims.{eqToScalaz, equalToCats, showToCats, showToScalaz}
 
 sealed trait DatasourceError[+I, +C] extends Product with Serializable
 

--- a/api/src/test/scala/quasar/api/datasource/DatasourcesSpec.scala
+++ b/api/src/test/scala/quasar/api/datasource/DatasourcesSpec.scala
@@ -37,7 +37,7 @@ import scalaz.syntax.equal._
 import scalaz.syntax.foldable._
 import scalaz.std.list._
 
-import shims._
+import shims.{eqToScalaz, equalToCats, showToCats, showToScalaz}
 
 abstract class DatasourcesSpec[
     F[_], G[_], I: Order: Show, C: Equal: Show, OldS <: SchemaConfig, S <: SchemaConfig](

--- a/api/src/test/scala/quasar/api/datasource/MockDatasourcesSpec.scala
+++ b/api/src/test/scala/quasar/api/datasource/MockDatasourcesSpec.scala
@@ -32,7 +32,7 @@ import scalaz.ISet
 import scalaz.std.anyVal._
 import scalaz.std.list._
 import scalaz.std.string._
-import shims._
+import shims.{monadToScalaz, monoidToCats}
 import MockDatasourcesSpec._
 
 final class MockDatasourcesSpec

--- a/api/src/test/scala/quasar/api/table/MockTablesSpec.scala
+++ b/api/src/test/scala/quasar/api/table/MockTablesSpec.scala
@@ -26,7 +26,7 @@ import cats.data.StateT
 import cats.effect.IO
 import scalaz.{~>, Id, IMap}, Id.Id
 import scalaz.std.string._
-import shims._
+import shims.monadToScalaz
 import MockTablesSpec.MockM
 
 final class MockTablesSpec extends TablesSpec[MockM, UUID, String] {

--- a/connector/src/main/scala/quasar/connector/QueryResult.scala
+++ b/connector/src/main/scala/quasar/connector/QueryResult.scala
@@ -32,7 +32,7 @@ import qdata.QDataDecode
 import scalaz.Show
 import scalaz.syntax.show._
 
-import shims._
+import shims.showToScalaz
 
 import tectonic.Plate
 

--- a/connector/src/test/scala/quasar/connector/DatasourceSpec.scala
+++ b/connector/src/test/scala/quasar/connector/DatasourceSpec.scala
@@ -29,7 +29,7 @@ import org.specs2.matcher.MatchResult
 
 import scalaz.Scalaz._
 
-import shims._
+import shims.monadToScalaz
 
 abstract class DatasourceSpec[F[_]: Effect, G[_], P <: ResourcePathType]
     extends EffectfulQSpec[F] {

--- a/connector/src/test/scala/quasar/connector/datasource/MapBasedDatasourceSpec.scala
+++ b/connector/src/test/scala/quasar/connector/datasource/MapBasedDatasourceSpec.scala
@@ -28,7 +28,8 @@ import cats.effect.IO
 import eu.timepit.refined.auto._
 import scalaz.IMap
 import scalaz.std.list._
-import shims._
+
+import shims.monadToScalaz
 
 object MapBasedDatasourceSpec extends DatasourceSpec[IO, List, ResourcePathType.Physical] {
 

--- a/foundation/src/main/scala/quasar/contrib/fs2/convert.scala
+++ b/foundation/src/main/scala/quasar/contrib/fs2/convert.scala
@@ -27,7 +27,8 @@ import cats.syntax.monadError._
 import fs2.concurrent.{NoneTerminatedQueue, Queue, SignallingRef}
 import fs2.{Chunk, Stream}
 import scalaz.{Functor, StreamT, Scalaz}, Scalaz._
-import shims._
+
+import shims.monadToScalaz
 
 object convert {
 

--- a/impl/src/main/scala/quasar/impl/datasource/AggregatingDatasource.scala
+++ b/impl/src/main/scala/quasar/impl/datasource/AggregatingDatasource.scala
@@ -37,7 +37,7 @@ import fs2.{Pull, Stream}
 
 import monocle.Lens
 
-import shims._
+import shims.{equalToCats, monadToScalaz}
 
 /** A datasource transformer that augments underlying datasources by adding an aggregate resource
   * `p / **` for every prefix `p`. An aggregate resource `p / **` will aggregate

--- a/impl/src/main/scala/quasar/impl/datasource/local/EvaluableLocalDatasource.scala
+++ b/impl/src/main/scala/quasar/impl/datasource/local/EvaluableLocalDatasource.scala
@@ -34,7 +34,8 @@ import java.nio.file.attribute.BasicFileAttributes
 import cats.effect.{ContextShift, Effect, Timer}
 import fs2.Stream
 import scalaz.{OptionT, Scalaz}, Scalaz._
-import shims._
+
+import shims.monadToScalaz
 
 /** A Datasource backed by the underlying filesystem local to Quasar.
   *

--- a/impl/src/main/scala/quasar/impl/datasource/local/LocalConfig.scala
+++ b/impl/src/main/scala/quasar/impl/datasource/local/LocalConfig.scala
@@ -28,8 +28,6 @@ import cats.instances.string._
 import cats.instances.tuple._
 import cats.syntax.show._
 
-import shims._
-
 final case class LocalConfig(
     rootDir: String,
     readChunkSizeBytes: Int,

--- a/impl/src/main/scala/quasar/impl/datasource/local/LocalDestination.scala
+++ b/impl/src/main/scala/quasar/impl/datasource/local/LocalDestination.scala
@@ -31,7 +31,7 @@ import scalaz.NonEmptyList
 import scalaz.syntax.monad._
 import scalaz.syntax.tag._
 
-import shims._
+import shims.monadToScalaz
 
 import java.nio.file.{Path => JPath}
 

--- a/impl/src/main/scala/quasar/impl/datasources/DefaultDatasourceManager.scala
+++ b/impl/src/main/scala/quasar/impl/datasources/DefaultDatasourceManager.scala
@@ -44,7 +44,7 @@ import fs2.Stream
 import matryoshka.{BirecursiveT, EqualT, ShowT}
 import scalaz.{EitherT, IMap, ISet, OptionT, Order, Scalaz}
 import Scalaz._
-import shims._
+import shims.monadToScalaz
 
 final class DefaultDatasourceManager[
     I: Order,

--- a/impl/src/main/scala/quasar/impl/datasources/DefaultDatasources.scala
+++ b/impl/src/main/scala/quasar/impl/datasources/DefaultDatasources.scala
@@ -42,7 +42,7 @@ import scalaz.syntax.monad._
 import scalaz.syntax.std.boolean._
 import scalaz.syntax.std.option._
 
-import shims._
+import shims.monadToScalaz
 
 final class DefaultDatasources[
     F[_]: Sync, I: Equal, C: Equal, OldS <: SchemaConfig, S <: SchemaConfig,

--- a/impl/src/main/scala/quasar/impl/datasources/middleware/AggregatingMiddleware.scala
+++ b/impl/src/main/scala/quasar/impl/datasources/middleware/AggregatingMiddleware.scala
@@ -29,7 +29,7 @@ import cats.Monad
 import cats.effect.Sync
 import cats.syntax.functor._
 import fs2.Stream
-import shims._
+import shims.{functorToCats, functorToScalaz}
 
 object AggregatingMiddleware {
   def apply[T[_[_]], F[_]: MonadResourceErr: MonadCreateErr: Sync, I, R](

--- a/impl/src/main/scala/quasar/impl/destinations/DefaultDestinationManager.scala
+++ b/impl/src/main/scala/quasar/impl/destinations/DefaultDestinationManager.scala
@@ -32,7 +32,8 @@ import scalaz.syntax.monad._
 import scalaz.syntax.std.either._
 import scalaz.syntax.unzip._
 import scalaz.{EitherT, IMap, ISet, OptionT, Order, \/}
-import shims._
+
+import shims.monadToScalaz
 
 class DefaultDestinationManager[I: Order, F[_]: ConcurrentEffect: ContextShift: MonadResourceErr: Timer] (
   modules: IMap[DestinationType, DestinationModule],

--- a/impl/src/main/scala/quasar/impl/destinations/DefaultDestinations.scala
+++ b/impl/src/main/scala/quasar/impl/destinations/DefaultDestinations.scala
@@ -32,7 +32,8 @@ import scalaz.syntax.either._
 import scalaz.syntax.equal._
 import scalaz.syntax.monad._
 import scalaz.{\/, -\/, \/-, Bifunctor, Equal, EitherT, IMap, ISet, OptionT, Order}
-import shims._
+
+import shims.monadToScalaz
 
 class DefaultDestinations[I: Equal: Order, C, F[_]: Sync] private (
     freshId: F[I],

--- a/impl/src/main/scala/quasar/impl/evaluate/RValueScalarStagesInterpreter.scala
+++ b/impl/src/main/scala/quasar/impl/evaluate/RValueScalarStagesInterpreter.scala
@@ -35,7 +35,7 @@ import fs2.{Chunk, Pipe, Stream}
 
 import scalaz.{NonEmptyList, Scalaz}, Scalaz._
 
-import shims._
+import shims.monadToScalaz
 
 object RValueScalarStagesInterpreter {
 

--- a/impl/src/main/scala/quasar/impl/external/ExternalConfig.scala
+++ b/impl/src/main/scala/quasar/impl/external/ExternalConfig.scala
@@ -23,7 +23,8 @@ import java.nio.file.{Files, Path}
 import cats.effect.Sync
 import scalaz.std.list._
 import scalaz.syntax.traverse._
-import shims._
+
+import shims.applicativeToScalaz
 
 sealed trait ExternalConfig extends Product with Serializable
 

--- a/impl/src/main/scala/quasar/impl/push/DefaultResultPush.scala
+++ b/impl/src/main/scala/quasar/impl/push/DefaultResultPush.scala
@@ -43,7 +43,8 @@ import scalaz.syntax.monad._
 import scalaz.syntax.show._
 import scalaz.syntax.std.option._
 import scalaz.{EitherT, Functor, Id, NonEmptyList, OptionT, Traverse, \/}
-import shims._
+
+import shims.monadToScalaz
 
 class DefaultResultPush[
   F[_]: Concurrent: Timer, T, D, Q, R] private (

--- a/impl/src/main/scala/quasar/impl/schema/SstSchema.scala
+++ b/impl/src/main/scala/quasar/impl/schema/SstSchema.scala
@@ -30,7 +30,6 @@ import scalaz.syntax.show._
 import scalaz.syntax.tag._
 import spire.algebra.{AdditiveSemigroup, Field, NRoot}
 import spire.syntax.field._
-import shims._
 
 sealed trait SstSchema[J, A] extends Product with Serializable {
   import SstSchema._

--- a/impl/src/main/scala/quasar/impl/storage/ConcurrentMapIndexedStore.scala
+++ b/impl/src/main/scala/quasar/impl/storage/ConcurrentMapIndexedStore.scala
@@ -30,7 +30,7 @@ import scalaz.syntax.tag._
 import java.util.concurrent.ConcurrentMap
 import scala.collection.JavaConverters._
 
-import shims._
+import shims.monadToScalaz
 
 final class ConcurrentMapIndexedStore[F[_]: Sync: ContextShift, K, V](
     mp: ConcurrentMap[K, V], blockingPool: BlockingContext)

--- a/impl/src/main/scala/quasar/impl/table/DefaultTables.scala
+++ b/impl/src/main/scala/quasar/impl/table/DefaultTables.scala
@@ -32,7 +32,7 @@ import scalaz.syntax.either._
 import scalaz.syntax.equal._
 import scalaz.syntax.monad._
 
-import shims._
+import shims.monadToScalaz
 
 final class DefaultTables[F[_]: Effect, I: Equal, Q](
     freshId: F[I],

--- a/impl/src/test/scala/quasar/impl/datasource/AggregatingDatasourceSpec.scala
+++ b/impl/src/test/scala/quasar/impl/datasource/AggregatingDatasourceSpec.scala
@@ -42,7 +42,7 @@ import scalaz.syntax.equal._
 import scalaz.syntax.traverse._
 import scalaz.syntax.std.option._
 
-import shims._
+import shims.monadToScalaz
 
 object AggregatingDatasourceSpec extends DatasourceSpec[IO, Stream[IO, ?], ResourcePathType] {
 

--- a/impl/src/test/scala/quasar/impl/datasource/local/LocalConfigSpec.scala
+++ b/impl/src/test/scala/quasar/impl/datasource/local/LocalConfigSpec.scala
@@ -26,7 +26,7 @@ import cats.instances.either._
 import cats.instances.string._
 import cats.syntax.either._
 
-import shims._
+import shims.{eqToScalaz, showToScalaz}
 
 object LocalConfigSpec extends quasar.Qspec {
   "json decoding" >> {

--- a/impl/src/test/scala/quasar/impl/datasource/local/LocalDatasourceSpec.scala
+++ b/impl/src/test/scala/quasar/impl/datasource/local/LocalDatasourceSpec.scala
@@ -33,7 +33,8 @@ import quasar.contrib.scalaz.MonadError_
 import quasar.fp.ski.κ
 import quasar.qscript.InterpretedRead
 
-import shims._
+import shims.{monadToScalaz, monoidToCats}
+
 import tectonic.Plate
 
 abstract class LocalDatasourceSpec

--- a/impl/src/test/scala/quasar/impl/datasources/DefaultDatasourcesSpec.scala
+++ b/impl/src/test/scala/quasar/impl/datasources/DefaultDatasourcesSpec.scala
@@ -49,7 +49,8 @@ import scalaz.{-\/, IMap, ISet, Monoid, \/-}
 import scalaz.std.anyVal._
 import scalaz.std.string._
 import scalaz.syntax.std.option._
-import shims._
+
+import shims.{eqToScalaz, equalToCats, monoidToCats, monoidToScalaz, monadToScalaz, showToCats, showToScalaz}
 
 final class DefaultDatasourcesSpec
     extends DatasourcesSpec[DefaultM, Stream[DefaultM, ?], Int, String, MockSchemaConfig.type, MockSchemaConfig.type] {

--- a/impl/src/test/scala/quasar/impl/datasources/middleware/ConditionReportingMiddlewareSpec.scala
+++ b/impl/src/test/scala/quasar/impl/datasources/middleware/ConditionReportingMiddlewareSpec.scala
@@ -34,7 +34,7 @@ import cats.effect.concurrent.Ref
 
 import eu.timepit.refined.auto._
 
-import shims._
+import shims.monadToScalaz
 
 object ConditionReportingMiddlewareSpec extends quasar.EffectfulQSpec[IO] with ConditionMatchers {
 

--- a/impl/src/test/scala/quasar/impl/destinations/DefaultDestinationManagerSpec.scala
+++ b/impl/src/test/scala/quasar/impl/destinations/DefaultDestinationManagerSpec.scala
@@ -31,7 +31,8 @@ import eu.timepit.refined.auto._
 import scalaz.{-\/, IMap, ISet}
 import scalaz.std.anyVal._
 import scalaz.syntax.applicative._
-import shims._
+
+import shims.monadToScalaz
 
 object DefaultDestinationManagerSpec extends quasar.Qspec {
   implicit val cs = IO.contextShift(global)

--- a/impl/src/test/scala/quasar/impl/destinations/DefaultDestinationsSpec.scala
+++ b/impl/src/test/scala/quasar/impl/destinations/DefaultDestinationsSpec.scala
@@ -38,7 +38,8 @@ import scalaz.syntax.monad._
 import scalaz.syntax.traverse._
 import scalaz.syntax.unzip._
 import scalaz.{IMap, ISet}
-import shims._
+
+import shims.monadToScalaz
 
 object DefaultDestinationsSpec extends quasar.Qspec with ConditionMatchers {
   implicit val cs = IO.contextShift(global)

--- a/impl/src/test/scala/quasar/impl/destinations/MockDestination.scala
+++ b/impl/src/test/scala/quasar/impl/destinations/MockDestination.scala
@@ -35,7 +35,7 @@ import quasar.connector.{DestinationModule, MonadResourceErr}
 import scalaz.syntax.applicative._
 import scalaz.{Applicative, NonEmptyList}
 
-import shims._
+import shims.monadToScalaz
 
 object MockDestinationModule extends DestinationModule {
   def destinationType = DestinationType("mock", 1L)

--- a/impl/src/test/scala/quasar/impl/push/DefaultResultPushSpec.scala
+++ b/impl/src/test/scala/quasar/impl/push/DefaultResultPushSpec.scala
@@ -41,7 +41,7 @@ import scalaz.std.string._
 import scalaz.syntax.bind._
 import scalaz.{Equal, NonEmptyList, \/-}
 
-import shims._
+import shims.monadToScalaz
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._

--- a/impl/src/test/scala/quasar/impl/schema/SstSchemaSpec.scala
+++ b/impl/src/test/scala/quasar/impl/schema/SstSchemaSpec.scala
@@ -27,7 +27,7 @@ import quasar.tpe._
 import matryoshka.data.Fix
 import matryoshka.implicits._
 import scalaz._, Scalaz._
-import shims._
+import shims.orderToScalaz
 import spire.math.Real
 
 object SstSchemaSpec extends quasar.Qspec {

--- a/impl/src/test/scala/quasar/impl/storage/AntiEntropyStoreSpec.scala
+++ b/impl/src/test/scala/quasar/impl/storage/AntiEntropyStoreSpec.scala
@@ -41,8 +41,6 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.util.Random
 
-import shims._
-
 final class AntiEntropyStoreSpec extends IndexedStoreSpec[IO, String, String] {
   implicit val ec: ExecutionContext = ExecutionContext.global
   implicit val strCodec: Codec[String] = utf8_32

--- a/impl/src/test/scala/quasar/impl/storage/ConcurrentMapIndexedStoreSpec.scala
+++ b/impl/src/test/scala/quasar/impl/storage/ConcurrentMapIndexedStoreSpec.scala
@@ -27,7 +27,9 @@ import cats.data.StateT
 import cats.effect.{Sync, IO, Resource}
 import scalaz.std.anyVal._
 import scalaz.std.string._
-import shims._
+
+import shims.monoidToCats
+
 import java.util.concurrent.ConcurrentHashMap
 
 final class ConcurrentMapIndexedStoreSpec extends

--- a/impl/src/test/scala/quasar/impl/storage/PureIndexedStoreSpec.scala
+++ b/impl/src/test/scala/quasar/impl/storage/PureIndexedStoreSpec.scala
@@ -29,7 +29,8 @@ import cats.syntax.applicative._
 import scalaz.IMap
 import scalaz.std.anyVal._
 import scalaz.std.string._
-import shims._
+
+import shims.{monadToScalaz, monoidToCats}
 
 final class PureIndexedStoreSpec extends
     IndexedStoreSpec[StateT[IO, IMap[Int, String], ?], Int, String] {

--- a/impl/src/test/scala/quasar/impl/storage/RefIndexedStoreSpec.scala
+++ b/impl/src/test/scala/quasar/impl/storage/RefIndexedStoreSpec.scala
@@ -25,7 +25,6 @@ import cats.effect.concurrent.Ref
 import scalaz.IMap
 import scalaz.std.anyVal._
 import scalaz.std.string._
-import shims._
 
 object RefIndexedStoreSpec extends RefSpec(Ref.unsafe[IO, Int](0))
 

--- a/impl/src/test/scala/quasar/impl/storage/TimestampedStoreSpec.scala
+++ b/impl/src/test/scala/quasar/impl/storage/TimestampedStoreSpec.scala
@@ -33,8 +33,6 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.util.Random
 
-import shims._
-
 final class TimestampedStoreSpec extends IndexedStoreSpec[IO, String, String] {
   implicit val ec: ExecutionContext = ExecutionContext.global
   implicit val timer: Timer[IO] = IO.timer(ec)

--- a/impl/src/test/scala/quasar/impl/table/DefaultTablesSpec.scala
+++ b/impl/src/test/scala/quasar/impl/table/DefaultTablesSpec.scala
@@ -29,7 +29,8 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import cats.effect.{IO, Sync}
 import scalaz.{~>, IMap, Id}
 import scalaz.std.string._
-import shims._
+
+import shims.monadToScalaz
 
 final class DefaultTablesSpec extends TablesSpec[IO, UUID, String] {
   import DefaultTablesSpec._

--- a/qsu/src/main/scala/quasar/qsu/Bucketing.scala
+++ b/qsu/src/main/scala/quasar/qsu/Bucketing.scala
@@ -35,7 +35,7 @@ import scalaz.std.option._
 import scalaz.syntax.monad._
 import scalaz.syntax.std.option._
 
-import shims._
+import shims.{applicativeToCats, equalToCats, monoidToCats}
 
 final class Bucketing[T[_[_]]: BirecursiveT: EqualT, P] private (
     qprov: QProvAux[T, P])

--- a/qsu/src/main/scala/quasar/qsu/MinimizeAutoJoins.scala
+++ b/qsu/src/main/scala/quasar/qsu/MinimizeAutoJoins.scala
@@ -47,7 +47,7 @@ import matryoshka.{BirecursiveT, EqualT, ShowT}
 
 import scalaz.{Bind, Equal, Monad, OptionT, Scalaz, StateT}, Scalaz._   // sigh, monad/traverse conflict
 
-import shims._
+import shims.equalToCats
 
 sealed abstract class MinimizeAutoJoins[T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT] extends MraPhase[T] {
   import MinimizeAutoJoins._

--- a/qsu/src/main/scala/quasar/qsu/mra/AutoJoin.scala
+++ b/qsu/src/main/scala/quasar/qsu/mra/AutoJoin.scala
@@ -26,7 +26,7 @@ import cats.syntax.show._
 
 import monocle.macros.Lenses
 
-import shims._
+import shims.{equalToCats, showToCats}
 
 /** Description of an MRA autojoin.
   *

--- a/qsu/src/main/scala/quasar/qsu/mra/Identities.scala
+++ b/qsu/src/main/scala/quasar/qsu/mra/Identities.scala
@@ -459,7 +459,7 @@ object Identities extends IdentitiesInstances {
   /** NB: Linear in the size of the fully expanded representation. */
   def values[A, B: Order]: PTraversal[Identities[A], Identities[B], A, B] =
     new PTraversal[Identities[A], Identities[B], A, B] {
-      import shims._
+      import shims.applicativeToCats
 
       val T = Traverse[NonEmptyList].compose[NonEmptyList].compose[NonEmptyList]
 

--- a/qsu/src/main/scala/quasar/qsu/mra/ProvImpl.scala
+++ b/qsu/src/main/scala/quasar/qsu/mra/ProvImpl.scala
@@ -164,12 +164,12 @@ trait ProvImpl[S, V, T] extends Provenance[S, V, T] {
   }
 
   def traverseScalarIds[F[_]: Applicative](f: (S, T) => F[(S, T)])(p: P): F[P] = {
-    import shims._
+    import shims.applicativeToScalaz
     scalarIds.modifyF[F](f.tupled)(p)
   }
 
   def traverseVectorIds[F[_]: Applicative](f: (V, T) => F[(V, T)])(p: P): F[P] = {
-    import shims._
+    import shims.applicativeToScalaz
     vectorIds.modifyF[F](f.tupled)(p)
   }
 
@@ -180,7 +180,7 @@ trait ProvImpl[S, V, T] extends Provenance[S, V, T] {
   // Not totally lawful, so private
   private lazy val UopT =
     new Traversal[P, J] {
-      import shims._
+      import shims.applicativeToCats
       def modifyF[F[_]: scalaz.Applicative](f: J => F[J])(p: P): F[P] =
         p.toList.traverse(f).map(Uop.fromFoldable(_))
     }

--- a/qsu/src/main/scala/quasar/qsu/mra/package.scala
+++ b/qsu/src/main/scala/quasar/qsu/mra/package.scala
@@ -33,7 +33,7 @@ package object mra {
     Equal.equal((x, y) => Tag.unwrap(x).equalsAsSets(Tag.unwrap(y)))
 
   implicit def asSetEq[F[_]: CFoldable, A: Eq]: Eq[F[A] @@ AsSet] = {
-    import shims._
+    import shims.{eqToScalaz, foldableToScalaz}
     Eq.instance((x, y) => Tag.unwrap(x).equalsAsSets(Tag.unwrap(y)))
   }
 }

--- a/qsu/src/test/scala/quasar/qsu/mra/IdentitiesSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/mra/IdentitiesSpec.scala
@@ -36,8 +36,6 @@ import org.specs2.scalacheck.Parameters
 
 import org.typelevel.discipline.specs2.mutable.Discipline
 
-import shims._
-
 object IdentitiesSpec extends Qspec
     with SpecificationLike
     with IdentitiesGenerator

--- a/run/src/main/scala/quasar/run/Quasar.scala
+++ b/run/src/main/scala/quasar/run/Quasar.scala
@@ -52,7 +52,7 @@ import matryoshka.data.Fix
 import org.slf4s.Logging
 import scalaz.{IMap, Show, ~>}
 import scalaz.syntax.show._
-import shims._
+import shims.{monadToScalaz, functorToCats, functorToScalaz, orderToScalaz}
 import spire.std.double._
 
 final class Quasar[F[_], R, C <: SchemaConfig](

--- a/run/src/main/scala/quasar/run/QuasarError.scala
+++ b/run/src/main/scala/quasar/run/QuasarError.scala
@@ -30,7 +30,8 @@ import argonaut.JsonScalaz._
 import monocle.Prism
 import scalaz.Show
 import scalaz.syntax.show._
-import shims._
+
+import shims.{showToCats, showToScalaz}
 
 sealed abstract trait QuasarError extends Product with Serializable
 

--- a/run/src/main/scala/quasar/run/Sql2QueryEvaluator.scala
+++ b/run/src/main/scala/quasar/run/Sql2QueryEvaluator.scala
@@ -36,8 +36,6 @@ import org.slf4s.Logging
 import scalaz.{Monad, StateT}
 import scalaz.syntax.bind._
 
-import shims._
-
 object Sql2QueryEvaluator extends Logging {
   def apply[
     T[_[_]]: BirecursiveT: EqualT: RenderTreeT: ShowT,

--- a/run/src/main/scala/quasar/run/store/Store.scala
+++ b/run/src/main/scala/quasar/run/store/Store.scala
@@ -33,7 +33,8 @@ import org.mapdb._
 
 import argonaut.{CodecJson, Parse}
 import monocle.Prism
-import shims._
+
+import shims.monadToScalaz
 
 object Store {
   val MapDBTableName = "default"

--- a/run/src/test/scala/quasar/CountingQScriptEvaluator.scala
+++ b/run/src/test/scala/quasar/CountingQScriptEvaluator.scala
@@ -38,7 +38,7 @@ import scalaz.{Const, Functor, Monad}
 import scalaz.syntax.applicative._
 import scalaz.syntax.monoid._
 
-import shims._
+import shims.monadToScalaz
 
 abstract class CountingQScriptEvaluator[
     T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT,

--- a/run/src/test/scala/quasar/CountingRegressionSpec.scala
+++ b/run/src/test/scala/quasar/CountingRegressionSpec.scala
@@ -28,7 +28,8 @@ import cats.effect.IO
 import org.specs2.matcher.{Expectable, MatchResult, Matcher}
 import matryoshka.data._
 import pathy.Path
-import shims._
+
+import shims.monadToScalaz
 
 abstract class CountingRegressionSpec extends Qspec {
 

--- a/run/src/test/scala/quasar/QScriptRegressionSpec.scala
+++ b/run/src/test/scala/quasar/QScriptRegressionSpec.scala
@@ -22,7 +22,7 @@ import cats.effect.IO
 
 import matryoshka.data.Fix
 
-import shims._
+import shims.monadToScalaz
 
 object QScriptRegressionSpec extends CountingRegressionSpec {
 

--- a/run/src/test/scala/quasar/RegressionQScriptEvaluator.scala
+++ b/run/src/test/scala/quasar/RegressionQScriptEvaluator.scala
@@ -27,8 +27,6 @@ import matryoshka.implicits._
 import scalaz.Monad
 import scalaz.syntax.applicative._
 
-import shims._
-
 final class RegressionQScriptEvaluator[
     T[_[_]]: BirecursiveT: EqualT: ShowT: RenderTreeT,
     F[_]: Monad: MonadPlannerErr: PhaseResultTell]


### PR DESCRIPTION
Unfortunately, the wildcard shims import currently incurs significant overhead (about 40% minimum for quasar modules).