### PR TITLE
Fix flaky test in DefaultResultPushSpec

### DIFF
--- a/impl/src/test/scala/quasar/impl/push/DefaultResultPushSpec.scala
+++ b/impl/src/test/scala/quasar/impl/push/DefaultResultPushSpec.scala
@@ -255,6 +255,7 @@ object DefaultResultPushSpec extends EffectfulQSpec[IO] with ConditionMatchers {
       Stream.eval(p.destinationStatus(destinationId))
         .map(_.toOption.flatMap(_.get(tableId)))
         .unNone
+        .repeat
 
     Stream.fixedDelay[IO](100.millis)
       .zipRight(metas)


### PR DESCRIPTION
The underlying stream of statuses being inspected only ever produced one element. If that element wasn't the matching one, then the stream errored. This wasn't the intent, instead we want to keep producing statuses as demanded and only error the stream if we timeout before seeing the element we're interested in.

[ch10816]