### PR TITLE
Terminate provenance identity vectors when projecting non-matching injects

### DIFF
--- a/qsu/src/main/scala/quasar/qsu/mra/ProvImpl.scala
+++ b/qsu/src/main/scala/quasar/qsu/mra/ProvImpl.scala
@@ -18,19 +18,13 @@ package quasar.qsu.mra
 
 import slamdata.Predef.{None, Option, Some}
 
+import quasar.RenderTree, RenderTree.ops._
 import quasar.contrib.cats.boolean._
 import quasar.qscript.OnUndefined
 
-import cats.{Applicative, Order}
-import cats.data.NonEmptyList
-import cats.instances.list._
-import cats.instances.set._
-import cats.instances.tuple._
-import cats.syntax.eq._
-import cats.syntax.foldable._
-import cats.syntax.functor._
-import cats.syntax.list._
-import cats.syntax.traverse._
+import cats.{Applicative, Order, Semigroup, Show}
+import cats.data.{Ior, NonEmptyList}
+import cats.implicits._
 
 import monocle.Traversal
 
@@ -40,13 +34,16 @@ import scalaz.syntax.tag._
 
 trait ProvImpl[S, V, T] extends Provenance[S, V, T] {
 
+  import ProvImpl.Vecs
+
   implicit def sOrder: Order[S]
   implicit def vOrder: Order[V]
   implicit def tOrder: Order[T]
 
+  type D = Dim[S, V, T]
   private val D = Dim.Optics[S, V, T]
 
-  type P = Uop[Identities[Dim[S, V, T]]]
+  type P = Uop[Vecs[D]]
 
   def autojoin(l: P, r: P): AutoJoin[S, V] = {
     import JoinKeys._
@@ -72,7 +69,7 @@ trait ProvImpl[S, V, T] extends Provenance[S, V, T] {
     val joins = for {
       lids <- l.toSortedSet
       rids <- r.toSortedSet
-    } yield lids.zipWithDefined(rids)(join)
+    } yield lids.united.zipWithDefined(rids.united)(join)
 
     val (Disjunction(keys), Disjunction(shouldEmit)) =
       joins unorderedFoldMap {
@@ -92,19 +89,19 @@ trait ProvImpl[S, V, T] extends Provenance[S, V, T] {
     Uop.empty
 
   def inflateConjoin(vectorId: V, sort: T, p: P): P =
-    p.map(_ :≻ D.inflate(vectorId, sort))
+    p.map(_.mapActive(_ :≻ D.inflate(vectorId, sort)))
 
   def inflateExtend(vectorId: V, sort: T, p: P): P = {
     val n = D.inflate(vectorId, sort)
 
     if (p.isEmpty)
-      Uop.one(Identities(n))
+      Uop.one(Vecs.active(Identities(n)))
     else
-      p.map(_ :+ n)
+      p.map(_.mapActive(_ :+ n))
   }
 
   def inflateSubmerge(vectorId: V, sort: T, p: P): P =
-    p.map(_.submerge(D.inflate(vectorId, sort)))
+    p.map(_.mapActive(_.submerge(D.inflate(vectorId, sort))))
 
   def injectDynamic(p: P): P =
     createOrConj(D.fresh(), p)
@@ -119,42 +116,71 @@ trait ProvImpl[S, V, T] extends Provenance[S, V, T] {
     createOrConj(D.fresh(), p)
 
   def projectStatic(scalarId: S, sort: T, p: P): P = {
-    def applyVec(v: NonEmptyList[NonEmptyList[Dim[S, V, T]]]): Option[NonEmptyList[NonEmptyList[Dim[S, V, T]]]] = {
+    def applyVec(v: NonEmptyList[NonEmptyList[Dim[S, V, T]]]): Option[Vecs[D]] = {
       val r = v.reverse
       val rh = r.head.reverse
 
-      val newh =
+      val (newh, isActive) =
         if (rh.head === D.inject(scalarId, sort))
-          rh.tail
+          (rh.tail, true)
+        else if (D.inject.isEmpty(rh.head))
+          (D.project(scalarId, sort) :: rh.toList, true)
         else
-          rh.toList.dropWhile(D.inject.nonEmpty)
+          (rh.toList.dropWhile(D.inject.nonEmpty), false)
 
-      newh.reverse.toNel match {
-        case Some(h) => Some(NonEmptyList(h, r.tail).reverse)
-        case None => r.tail.reverse.toNel
+      val vecs =
+        newh.reverse.toNel match {
+          case Some(h) => Some(NonEmptyList(h, r.tail).reverse)
+          case None => r.tail.reverse.toNel
+        }
+
+      vecs map { v =>
+        val ids = Identities.collapsed[cats.Id, Dim[S, V, T]](v)
+
+        if (isActive)
+          Vecs.active(ids)
+        else
+          Vecs.terminal(ids)
       }
     }
 
-    def applyIds(ids: Identities[Dim[S, V, T]]): Option[Identities[Dim[S, V, T]]] =
-      if (ids.lastValues.forall(D.inject.isEmpty))
-        Some(ids :≻ D.project(scalarId, sort))
-      else
-        ids.expanded.toList
-          .flatMap(applyVec(_).toList)
-          .toNel
-          .map(Identities.collapsed(_))
+    def applyVecs(vecs: Vecs[D]): Option[Vecs[D]] =
+      vecs.active match {
+        case Some(a) if a.lastValues.forall(D.inject.isEmpty) =>
+          Some(vecs.setActive(a :≻ D.project(scalarId, sort)))
+
+        case Some(a) =>
+          a.expanded.toList
+            .foldMap(applyVec(_))
+            .combine(vecs.terminal.map(Vecs.terminal(_)))
+
+        case None =>
+          Some(vecs)
+      }
 
     if (p.isEmpty)
-      Uop.one(Identities(D.project(scalarId, sort)))
+      Uop.one(Vecs.active(Identities(D.project(scalarId, sort))))
     else
-      Uop.fromFoldable(p.toList.flatMap(applyIds(_).toList))
+      Uop.fromFoldable(p.toList.flatMap(applyVecs(_).toList))
   }
 
   def reduce(p: P): P =
-    Uop.fromFoldable(p.toList.flatMap(_.initRegions.toList))
+    Uop.fromFoldable(p.toList.flatMap(_.toIor match {
+      case Ior.Left(t) =>
+        t.initRegions.map(Vecs.terminal(_)).toList
+
+      case Ior.Right(a) =>
+        a.initRegions.map(Vecs.active(_)).toList
+
+      case Ior.Both(t, a) =>
+        (
+          t.initRegions.map(Vecs.terminal(_)) |+|
+          a.initRegions.map(Vecs.active(_))
+        ).toList
+    }))
 
   def squash(p: P): P =
-    p.map(_.squash)
+    p.map(Vecs.identities.modify(_.squash))
 
   def traverseComponents[F[_]: Applicative](f: P => F[P])(p: P): F[P] = {
     import Uop._
@@ -175,35 +201,86 @@ trait ProvImpl[S, V, T] extends Provenance[S, V, T] {
 
   ////
 
-  private type J = Identities[Dim[S, V, T]]
-
   // Not totally lawful, so private
   private lazy val UopT =
-    new Traversal[P, J] {
+    new Traversal[P, Vecs[D]] {
       import shims.applicativeToCats
-      def modifyF[F[_]: scalaz.Applicative](f: J => F[J])(p: P): F[P] =
+      def modifyF[F[_]: scalaz.Applicative](f: Vecs[D] => F[Vecs[D]])(p: P): F[P] =
         p.toList.traverse(f).map(Uop.fromFoldable(_))
     }
 
   private lazy val scalarIds: Traversal[P, (S, T)] =
-    UopT composeTraversal Identities.values composeTraversal D.scalar
+    UopT composeTraversal Vecs.identities composeTraversal Identities.values composeTraversal D.scalar
 
   private lazy val vectorIds: Traversal[P, (V, T)] =
-    UopT composeTraversal Identities.values composePrism D.inflate
+    UopT composeTraversal Vecs.identities composeTraversal Identities.values composePrism D.inflate
 
   private def createOrConj(d: Dim[S, V, T], p: P): P =
     if (p.isEmpty)
-      Uop.one(Identities(d))
+      Uop.one(Vecs.active(Identities(d)))
     else
-      p.map(_ :≻ d)
+      p.map(_.mapActive(_ :≻ d))
 }
 
 object ProvImpl {
   def apply[S, V, T](implicit sord: Order[S], vord: Order[V], tord: Order[T])
-      : Provenance.Aux[S, V, T, Uop[Identities[Dim[S, V, T]]]] =
+      : Provenance.Aux[S, V, T, Uop[Vecs[Dim[S, V, T]]]] =
     new ProvImpl[S, V, T] {
       val sOrder = sord
       val vOrder = vord
       val tOrder = tord
     }
+
+  final case class Vecs[A](toIor: Ior[Identities[A], Identities[A]]) extends scala.AnyVal {
+    def active: Option[Identities[A]] =
+      toIor.right
+
+    def combine(other: Vecs[A])(implicit A: Order[A]): Vecs[A] =
+      Vecs(toIor |+| other.toIor)
+
+    def mapActive(f: Identities[A] => Identities[A]): Vecs[A] =
+      Vecs(toIor map f)
+
+    def mapTerminal(f: Identities[A] => Identities[A]): Vecs[A] =
+      Vecs(toIor leftMap f)
+
+    def setActive(ids: Identities[A]): Vecs[A] =
+      Vecs(toIor.putRight(ids))
+
+    def setTerminal(ids: Identities[A]): Vecs[A] =
+      Vecs(toIor.putLeft(ids))
+
+    def terminal: Option[Identities[A]] =
+      toIor.left
+
+    def united(implicit A: Order[A]): Identities[A] =
+      toIor.merge
+  }
+
+  object Vecs {
+    def active[A](ids: Identities[A]): Vecs[A] =
+      Vecs(Ior.Right(ids))
+
+    def terminal[A](ids: Identities[A]): Vecs[A] =
+      Vecs(Ior.Left(ids))
+
+    def identities[A]: Traversal[Vecs[A], Identities[A]] =
+      new Traversal[Vecs[A], Identities[A]] {
+        import shims.applicativeToCats
+        def modifyF[F[_]: scalaz.Applicative](f: Identities[A] => F[Identities[A]])(v: Vecs[A]): F[Vecs[A]] =
+          v.toIor.bitraverse(f, f).map(Vecs(_))
+      }
+
+    implicit def order[A: Order]: Order[Vecs[A]] =
+      Order.by(_.united)
+
+    implicit def renderTree[A: Order: Show]: RenderTree[Vecs[A]] =
+      RenderTree.make(_.united.render)
+
+    implicit def semigroup[A: Order]: Semigroup[Vecs[A]] =
+      Semigroup.instance(_ combine _)
+
+    implicit def show[A: Order: Show]: Show[Vecs[A]] =
+      Show[Identities[A]].contramap(_.united)
+  }
 }

--- a/qsu/src/test/scala/quasar/qsu/mra/ProvImplSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/mra/ProvImplSpec.scala
@@ -29,19 +29,20 @@ import org.scalacheck.Arbitrary
 
 import org.specs2.scalacheck.Parameters
 
-object ProvImplSpec extends {
+import ProvImpl.Vecs
 
-  val prov: Provenance.Aux[Char, Int, Boolean, Uop[Identities[Dim[Char, Int, Boolean]]]] =
+object ProvImplSpec extends {
+  val prov: Provenance.Aux[Char, Int, Boolean, Uop[Vecs[Dim[Char, Int, Boolean]]]] =
     ProvImpl[Char, Int, Boolean]
 
   val params = Parameters(maxSize = 8, workers = 2)
 
 }   with ProvenanceSpec[Char, Int, Boolean]
     with UopGenerator
-    with IdentitiesGenerator
+    with VecsGenerator
     with DimGenerator {
 
-  type Dims = Uop[Identities[Dim[Char, Int, Boolean]]]
+  type Dims = Uop[Vecs[Dim[Char, Int, Boolean]]]
 
   def ts = (true, false)
   def ss = ('a', 'b', 'c')

--- a/qsu/src/test/scala/quasar/qsu/mra/ProvenanceSpec.scala
+++ b/qsu/src/test/scala/quasar/qsu/mra/ProvenanceSpec.scala
@@ -16,7 +16,7 @@
 
 package quasar.qsu.mra
 
-import slamdata.Predef.List
+import slamdata.Predef._
 
 import quasar.Qspec
 import quasar.qscript.OnUndefined
@@ -330,12 +330,24 @@ abstract class ProvenanceSpec[
       p.injectStatic(s, t1).projectStatic(s, t1) eqv p
     }
 
-    "does not extend when any injects exist" >> prop { (p: P, s: S, v: V, t: T) =>
+    "extends uninjected vectors when injected exist" >> prop { (p: P, s: S, v: V, t: T) =>
       val q = empty.projectStatic(s1, t)
       val x = p.inflateExtend(v, t)
       val y = q.injectStatic(s, t)
 
-      (x ∧ y).projectStatic(s, t) eqv (x ∧ q)
+      val px = x.projectStatic(s, t)
+
+      (x ∧ y).projectStatic(s, t) eqv (px ∧ q)
+    }
+
+    "terminates vectors with non-matching inject" >> prop { (p: P, s: S, v: V, t: T) =>
+      val q = empty.projectStatic(s1, t)
+      val x = p.inflateExtend(v, t)
+      val y = q.injectStatic(s2, t)
+
+      val px = x.projectStatic(s, t).inflateExtend(v, t)
+
+      (x ∧ y).projectStatic(s, t).inflateExtend(v, t) eqv (px ∧ q)
     }
 
     "affects unions independently" >> prop { (v: V, x: S, y: S, t: T) =>

--- a/qsu/src/test/scala/quasar/qsu/mra/VecsGenerator.scala
+++ b/qsu/src/test/scala/quasar/qsu/mra/VecsGenerator.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014–2019 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.qsu.mra
+
+import quasar.pkg.tests._
+
+import cats.Order
+
+import org.scalacheck.Cogen
+
+import ProvImpl.Vecs
+
+trait VecsGenerator {
+  import IdentitiesGenerator._
+
+  implicit def arbitraryVecs[A: Arbitrary: Order]: Arbitrary[Vecs[A]] =
+    Arbitrary(arbitrary[Identities[A]].map(Vecs.active(_)))
+
+  implicit def cogenVecs[A: Order: Cogen]: Cogen[Vecs[A]] =
+    Cogen[Identities[A]].contramap(_.united)
+}
+
+object VecsGenerator extends VecsGenerator


### PR DESCRIPTION
This preserves the provenance contributed by the injected values while curbing unbounded growth of the vector set in the presence of many operations on arguments which have overlapping provenance.

[ch10353]