### PR TITLE
Prune provenance vectors when projecting a matching inject

### DIFF
--- a/qsu/src/test/scala/quasar/qsu/ApplyProvenanceSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/ApplyProvenanceSpec.scala
@@ -163,8 +163,7 @@ object ApplyProvenanceSpec extends Qspec with QSUTTypes[Fix] {
           (FooBar.infRow('name0).prjMap("X").injMap("A") ∧
             FooBar.infRow('name0).prjMap("Y").injMap("B")),
         'name2 ->
-          (FooBar.infRow('name0).prjMap("X") ∧
-            FooBar.infRow('name0).prjMap("Y")))
+          FooBar.infRow('name0).prjMap("Y"))
 
       tree must haveDimensions(dims)
     }


### PR DESCRIPTION
Changes provenance behavior when projecting to prune non-matching vectors when a matching inject exists. This doesn't affect correctness in the absolute sense as it looks like the previous behavior could lead to incorrect provenance under certain conditions. This behavior may also be incorrect in certain circumstances, but it is much more performant.

Further work is required to determine what the actual correct behavior is regarding projection in these scenarios.

[ch10353]